### PR TITLE
feat: added branching to logmanager, to allow tree-structured conversations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SRCFILES = $(shell find ${SRCDIRS} -name '*.py')
 
 # exclude files
 EXCLUDES = tests/output scripts/build_changelog.py
-SRCFILES = $(shell find ${SRCDIRS} -name '*.py' -not -path ${EXCLUDES})
+SRCFILES = $(shell find ${SRCDIRS} -name '*.py' $(foreach EXCLUDE,$(EXCLUDES),-not -path $(EXCLUDE)))
 
 # Check if playwright is installed (for browser tests)
 HAS_PLAYWRIGHT := $(shell poetry run command -v playwright 2> /dev/null)

--- a/gptme/commands.py
+++ b/gptme/commands.py
@@ -165,8 +165,7 @@ def edit(log: LogManager) -> Generator[Message, None, None]:  # pragma: no cover
             except KeyboardInterrupt:
                 yield Message("system", "Interrupted")
                 return
-    log.log = list(reversed(res))
-    log.write()
+    log.edit(list(reversed(res)))
     # now we need to redraw the log so the user isn't seeing stale messages in their buffer
     # log.print()
     print("Applied edited messages, write /log to see the result")

--- a/gptme/commands.py
+++ b/gptme/commands.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import sys
 from collections.abc import Generator
 from pathlib import Path
@@ -18,7 +19,7 @@ from .tools import execute_msg, execute_python, execute_shell
 from .tools.context import gen_context_msg
 from .tools.summarize import summarize
 from .tools.useredit import edit_text_with_editor
-from .util import len_tokens
+from .util import ask_execute, len_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +80,7 @@ def handle_cmd(
     """Handles a command."""
     cmd = cmd.lstrip(CMDFIX)
     logger.debug(f"Executing command: {cmd}")
-    name, *args = cmd.split(" ")
+    name, *args = re.split(r"[\n\s]", cmd)
     match name:
         case "bash" | "sh" | "shell":
             yield from execute_shell(" ".join(args), ask=not no_confirm)
@@ -94,7 +95,7 @@ def handle_cmd(
             # rename the conversation
             print("Renaming conversation (enter empty name to auto-generate)")
             new_name = args[0] if args else input("New name: ")
-            rename(log, new_name)
+            rename(log, new_name, ask=not no_confirm)
         case "fork":
             # fork the conversation
             new_name = args[0] if args else input("New name: ")
@@ -186,15 +187,16 @@ def save(log: LogManager, filename: str):
     print(f"Saved code block to {filename}")
 
 
-def rename(log: LogManager, new_name: str):
+def rename(log: LogManager, new_name: str, ask: bool = True):
     if new_name in ["", "auto"]:
         new_name = llm.generate_name(log.prepare_messages())
         assert " " not in new_name
         print(f"Generated name: {new_name}")
-        confirm = input("Confirm? [y/N] ")
-        if confirm.lower() not in ["y", "yes"]:
-            print("Aborting")
-            return
+        if ask:
+            confirm = ask_execute("Confirm?")
+            if not confirm:
+                print("Aborting")
+                return
         log.rename(new_name, keep_date=True)
     else:
         log.rename(new_name, keep_date=False)

--- a/gptme/constants.py
+++ b/gptme/constants.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 # prefix for commands, e.g. /help
 CMDFIX = "/"
 
@@ -23,15 +21,3 @@ PROMPT_USER = (
 PROMPT_ASSISTANT = (
     f"[bold {ROLE_COLOR['assistant']}]Assistant[/bold {ROLE_COLOR['assistant']}]"
 )
-
-# Config
-CONFIG_PATH = Path("~/.config/gptme").expanduser()
-HISTORY_FILE = CONFIG_PATH / "history"
-
-# Data
-DATADIR = Path("~/.local/share/gptme").expanduser()
-LOGSDIR = DATADIR / "logs"
-
-# create all paths
-for path in [CONFIG_PATH, DATADIR, LOGSDIR]:
-    path.mkdir(parents=True, exist_ok=True)

--- a/gptme/dirs.py
+++ b/gptme/dirs.py
@@ -1,0 +1,43 @@
+import os
+from pathlib import Path
+
+from platformdirs import user_config_dir, user_data_dir
+
+
+def get_config_dir() -> Path:
+    return Path(user_config_dir("gptme"))
+
+
+def get_readline_history_file() -> Path:
+    # TODO: move to data dir
+    return get_config_dir() / "history"
+
+
+def get_data_dir() -> Path:
+    # used in testing, so must take precedence
+    if "XDG_DATA_HOME" in os.environ:
+        return Path(os.environ["XDG_DATA_HOME"]) / "gptme"
+
+    # just a workaround for me personally
+    old = Path("~/.local/share/gptme").expanduser()
+    if old.exists():
+        return old
+
+    return Path(user_data_dir("gptme"))
+
+
+def get_logs_dir() -> Path:
+    """Get the path for **conversation logs** (not to be confused with the logger file)"""
+    path = get_data_dir() / "logs"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _init_paths():
+    # create all paths
+    for path in [get_config_dir(), get_data_dir(), get_logs_dir()]:
+        path.mkdir(parents=True, exist_ok=True)
+
+
+# run once on init
+_init_paths()

--- a/gptme/logmanager.py
+++ b/gptme/logmanager.py
@@ -104,12 +104,15 @@ class LogManager:
         # create directory if it doesn't exist
         Path(self.logfile).parent.mkdir(parents=True, exist_ok=True)
 
+        # write current branch
         with open(self.logfile, "w") as file:
             for msg in self.log:
                 file.write(json.dumps(msg.to_dict()) + "\n")
 
+        # write other branches
+        # FIXME: wont write main branch if on a different branch
         if branches:
-            branches_dir = self.logfile.parent / "branches"
+            branches_dir = self.logdir / "branches"
             branches_dir.mkdir(parents=True, exist_ok=True)
             for branch, msgs in self._branches.items():
                 if branch == "main":

--- a/gptme/message.py
+++ b/gptme/message.py
@@ -4,12 +4,12 @@ import sys
 import textwrap
 from datetime import datetime
 from typing import Literal
-from typing_extensions import Self
 
 import tomlkit
 from rich import print
 from rich.console import Console
 from rich.syntax import Syntax
+from typing_extensions import Self
 
 from .constants import ROLE_COLOR
 
@@ -45,6 +45,16 @@ class Message:
     def __repr__(self):
         content = textwrap.shorten(self.content, 20, placeholder="...")
         return f"<Message role={self.role} content={content}>"
+
+    def __eq__(self, other):
+        # FIXME: really include timestamp?
+        if not isinstance(other, Message):
+            return False
+        return (
+            self.role == other.role
+            and self.content == other.content
+            and self.timestamp == other.timestamp
+        )
 
     def to_dict(self, keys=None):
         """Return a dict representation of the message, serializable to JSON."""

--- a/gptme/server.py
+++ b/gptme/server.py
@@ -65,8 +65,9 @@ def api_conversation_put(logfile: str):
 )
 def api_conversation_post(logfile: str):
     """Post a message to the conversation."""
-    log = LogManager.load(logfile)
     req_json = flask.request.json
+    branch = (req_json or {}).get("branch", "main")
+    log = LogManager.load(logfile, branch=branch)
     assert req_json
     assert "role" in req_json
     assert "content" in req_json

--- a/gptme/server.py
+++ b/gptme/server.py
@@ -36,7 +36,7 @@ def api_conversations():
 def api_conversation(logfile: str):
     """Get a conversation."""
     log = LogManager.load(logfile)
-    return flask.jsonify(log.to_dict())
+    return flask.jsonify(log.to_dict(branches=True))
 
 
 @api.route("/api/conversations/<path:logfile>", methods=["PUT"])
@@ -78,11 +78,12 @@ def api_conversation_post(logfile: str):
 # generate response
 @api.route("/api/conversations/<path:logfile>/generate", methods=["POST"])
 def api_conversation_generate(logfile: str):
-    log = LogManager.load(logfile)
-
     # get model or use server default
     req_json = flask.request.json or {}
     model = req_json.get("model", get_model()["model"])
+
+    # load conversation
+    log = LogManager.load(logfile, branch=req_json.get("branch", "main"))
 
     # if prompt is a user-command, execute it
     if log[-1].role == "user":

--- a/gptme/server.py
+++ b/gptme/server.py
@@ -11,7 +11,7 @@ from contextlib import redirect_stdout
 import flask
 
 from .commands import execute_cmd
-from .constants import LOGSDIR
+from .dirs import get_logs_dir
 from .llm import reply
 from .logmanager import LogManager, get_conversations
 from .message import Message
@@ -50,11 +50,11 @@ def api_conversation_put(logfile: str):
                 Message(msg["role"], msg["content"], timestamp=msg["timestamp"])
             )
 
-    logpath = LOGSDIR / logfile / "conversation.jsonl"
-    if logpath.exists():
-        raise ValueError(f"Conversation already exists: {logpath}")
-    logpath.parent.mkdir(parents=True)
-    log = LogManager(msgs, logfile=logpath)
+    logdir = get_logs_dir() / logfile
+    if logdir.exists():
+        raise ValueError(f"Conversation already exists: {logdir.name}")
+    logdir.mkdir(parents=True)
+    log = LogManager(msgs, logdir=logdir)
     log.write()
     return {"status": "ok"}
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3102,4 +3102,4 @@ training = ["torch", "transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "1d49658503d1c5ee632a8b911ba768548c9a1e3372ccf088f922d3abf245947d"
+content-hash = "3fae898bfa51c8ed9d3ab258ffbf70a6f5ede89f0f2ff70e278a024bb9e83a74"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ pick = "^2.2.0"
 tiktoken = "^0.5.1"
 tomlkit = "^0.12.1"
 typing-extensions = "^4.8.0"
+platformdirs = "^3.11.0"
 
 # optionals
 llama-cpp-python = {version = "^0.1.57", optional=true}

--- a/static/index.html
+++ b/static/index.html
@@ -88,7 +88,8 @@
               :disabled="message.branches.indexOf(branch) == 0">
               &lt;
             </button>
-            {{ message.branches.indexOf(branch) + 1 }}/{{ message.branches.length }}  <!-- ({{message.branches}}) -->
+            {{ message.branches.indexOf(branch) + 1 }}/{{ message.branches.length }}
+            <!-- ({{message.branches}}) -->
             <button class="text-sm p-1"
               @click="changeBranch(message.branches[message.branches.indexOf(branch) + 1])">
               &gt;
@@ -193,6 +194,8 @@ new Vue({
           // Check if the next message in current branch diverges from next message on other branch
           const next_msg = this.branches[this.branch][i + 1];
           const branch_msg = this.branches[branch][i + 1];
+
+          // FIXME: there is a bug here in more complex cases
           if (next_msg && branch_msg && branch_msg.timestamp !== next_msg.timestamp) {
             // We found a fork, so annotate the message
             msg.branches.push(branch);
@@ -226,7 +229,7 @@ new Vue({
       const res = await fetch(apiRoot);
       this.conversations = await res.json();
     },
-    async selectConversation(path) {
+    async selectConversation(path, branch) {
       // set the hash to the conversation name
       window.location.hash = path;
 
@@ -241,9 +244,10 @@ new Vue({
 
       try {
         const data = await res.json();
-        this.chatLog = data.log;
         this.branches = data.branches;
-        this.branches["main"] = this.chatLog.slice();
+        this.branches["main"] = data.log;
+        this.branch = branch || "main";
+        this.chatLog = this.branches[this.branch];
       } catch (e) {
         this.error = e;
         console.log(e);
@@ -271,7 +275,7 @@ new Vue({
       this.selectConversation(name);
     },
     async sendMessage() {
-      const payload = JSON.stringify({role: "user", content: this.newMessage});
+      const payload = JSON.stringify({role: "user", content: this.newMessage, branch: this.branch});
       const req = await fetch(`${apiRoot}/${this.selectedConversation}`, {
         method: "POST",
         headers: {
@@ -287,7 +291,7 @@ new Vue({
       console.log(await req.json());
       this.newMessage = "";
       // reload conversation
-      await this.selectConversation(this.selectedConversation);
+      await this.selectConversation(this.selectedConversation, this.branch);
       // generate
       this.generate();
     },
@@ -298,6 +302,7 @@ new Vue({
         headers: {
           "Content-Type": "application/json",
         },
+        body: JSON.stringify({branch: this.branch}),
       });
       this.generating = false;
       if(!req.ok) {
@@ -312,7 +317,7 @@ new Vue({
         this.cmdout = data[0].content;
       }
       // reload conversation
-      await this.selectConversation(this.selectedConversation);
+      await this.selectConversation(this.selectedConversation, this.branch);
     },
     changeBranch(branch) {
       this.branch = branch;

--- a/static/index.html
+++ b/static/index.html
@@ -38,6 +38,7 @@
           <tr>
             <th class="text-left">Name</th>
             <th class="text-right" @click="changeSort('messages')"># msgs</th>
+            <th class="text-right hidden md:table-cell" @click="changeSort('branches')">Branches</th>
             <th class="text-right hidden md:table-cell" @click="changeSort('modified')">Edited</th>
             <th class="text-right hidden md:table-cell" @click="changeSort('created')">Created</th>
           </tr>
@@ -46,6 +47,7 @@
           <tr v-for="conversation in sortedConversations">
             <td><a class="cursor-pointer hover:underline" @click="selectConversation(conversation.name)">{{ conversation.name }}</a></td>
             <td class="text-right">{{ conversation.messages }}</td>
+            <td class="text-right hidden md:table-cell">{{ conversation.branches }}</td>
             <td class="text-right hidden md:table-cell">
               <time :datetime="new Date(1000 * conversation.modified).toISOString()">
                 {{ fromNow(1000 * conversation.modified) }}
@@ -78,7 +80,21 @@
         <label for="hide-system-messages">Hide initial system messages</label>
       </div>
       <div v-for="message in preparedChatLog" v-show="!message.hide" class="chat-msg rounded border mb-4 p-2">
-        <div class="font-bold mb-1">{{ capitalize(message.role) }}</div>
+        <div class="flex">
+          <div class="font-bold mb-1">{{ capitalize(message.role) }}</div>
+          <div v-if="message.branches.length > 1" class="text-sm ml-auto">
+            <button class="text-sm p-1"
+              @click="changeBranch(message.branches[message.branches.indexOf(branch) - 1])"
+              :disabled="message.branches.indexOf(branch) == 0">
+              &lt;
+            </button>
+            {{ message.branches.indexOf(branch) + 1 }}/{{ message.branches.length }}  <!-- ({{message.branches}}) -->
+            <button class="text-sm p-1"
+              @click="changeBranch(message.branches[message.branches.indexOf(branch) + 1])">
+              &gt;
+            </button>
+          </div>
+        </div>
         <div class="text-sm" v-html="message.html"></div>
       </div>
       <div v-if="cmdout" class="chat-msg rounded border mb-4 p-2">
@@ -130,6 +146,7 @@ new Vue({
     selectedConversation: null,
 
     // List of messages in the selected conversation
+    branch: "main",
     chatLog: [],
 
     // Options
@@ -164,6 +181,39 @@ new Vue({
         msg.hide = this.hideSystemMessages;
       }
 
+      // Find branch points and annotate messages where branches occur,
+      // so that we can show them in the UI, and let the user jump to them.
+      this.chatLog.forEach((msg, i) => {
+        msg.branches = [this.branch];
+
+        // Check each branch if the fork at the current message
+        for (const branch of Object.keys(this.branches)) {
+          if (branch === this.branch) continue;  // skip main branch
+
+          // Check if the next message in current branch diverges from next message on other branch
+          const next_msg = this.branches[this.branch][i + 1];
+          const branch_msg = this.branches[branch][i + 1];
+          if (next_msg && branch_msg && branch_msg.timestamp !== next_msg.timestamp) {
+            // We found a fork, so annotate the message
+            msg.branches.push(branch);
+            break;
+          }
+        }
+
+        // Sort the branches by timestamp
+        msg.branches.sort((a, b) => {
+          const a_msg = this.branches[a][i + 1];
+          const b_msg = this.branches[b][i + 1];
+          if (!a_msg) return 1;
+          if (!b_msg) return -1;
+          const diff = new Date(a_msg.timestamp) - new Date(b_msg.timestamp);
+          if(Number.isNaN(diff)) {
+            console.error("diff was NaN");
+          }
+          return diff;
+        });
+      });
+
       // Convert markdown to HTML
       return this.chatLog.map(msg => {
         msg.html = this.mdToHtml(msg.content);
@@ -192,6 +242,8 @@ new Vue({
       try {
         const data = await res.json();
         this.chatLog = data.log;
+        this.branches = data.branches;
+        this.branches["main"] = this.chatLog.slice();
       } catch (e) {
         this.error = e;
         console.log(e);
@@ -261,6 +313,10 @@ new Vue({
       }
       // reload conversation
       await this.selectConversation(this.selectedConversation);
+    },
+    changeBranch(branch) {
+      this.branch = branch;
+      this.chatLog = this.branches[branch];
     },
     backToConversations() {
       this.getConversations();  // refresh conversations

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,23 @@
+import os
 import random
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import gptme.cli
+import gptme.constants
 import pytest
 from click.testing import CliRunner
 from gptme.constants import CMDFIX, MULTIPROMPT_SEPARATOR
+
+
+@pytest.fixture(scope="session", autouse=True)
+def tmp_data_dir():
+    tmpdir = TemporaryDirectory().name
+    Path(tmpdir).mkdir(parents=True, exist_ok=True)
+
+    # set the environment variable
+    print(f"setting XDG_DATA_HOME to {tmpdir}")
+    os.environ["XDG_DATA_HOME"] = tmpdir
 
 
 @pytest.fixture(scope="session")
@@ -95,6 +109,8 @@ def test_command_fork(args: list[str], runner: CliRunner, name: str):
 
 
 def test_command_rename(args: list[str], runner: CliRunner, name: str):
+    args_orig = args.copy()
+
     # tests the /rename command
     name += "-rename"
     args.append(f"{CMDFIX}rename {name}")
@@ -103,6 +119,7 @@ def test_command_rename(args: list[str], runner: CliRunner, name: str):
     assert result.exit_code == 0
 
     # test with "auto" name
+    args = args_orig.copy()
     args.append(f"{CMDFIX}rename auto")
     print(f"running: gptme {' '.join(args)}")
     result = runner.invoke(gptme.cli.main, args)

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -45,3 +45,7 @@ def test_branch():
     # undo and check no diff
     log.undo()
     assert log.diff("dev") == "- Assistant: hello\n- Assistant: world"
+
+    d = log.to_dict(branches=True)
+    assert "main" in d["branches"]
+    assert "dev" in d["branches"]

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -19,3 +19,29 @@ print('world')
         )
     )
     assert log.get_last_code_block(content=True) == "print('world')"
+
+
+def test_branch():
+    log = LogManager()
+
+    # add message to main branch
+    log.append(Message("assistant", "hello"))
+    assert log.log[-1].content == "hello"
+
+    # switch branch
+    log.branch("dev")
+    log.append(Message("assistant", "world"))
+    assert log.log[-2].content == "hello"
+    assert log.log[-1].content == "world"
+    assert log.diff("main") == "+ Assistant: world"
+
+    # switch back
+    log.branch("main")
+    assert log.log[-1].content == "hello"
+
+    # check diff
+    assert log.diff("dev") == "- Assistant: world"
+
+    # undo and check no diff
+    log.undo()
+    assert log.diff("dev") == "- Assistant: hello\n- Assistant: world"

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -31,8 +31,8 @@ def test_branch():
     # switch branch
     log.branch("dev")
     log.append(Message("assistant", "world"))
-    assert log.log[-2].content == "hello"
     assert log.log[-1].content == "world"
+    assert log.log[-2].content == "hello"
     assert log.diff("main") == "+ Assistant: world"
 
     # switch back


### PR DESCRIPTION
Fixes #17 

What's left:

 - [x] Add behavior for `/edit`, and perhaps even for `/undo`, such that it creates a new branch with the old history, before overwriting the main branch.
 - [x] Add support in the web-UI to give it ChatGPT-like behavior where one can switch branch at each message where the log branches
     - [x] Add support for actually generating a response on a branch