### PR TITLE
Sweep: Edit fails to parse some messages with invalid TOML

### DIFF
--- a/gptme/tools/patch.py
+++ b/gptme/tools/patch.py
@@ -79,6 +79,7 @@ def apply(codeblock: str, content: str) -> str:
     if UPDATED not in modified:  # pragma: no cover
         raise ValueError(f"invalid patch, no `{UPDATED.strip()}`", codeblock)
     modified = re.split(UPDATED, modified)[0].rstrip("\n")
+    modified = modified.replace("\\", "\\\\")
 
     # TODO: maybe allow modified chunk to contain "// ..." to refer to chunks in the original,
     #       and then replace these with the original chunks?


### PR DESCRIPTION
# Description
This pull request addresses an issue where the `apply` function in `patch.py` fails to correctly parse messages that contain invalid TOML due to unescaped backslashes. By adding an extra line of code, we ensure that all backslashes are properly escaped, thus preventing parsing errors and improving the robustness of the patch application process.

# Summary
- Fixed a bug in `gptme/tools/patch.py` where unescaped backslashes in the input could lead to invalid TOML parsing errors.
- Added a line to `apply` function to replace single backslashes (`\`) with double backslashes (`\\`), ensuring proper escaping.
- This change enhances the reliability of the patching tool when dealing with inputs that contain backslashes.

Fixes #71.

---

<details>
<summary><b>🎉 Latest improvements to Sweep:</b></summary>
<ul>
<li>New <a href="https://progress.sweep.dev">dashboard</a> launched for real-time tracking of Sweep issues, covering all stages from search to coding.</li>
<li>Integration of OpenAI's latest Assistant API for more efficient and reliable code planning and editing, improving speed by 3x.</li>
<li>Use the <a href="https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github">GitHub issues extension</a> for creating Sweep issues directly from your editor.</li>
</ul>
</details>


---

### 💡 To get Sweep to edit this pull request, you can:
* Comment below, and Sweep can edit the entire PR
* Comment on a file, Sweep will only modify the commented file
* Edit the original issue to get Sweep to recreate the PR from scratch

*This is an automated message generated by [Sweep AI](https://sweep.dev).*