### PR TITLE
Add local provider in provider examples

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -9,6 +9,7 @@ To select a provider and model, run `gptme` with the `--model` flag set to `<pro
 gptme --model openai/gpt-4o "hello"
 gptme --model anthropic "hello"  # if model part unspecified, will fall back to the provider default
 gptme --model openrouter/meta-llama/llama-3.1-70b-instruct "hello"
+gptme --model local/ollama
 ```
 
 On first startup, if `--model` is not set, and no API keys are set in the config or environment it will be prompted for. It will then auto-detect the provider, and save the key in the configuration file.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -9,7 +9,7 @@ To select a provider and model, run `gptme` with the `--model` flag set to `<pro
 gptme --model openai/gpt-4o "hello"
 gptme --model anthropic "hello"  # if model part unspecified, will fall back to the provider default
 gptme --model openrouter/meta-llama/llama-3.1-70b-instruct "hello"
-gptme --model local/ollama
+gptme --model local/ollama "hello"
 ```
 
 On first startup, if `--model` is not set, and no API keys are set in the config or environment it will be prompted for. It will then auto-detect the provider, and save the key in the configuration file.


### PR DESCRIPTION
Had to do a few trial and error to figure this out. Could have made easier if listed among the big boys :)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add example for `local/ollama` provider in `providers.md`.
> 
>   - **Documentation**:
>     - Adds example for using `local/ollama` provider in `providers.md` under the `gptme` command examples.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 8db2a101a5a567a4ac7d50b1f3ecdc0b8efeb444. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->