### PR TITLE
feat: support paths/URLs in any prompt, refactored entrypoint to call a new public API with core logic

### DIFF
--- a/gptme/cli_server.py
+++ b/gptme/cli_server.py
@@ -2,7 +2,7 @@ import click
 
 from gptme.util import logger
 
-from .cli import init
+from .cli import init, init_logging
 
 
 @click.command("gptme-server")
@@ -20,7 +20,8 @@ from .cli import init
 )
 def main(verbose, llm, model):  # pragma: no cover
     """Starts a server and web UI."""
-    init(verbose, llm, model, interactive=False)
+    init_logging(verbose)
+    init(llm, model, interactive=False)
 
     # if flask not installed, ask the user to install `server` extras
     try:

--- a/gptme/prompts.py
+++ b/gptme/prompts.py
@@ -147,7 +147,7 @@ def prompt_tools() -> Generator[Message, None, None]:
 
 ## python
 
-When you send a message containing Python code (and is not a file block), it will be executed in a stateful environment. 
+When you send a message containing Python code (and is not a file block), it will be executed in a stateful environment.
 Python will respond with the output of the execution.
 
 The following libraries are available:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -249,6 +249,14 @@ def test_stdin(args: list[str], runner: CliRunner):
     assert result.exit_code == 0
 
 
+@pytest.mark.slow
+def test_url(args: list[str], runner: CliRunner):
+    args.append(f"Who is the CEO of https://superuserlabs.org?")
+    result = runner.invoke(gptme.cli.main, args)
+    assert "Erik Bjäreholt" in result.output
+    assert result.exit_code == 0
+
+
 def test_version(args: list[str], runner: CliRunner):
     args.append("--version")
     result = runner.invoke(gptme.cli.main, args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import random
 from pathlib import Path
@@ -250,8 +251,12 @@ def test_stdin(args: list[str], runner: CliRunner):
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(
+    importlib.util.find_spec("playwright") is None,
+    reason="playwright not installed",
+)
 def test_url(args: list[str], runner: CliRunner):
-    args.append(f"Who is the CEO of https://superuserlabs.org?")
+    args.append("Who is the CEO of https://superuserlabs.org?")
     result = runner.invoke(gptme.cli.main, args)
     assert "Erik Bjäreholt" in result.output
     assert result.exit_code == 0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,7 +14,7 @@ from gptme.server import create_app  # fmt: skip
 
 @pytest.fixture(autouse=True)
 def init_():
-    init(verbose=False, llm="openai", model="gpt-3.5-turbo", interactive=False)
+    init(llm="openai", model="gpt-3.5-turbo", interactive=False)
 
 
 @pytest.fixture


### PR DESCRIPTION
WIP #35 

The goal is to have:

 - [ ] `gptme.chat()`
    - [ ] which can be called with no arguments to start a new conversation
    - [ ] return something meaningful
    - [ ] be used to run a batch job

also:
 - [x] added support for reading paths anywhere in prompt (fixes #38)
   - No more forgetting to include a path in the initial prompt 