### PR TITLE
fix: hopefully fix flaky config creation

### DIFF
--- a/gptme/config.py
+++ b/gptme/config.py
@@ -78,9 +78,14 @@ def get_config() -> Config:
 
 
 def load_config() -> Config:
-    # TODO: validate
     config = _load_config()
-    return Config(**config)  # type: ignore
+    assert "prompt" in config, "prompt key missing in config"
+    assert "env" in config, "env key missing in config"
+    prompt = config.pop("prompt")
+    env = config.pop("env")
+    if config:
+        logger.warning(f"Unknown keys in config: {config.keys()}")
+    return Config(prompt=prompt, env=env)
 
 
 def _load_config() -> tomlkit.TOMLDocument:
@@ -88,14 +93,16 @@ def _load_config() -> tomlkit.TOMLDocument:
     if not os.path.exists(config_path):
         # If not, create it and write some default settings
         os.makedirs(os.path.dirname(config_path), exist_ok=True)
+        toml = tomlkit.dumps(default_config.dict())
         with open(config_path, "w") as config_file:
-            tomlkit.dump(default_config.dict(), config_file)
+            config_file.write(toml)
         console.log(f"Created config file at {config_path}")
-
-    # Now you can read the settings from the config file like this:
-    with open(config_path) as config_file:
-        doc = tomlkit.load(config_file)
-    return doc
+        doc = tomlkit.loads(toml)
+        return doc
+    else:
+        with open(config_path) as config_file:
+            doc = tomlkit.load(config_file)
+        return doc
 
 
 def set_config_value(key: str, value: str) -> None:  # pragma: no cover


### PR DESCRIPTION
Tends to cause tests to fail, I assume due to some race condition with getting locks for the config file? Or something?

This should fix it anyhow.


<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves `load_config()` in `config.py` to handle unknown keys, ensures required keys, and enhances path logging readability.
> 
>   - **Behavior**:
>     - `load_config()` in `config.py` now warns about unknown keys and ensures `prompt` and `env` keys are present.
>     - `chat()` in `cli.py` logs paths using `path_with_tilde()` for readability.
>   - **Code Structure**:
>     - Refactored `_load_config()` in `config.py` for streamlined file reading and creation.
>     - Added `path_with_tilde()` in `util.py` to convert home directory paths to tilde.
>   - **Misc**:
>     - Updated `get_workspace_prompt()` in `config.py` to use `path_with_tilde()` for logging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for d95ed7d017ab8d454d3d13c90cfa3739fd536a79. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->