### PR TITLE
fix: limit image size, fixes exception for large images (fixes #185)

### DIFF
--- a/gptme/message.py
+++ b/gptme/message.py
@@ -109,7 +109,7 @@ class Message:
             data = base64.b64encode(data_bytes).decode("utf-8")
 
             # check that the file is not too large
-            # anthropic limit is 5MB
+            # anthropic limit is 5MB, seems to measure the base64-encoded size instead of raw bytes
             # TODO: use compression to reduce file size
             # print(f"{len(data)=}")
             if len(data) > 5_000_000:

--- a/gptme/message.py
+++ b/gptme/message.py
@@ -77,6 +77,10 @@ class Message:
     def _content_files_list(
         self, openai: bool = False, anthropic: bool = False
     ) -> list[dict[str, Any]]:
+        # only these providers support files in the content
+        if not openai and not anthropic:
+            raise ValueError("Provider does not support files in the content")
+
         # combines a content message with a list of files
         content: list[dict[str, Any]] = (
             self.content
@@ -99,6 +103,24 @@ class Message:
                     "text": f"![{f.name}]({f.name}):",
                 }
             )
+
+            # read file
+            data_bytes = f.read_bytes()
+            data = base64.b64encode(data_bytes).decode("utf-8")
+
+            # check that the file is not too large
+            # anthropic limit is 5MB
+            # TODO: use compression to reduce file size
+            # print(f"{len(data)=}")
+            if len(data) > 5_000_000:
+                content.append(
+                    {
+                        "type": "text",
+                        "text": "Image size exceeds 5MB. Please upload a smaller image.",
+                    }
+                )
+                continue
+
             if anthropic:
                 content.append(
                     {
@@ -106,7 +128,7 @@ class Message:
                         "source": {
                             "type": "base64",
                             "media_type": media_type,
-                            "data": base64.b64encode(f.read_bytes()).decode("utf-8"),
+                            "data": data,
                         },
                     }
                 )
@@ -115,9 +137,7 @@ class Message:
                 content.append(
                     {
                         "type": "image_url",
-                        "image_url": {
-                            "url": f"data:{media_type};base64,{base64.b64encode(f.read_bytes()).decode('utf-8')}"
-                        },
+                        "image_url": {"url": f"data:{media_type};base64,{data}"},
                     }
                 )
             else:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a 5MB image size limit and provider check in `_content_files_list()` in `message.py` to prevent exceptions with large images.
> 
>   - **Behavior**:
>     - Adds a 5MB size limit for image files in `_content_files_list()` in `message.py`. If exceeded, appends a warning message to content.
>     - Raises `ValueError` if neither `openai` nor `anthropic` is specified in `_content_files_list()`.
>   - **Refactoring**:
>     - Refactors file reading and base64 encoding to store in `data` variable for reuse in `message.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 9a4d2f6f39ce6726fa5e2a6863527e0492d4dc5a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->