### PR TITLE
fix: made several slow imports and top-level calls lazy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,3 +104,6 @@ cloc-server:
 
 cloc-tests:
 	cloc tests/*.py --by-file
+
+bench-importtime:
+	time poetry run python -X importtime -m gptme --model openrouter --non-interactive 2>&1 | grep "import time" | cut -d'|' -f 2- | sort -n

--- a/gptme/llm_anthropic.py
+++ b/gptme/llm_anthropic.py
@@ -1,25 +1,28 @@
 from collections.abc import Generator
-from typing import Literal, TypedDict
-from typing_extensions import Required
+from typing import TYPE_CHECKING, Literal, TypedDict
 
-from anthropic import Anthropic
+from typing_extensions import Required
 
 from .constants import TEMPERATURE, TOP_P
 from .message import Message, len_tokens, msgs2dicts
 
-anthropic: Anthropic | None = None
+if TYPE_CHECKING:
+    from anthropic import Anthropic
+
+anthropic: "Anthropic | None" = None
 
 
 def init(config):
     global anthropic
     api_key = config.get_env_required("ANTHROPIC_API_KEY")
+    from anthropic import Anthropic  # fmt: skip
     anthropic = Anthropic(
         api_key=api_key,
         max_retries=5,
     )
 
 
-def get_client() -> Anthropic | None:
+def get_client() -> "Anthropic | None":
     return anthropic
 
 

--- a/gptme/llm_openai.py
+++ b/gptme/llm_openai.py
@@ -1,12 +1,14 @@
 import logging
 from collections.abc import Generator
-
-from openai import AzureOpenAI, OpenAI
+from typing import TYPE_CHECKING
 
 from .constants import TEMPERATURE, TOP_P
 from .message import Message, msgs2dicts
 
-openai: OpenAI | None = None
+if TYPE_CHECKING:
+    from openai import OpenAI
+
+openai: "OpenAI | None" = None
 logger = logging.getLogger(__name__)
 
 
@@ -19,6 +21,7 @@ openrouter_headers = {
 
 def init(llm: str, config):
     global openai
+    from openai import AzureOpenAI, OpenAI  # fmt: skip
 
     if llm == "openai":
         api_key = config.get_env_required("OPENAI_API_KEY")
@@ -44,7 +47,7 @@ def init(llm: str, config):
     assert openai, "LLM not initialized"
 
 
-def get_client() -> OpenAI | None:
+def get_client() -> "OpenAI | None":
     return openai
 
 


### PR DESCRIPTION
Including LLM providers and IPython for python tool (top offenders)

Running `time poetry run python -X importtime -m gptme --model openrouter --non-interactive 2>&1 | grep "import time" | cut -d'|' -f 2- | sort -n` on my M2 Air gives on master: 

```
      86117 |                       IPython.terminal.interactiveshell
     103490 |                 bashlex.parser
     103616 |               bashlex
     104792 |             gptme.tools.shell
     108901 |           openai
     109037 |         gptme.llm_openai
     124811 |                     IPython.terminal.embed
     148007 |                 pandas.core.api
     150722 |                   IPython
     150729 |                 IPython.terminal
     150738 |               IPython.terminal.embed
     155561 |                 anthropic._models
     155860 |               anthropic.types.usage
     163609 |             anthropic.types
     184203 |           anthropic
     193510 |         gptme.llm_anthropic
     232356 |               pandas
     309089 |       gptme.llm
     481898 |             gptme.tools.python
     611812 |           gptme.tools
     611964 |         gptme.prompts
     613213 |       gptme.logmanager
     922704 |     gptme.commands
     994879 |   gptme.cli
     994970 | gptme

________________________________________________________
Executed in    1.66 secs    fish           external
   usr time    2.65 secs    0.22 millis    2.65 secs
   sys time    0.38 secs    2.03 millis    0.38 secs
```

With these changes applied:

```
     110080 |                 bashlex.parser
     110222 |               bashlex
     111392 |             gptme.tools.shell
     122130 |       openai._models
     123272 |     openai.types.image
     135583 |   pandas.core.api
     145182 |   openai.types
     150997 |           gptme.tools
     151147 |         gptme.prompts
     154340 |       gptme.logmanager
     180162 |     gptme.commands
     181135 | pandas
     221171 | openai
     259043 |   gptme.cli
     259135 | gptme

________________________________________________________
Executed in    1.51 secs    fish           external
   usr time    2.49 secs    0.21 millis    2.49 secs
   sys time    0.31 secs    2.16 millis    0.30 secs
```