### PR TITLE
fix: made shell tool more strict, now requires exact 'shell' langtag

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1,5 +1,5 @@
 """
-The assistant can execute shell commands by outputting code blocks with `bash` or `sh` as the language.
+The assistant can execute shell commands with bash by outputting code blocks with `shell` as the language.
 """
 
 import atexit
@@ -60,43 +60,37 @@ examples = f"""
 
 User: list the current directory
 Assistant: To list the files in the current directory, use `ls`:
-{ToolUse("bash", [], "ls").to_output()}
+{ToolUse("shell", [], "ls").to_output()}
 System: Ran command: `ls`
-```stdout
+{ToolUse("shell", [], '''
 file1.txt
 file2.txt
-```
+'''.strip()).to_output()}
 
 #### The assistant can learn context by exploring the filesystem
 User: learn about the project
 Assistant: Lets start by checking the files
-{ToolUse("bash", [], "git ls-files").to_output()}
+{ToolUse("shell", [], "git ls-files").to_output()}
 System:
-```output
+{ToolUse("stdout", [], '''
 README.md
 main.py
-```
+'''.strip()).to_output()}
 Assistant: Now lets check the README
-```bash
-cat README.md
-```
+{ToolUse("shell", [], "cat README.md").to_output()}
 System:
-```stdout
-(contents of README.md)
-```
+{ToolUse("stdout", [], "(contents of README.md)").to_output()}
 Assistant: Now we check main.py
-{ToolUse("bash", [], "cat main.py").to_output()}
+{ToolUse("shell", [], "cat main.py").to_output()}
 System:
-```output
-(contents of main.py)
-```
+{ToolUse("stdout", [], "(contents of main.py)").to_output()}
 Assistant: The project is...
 
 
 #### Create vue project
 User: Create a new vue project with typescript and pinia named fancy-project
 Assistant: Sure! Let's create a new vue project with TypeScript and Pinia named fancy-project:
-{ToolUse("bash", [], "npm init vue@latest fancy-project --yes -- --typescript --pinia").to_output()}
+{ToolUse("shell", [], "npm init vue@latest fancy-project --yes -- --typescript --pinia").to_output()}
 System:
 ```output
 > npx
@@ -389,6 +383,6 @@ tool = ToolSpec(
     instructions=instructions,
     examples=examples,
     execute=execute_shell,
-    block_types=["bash", "sh", "shell"],
+    block_types=["shell"],
 )
 __doc__ = tool.get_doc(__doc__)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> The shell tool now requires the exact 'shell' langtag instead of 'bash' or 'sh', with updates to `ToolSpec` and examples in `shell.py`.
> 
>   - **Behavior**:
>     - `ToolSpec` in `shell.py` now requires `shell` langtag instead of `bash` or `sh`.
>     - Updated examples in `shell.py` to use `shell` langtag.
>   - **Misc**:
>     - Updated docstring in `shell.py` to reflect langtag change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 3f931caf65e2afac9162463a0b5e2178fa20b0ed. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->