### PR TITLE
feat: added unified diffs support to patch tool

### DIFF
--- a/gptme/tools/patch.py
+++ b/gptme/tools/patch.py
@@ -215,14 +215,14 @@ def apply_file(codeblock, filename):
                 result = apply(codeblock, content)
             except ValueError as e:
                 raise ValueError(
-                    f"patch application using search/replace failed: {str(e)}"
+                    f"patch application using search/replace failed"
                 ) from e
         elif is_unified_diff(codeblock):
             try:
                 result = apply_unified_diff(codeblock, content)
             except ValueError as e:
                 raise ValueError(
-                    f"patch application using unified diff failed: {str(e)}"
+                    f"patch application using unified diff failed"
                 ) from e
         else:
             raise ValueError("invalid patch format")

--- a/gptme/tools/patch.py
+++ b/gptme/tools/patch.py
@@ -1,8 +1,8 @@
 """
-Gives the LLM agent the ability to patch text files, by using a adapted version git conflict markers.
+Gives the LLM agent the ability to patch text files, using both an adapted version of git conflict markers
+and unified diff format.
 """
 
-# TODO: support multiple patches in one codeblock (or make it clear that only one patch per codeblock is supported/applied)
 import re
 from collections.abc import Generator
 from pathlib import Path
@@ -11,23 +11,20 @@ from ..message import Message
 from ..util import ask_execute
 from .base import ToolSpec, ToolUse
 
+ORIGINAL = "<<<<<<< ORIGINAL\n"
+DIVIDER = "\n=======\n"
+UPDATED = "\n>>>>>>> UPDATED"
+
 
 def patch_to_output(filename: str, patch: str) -> str:
     return ToolUse("patch", [filename], patch.strip()).to_output()
 
 
+enable_udiff = False
 instructions = f"""
-To patch/modify files, we can use an adapted version of git conflict markers.
+To patch/modify files, we can use an adapted version of git conflict markers{' or unified diff format.' if enable_udiff else '.'}
 
-This can be used to make changes to files, without having to rewrite the whole file.
-Only one patch block can be written per codeblock. Extra ORIGINAL/UPDATED blocks will be ignored.
-Try to keep the patch as small as possible. Avoid placeholders, as they may make the patch fail.
-
-To keep the patch small, try to scope the patch to imports/function/class.
-If the patch is large, consider using the save tool to rewrite the whole file.
-
-The patch block should be written in the following format:
-
+For git conflict markers (aka search/replace):
 {patch_to_output("$FILENAME", '''
 <<<<<<< ORIGINAL
 $ORIGINAL_CONTENT
@@ -37,9 +34,16 @@ $UPDATED_CONTENT
 ''')}
 """
 
-ORIGINAL = "<<<<<<< ORIGINAL\n"
-DIVIDER = "\n=======\n"
-UPDATED = "\n>>>>>>> UPDATED"
+if enable_udiff:
+    instructions += f"""
+For unified diff format:
+{patch_to_output("$FILENAME", '''
+@@ -1,3 +1,3 @@
+ unchanged line
+-removed line
++added line
+''')}
+"""
 
 
 examples = f"""
@@ -59,33 +63,28 @@ def hello():
 
 
 def apply_searchreplace(codeblock: str, content: str) -> str:
-    """
-    Applies multiple patches in ``codeblock`` to ``content``.
-    """
     codeblock = codeblock.strip()
     new_content = content
 
-    # Split the codeblock into multiple patches
     patches = re.split(f"(?={re.escape(ORIGINAL)})", codeblock)
 
     for patch in patches:
         if not patch.strip():
             continue
 
-        if ORIGINAL not in patch:  # pragma: no cover
+        if ORIGINAL not in patch:
             raise ValueError(f"invalid patch, no `{ORIGINAL.strip()}`", patch)
 
         parts = re.split(
             f"{re.escape(ORIGINAL)}|{re.escape(DIVIDER)}|{re.escape(UPDATED)}", patch
         )
-        if len(parts) != 4:  # pragma: no cover
+        if len(parts) != 4:
             raise ValueError("invalid patch format", patch)
 
         _, original, modified, _ = parts
 
         re_placeholder = re.compile(r"^[ \t]*(#|//|\") \.\.\. ?.*$", re.MULTILINE)
         if re_placeholder.search(original) or re_placeholder.search(modified):
-            # if placeholder found in content, then we cannot use placeholder-aware patching
             if re_placeholder.search(content):
                 raise ValueError(
                     "placeholders found in content, cannot use placeholder-aware patching"
@@ -96,14 +95,13 @@ def apply_searchreplace(codeblock: str, content: str) -> str:
             if len(originals) != len(modifieds):
                 raise ValueError(
                     "different number of placeholders in original and modified chunks"
-                    f"\n{originals}\n{modifieds}"
                 )
-            for orig, mod in zip(originals, modifieds):
+            for orig, mod in zip(originals, modifieds, strict=False):
                 if orig == mod:
                     continue
                 new_content = new_content.replace(orig, mod)
         else:
-            if original not in new_content:  # pragma: no cover
+            if original not in new_content:
                 raise ValueError("original chunk not found in file", original)
             new_content = new_content.replace(original, modified)
 
@@ -111,94 +109,72 @@ def apply_searchreplace(codeblock: str, content: str) -> str:
 
 
 def apply_unified_diff(codeblock: str, content: str) -> str:
-    """
-    Applies a unified diff patch in ``codeblock`` to ``content``.
-    Accepts invalid metadata (since LLMs can't reliably generate them) as long as the diff is valid, unique, and applies cleanly.
-    Aider has a great writeup: https://aider.chat/docs/unified-diffs.html
-    """
-    # Pre-process content
-    lines = [line for line in content.splitlines() if line.strip()]
+    lines = content.splitlines()
+    hunks = parse_unified_diff(codeblock)
 
-    # Remove potential invalid metadata lines
-    clean_diff = re.sub(r"^--- .*$\n^\+\+\+ .*$\n", "", codeblock, flags=re.MULTILINE)
+    for hunk in hunks:
+        lines = apply_hunk(lines, hunk)
 
-    # Split the diff into chunks
-    chunks = re.split(r"(?=^@@)", clean_diff, flags=re.MULTILINE)
-
-    result_lines = []
-    content_line = 0
-
-    for chunk in chunks:
-        if not chunk.strip():
-            continue
-
-        # Extract hunk header
-        hunk_match = re.match(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@", chunk)
-        if not hunk_match:
-            raise ValueError("Invalid hunk header")
-
-        start1, length1, start2, length2 = map(
-            lambda x: int(x) if x else 1, hunk_match.groups()
-        )
-
-        # Extract hunk lines
-        hunk_lines = chunk[hunk_match.end() :].splitlines()
-
-        # Add unchanged lines before the hunk
-        while content_line < start1 - 1:
-            result_lines.append(lines[content_line])
-            content_line += 1
-
-        # Apply the changes
-        i = 0
-        while i < len(hunk_lines):
-            line = hunk_lines[i]
-            if not line.strip():
-                result_lines.append(line)
-                i += 1
-            elif line.startswith(" "):
-                if (
-                    content_line < len(lines)
-                    and line[1:].strip() == lines[content_line].strip()
-                ):
-                    result_lines.append(lines[content_line])
-                    content_line += 1
-                else:
-                    result_lines.append(line[1:])
-                i += 1
-            elif line.startswith("-"):
-                if (
-                    content_line < len(lines)
-                    and line[1:].strip() == lines[content_line].strip()
-                ):
-                    content_line += 1
-                i += 1
-            elif line.startswith("+"):
-                result_lines.append(line[1:])
-                i += 1
-            else:
-                raise ValueError(f"Invalid line in hunk: {line}")
-
-    # Add any remaining lines from the original content
-    result_lines.extend(lines[content_line:])
-
-    return "\n".join(result_lines)
+    return "\n".join(lines) + "\n"
 
 
-def is_searchreplace(codeblock: str) -> bool:
-    """
-    Check if the codeblock is a search/replace patch.
-    """
-    return ORIGINAL in codeblock and UPDATED in codeblock
+def parse_unified_diff(codeblock: str) -> list[list[str]]:
+    hunks: list[list[str]] = []
+    current_hunk: list[str] = []
+    for line in codeblock.strip().splitlines():
+        if line.startswith("@@") or not hunks:
+            if current_hunk:
+                hunks.append(current_hunk)
+            current_hunk = []
+        current_hunk.append(line)
+    if current_hunk:
+        hunks.append(current_hunk)
+    return hunks if hunks else [codeblock.strip().splitlines()]
+
+
+def apply_hunk(lines: list[str], hunk: list[str]) -> list[str]:
+    if hunk[0].startswith("@@"):
+        _, old_range, new_range, _ = hunk[0].split()
+        start = int(old_range.split(",")[0][1:]) - 1
+    else:
+        start = find_hunk_start(lines, hunk)
+
+    result = lines[:start]
+    file_index = start
+
+    for line in hunk[1:]:
+        if line.startswith(" "):
+            result.append(line[1:])
+            file_index += 1
+        elif line.startswith("+"):
+            result.append(line[1:])
+        elif line.startswith("-"):
+            file_index += 1
+        else:
+            result.append(line)
+            file_index += 1
+
+    result.extend(lines[file_index:])
+    return result
+
+
+def find_hunk_start(lines: list[str], hunk: list[str]) -> int:
+    context_before = [line[1:] for line in hunk if line.startswith(" ")][:3]
+    for i in range(len(lines) - len(context_before) + 1):
+        if all(
+            lines[i + j].strip() == line.strip()
+            for j, line in enumerate(context_before)
+        ):
+            return i
+    return 0
 
 
 def is_unified_diff(codeblock: str) -> bool:
-    """
-    Check if the codeblock is in unified diff format.
-    """
-    # Look for typical unified diff patterns
-    unified_diff_pattern = r"(^@@\s+-\d+,?\d*\s+\+\d+,?\d*\s+@@)"
-    return bool(re.search(unified_diff_pattern, codeblock, re.MULTILINE))
+    return bool(
+        re.search(r"^@@\s+-\d+,?\d*\s+\+\d+,?\d*\s+@@", codeblock, re.MULTILINE)
+    ) or all(
+        line.startswith((" ", "+", "-")) for line in codeblock.strip().splitlines()
+    )
 
 
 def apply_file(codeblock, filename):
@@ -209,22 +185,16 @@ def apply_file(codeblock, filename):
     with open(filename, "r+") as f:
         content = f.read()
 
-        if is_searchreplace(codeblock):
-            try:
-                result = apply_searchreplace(codeblock, content)
-            except ValueError as e:
-                raise ValueError(
-                    f"patch application using search/replace failed"
-                ) from e
-        elif is_unified_diff(codeblock):
+        if is_unified_diff(codeblock):
             try:
                 result = apply_unified_diff(codeblock, content)
             except ValueError as e:
-                raise ValueError(
-                    f"patch application using unified diff failed"
-                ) from e
+                raise ValueError("patch application using unified diff failed") from e
         else:
-            raise ValueError("invalid patch format")
+            try:
+                result = apply_searchreplace(codeblock, content)
+            except ValueError as e:
+                raise ValueError("patch application using search/replace failed") from e
 
         if result == content:
             raise ValueError("patch did not change the file")
@@ -263,4 +233,5 @@ tool = ToolSpec(
     execute=execute_patch,
     block_types=["patch"],
 )
+
 __doc__ = tool.get_doc(__doc__)

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -59,6 +59,6 @@ def pytest_generate_tests(metafunc):
         # for now, only run the hello-patch test (the "hello" test is unreliable with gpt-4o-mini)
         allowlist = ["hello-patch"]
         test_set, test_names = zip(
-            *[(test, test["name"]) for test in tests if test["name"] in allowlist]
+            *[(test, test["name"]) for test in tests if test["name"] in allowlist],
         )
         metafunc.parametrize("test", test_set, ids=test_names)

--- a/tests/test_tools_patch.py
+++ b/tests/test_tools_patch.py
@@ -1,4 +1,4 @@
-from gptme.tools.patch import apply, apply_unified_diff, is_unified_diff
+from gptme.tools.patch import apply_searchreplace, apply_unified_diff, is_unified_diff
 
 example_patch = """
 <<<<<<< ORIGINAL
@@ -12,7 +12,7 @@ modified lines
 def test_apply_simple():
     codeblock = example_patch
     content = """original lines"""
-    result = apply(codeblock, content)
+    result = apply_searchreplace(codeblock, content)
     assert result == """modified lines"""
 
 
@@ -35,7 +35,7 @@ def hello(name="world"):
 >>>>>>> UPDATED
 """
 
-    result = apply(codeblock, content)
+    result = apply_searchreplace(codeblock, content)
     assert result.startswith(
         """
 def hello(name="world"):
@@ -64,7 +64,7 @@ def hello():
 >>>>>>> UPDATED
 """
     print(content)
-    result = apply(codeblock, content)
+    result = apply_searchreplace(codeblock, content)
     newline = "\n"
     newline_escape = "\\n"
     assert result.startswith(
@@ -90,7 +90,7 @@ if __name__ == "__main__":
 
 >>>>>>> UPDATED
 """
-    result = apply(codeblock, content)
+    result = apply_searchreplace(codeblock, content)
     assert "\n\n\n" in result
 
 
@@ -117,7 +117,7 @@ def hello_world():
     hello_world()
 >>>>>>> UPDATED
 """
-    result = apply(codeblock, content)
+    result = apply_searchreplace(codeblock, content)
     assert "    hello_world()" in result
 
 
@@ -137,7 +137,7 @@ def hello_world():
     # ...
 >>>>>>> UPDATED
 """
-    result = apply(codeblock, content)
+    result = apply_searchreplace(codeblock, content)
     assert "hello_world()" in result
 
 
@@ -212,3 +212,33 @@ def test_apply_unified_diff_remove_lines():
     result = apply_unified_diff(unified_diff, content)
     assert 'print("world")' not in result
     assert "return None" not in result
+
+
+def test_apply_unified_diff_no_hunkheader():
+    content = """
+def hello():
+    print("hello")
+"""
+    unified_diff = """
+@@ ... @@
+ def hello():
+-    print("hello")
++    print("hello world")
+"""
+    result = apply_unified_diff(unified_diff, content)
+    assert 'print("hello world")' in result
+
+
+def test_apply_unified_diff_bad_hunkheader():
+    content = """
+def hello():
+    print("hello")
+"""
+    unified_diff = """
+@@ -999,999 +999,999 @@
+ def hello():
+-    print("hello")
++    print("hello world")
+"""
+    result = apply_unified_diff(unified_diff, content)
+    assert 'print("hello world")' in result

--- a/tests/test_tools_patch.py
+++ b/tests/test_tools_patch.py
@@ -1,4 +1,4 @@
-from gptme.tools.patch import apply
+from gptme.tools.patch import apply, apply_unified_diff, is_unified_diff
 
 example_patch = """
 <<<<<<< ORIGINAL
@@ -139,3 +139,76 @@ def hello_world():
 """
     result = apply(codeblock, content)
     assert "hello_world()" in result
+
+
+def test_is_unified_diff():
+    unified_diff = """
+@@ -1,3 +1,3 @@
+ def hello():
+-    print("hello")
++    print("hello world")
+"""
+    assert is_unified_diff(unified_diff)
+    assert not is_unified_diff(example_patch)
+
+
+def test_apply_unified_diff_simple():
+    content = 'def hello():\n    print("hello")\n'
+    unified_diff = """
+@@ -1,2 +1,2 @@
+ def hello():
+-    print("hello")
++    print("hello world")
+"""
+    result = apply_unified_diff(unified_diff, content)
+    assert 'print("hello world")' in result
+
+
+def test_apply_unified_diff_multiple_hunks():
+    content = (
+        'def hello():\n    print("hello")\n\ndef goodbye():\n    print("goodbye")\n'
+    )
+    unified_diff = """
+@@ -1,2 +1,2 @@
+ def hello():
+-    print("hello")
++    print("hello world")
+@@ -4,2 +4,2 @@
+ def goodbye():
+-    print("goodbye")
++    print("farewell")
+"""
+    result = apply_unified_diff(unified_diff, content)
+    assert 'print("hello world")' in result
+    assert 'print("farewell")' in result
+
+
+def test_apply_unified_diff_add_lines():
+    content = """
+def hello():
+    print("hello")
+"""
+    unified_diff = """
+@@ -1,2 +1,4 @@
+ def hello():
+     print("hello")
++    print("world")
++    return None
+"""
+    result = apply_unified_diff(unified_diff, content)
+    assert 'print("world")' in result
+    assert "return None" in result
+
+
+def test_apply_unified_diff_remove_lines():
+    content = 'def hello():\n    print("hello")\n    print("world")\n    return None\n'
+    unified_diff = """
+@@ -1,4 +1,2 @@
+ def hello():
+     print("hello")
+-    print("world")
+-    return None
+"""
+    result = apply_unified_diff(unified_diff, content)
+    assert 'print("world")' not in result
+    assert "return None" not in result


### PR DESCRIPTION
Sometimes the models just can't help themselves, and insist on writing unified diffs patches. Figured I might as well try implementing support for it.

I got Claude 3.5 to write all of this for me, with some prompting. It got stuck for a while, but I asked it to take a step back and think through it, after which it made a great plan, which worked!

I should probably look at how Aider does it these days.

## TODO

 - [ ] Actually test asking an LLM to output on the format and check how well it works
 - [ ] Write more extensive tests