### PR TITLE
docs: Update Ollama configuration

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -37,7 +37,7 @@ Here is an example:
 
     # Uncomment to use with Ollama
     #MODEL = "local/<model-name>"
-    #OPENAI_BASE_URL = "http://localhost:11434/v1"
+    #OPENAI_API_BASE = "http://localhost:11434/v1"
 
 The ``prompt`` section contains options for the prompt.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -49,5 +49,5 @@ You first need to install `ollama`, then you can run it with:
 ```sh
 ollama pull llama3.2:1b
 ollama serve
-OPENAI_BASE_URL="http://127.0.0.1:11434/v1" gptme 'hello' -m local/llama3.2:1b
+OPENAI_API_BASE="http://127.0.0.1:11434/v1" gptme 'hello' -m local/llama3.2:1b
 ```


### PR DESCRIPTION
Changed `OPENAI_BASE_URL` to `OPENAI_API_BASE` for Ollama integration.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Renamed `OPENAI_BASE_URL` to `OPENAI_API_BASE` in `config.rst` for Ollama integration.
> 
>   - **Docs**:
>     - Renamed `OPENAI_BASE_URL` to `OPENAI_API_BASE` in `config.rst` for Ollama integration example.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for a51be468234f792cd3687d93fdf282c47303c3fb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->