### PR TITLE
fix: fixed support for groq (and deepseek?)

### DIFF
--- a/gptme/llm_anthropic.py
+++ b/gptme/llm_anthropic.py
@@ -38,7 +38,7 @@ class MessagePart(TypedDict, total=False):
 def chat(messages: list[Message], model: str) -> str:
     assert anthropic, "LLM not initialized"
     messages, system_messages = _transform_system_messages(messages)
-    messages_dicts = msgs2dicts(messages, anthropic=True)
+    messages_dicts = msgs2dicts(messages, provider="anthropic")
     response = anthropic.beta.prompt_caching.messages.create(
         model=model,
         messages=messages_dicts,  # type: ignore
@@ -56,7 +56,7 @@ def chat(messages: list[Message], model: str) -> str:
 def stream(messages: list[Message], model: str) -> Generator[str, None, None]:
     assert anthropic, "LLM not initialized"
     messages, system_messages = _transform_system_messages(messages)
-    messages_dicts = msgs2dicts(messages, anthropic=True)
+    messages_dicts = msgs2dicts(messages, provider="anthropic")
     with anthropic.beta.prompt_caching.messages.stream(
         model=model,
         messages=messages_dicts,  # type: ignore

--- a/gptme/llm_openai.py
+++ b/gptme/llm_openai.py
@@ -60,6 +60,20 @@ def init(provider: Provider, config: Config):
     assert openai, "Provider not initialized"
 
 
+def get_provider() -> Provider | None:
+    if not openai:
+        return None
+    if "openai.com" in str(openai.base_url):
+        return "openai"
+    if "openrouter.ai" in str(openai.base_url):
+        return "openrouter"
+    if "groq.com" in str(openai.base_url):
+        return "groq"
+    if "x.ai" in str(openai.base_url):
+        return "xai"
+    return None
+
+
 def get_client() -> "OpenAI | None":
     return openai
 
@@ -88,7 +102,7 @@ def chat(messages: list[Message], model: str) -> str:
 
     response = openai.chat.completions.create(
         model=model,
-        messages=msgs2dicts(messages, openai=True),  # type: ignore
+        messages=msgs2dicts(messages, provider=get_provider()),  # type: ignore
         temperature=TEMPERATURE if not is_o1 else NOT_GIVEN,
         top_p=TOP_P if not is_o1 else NOT_GIVEN,
         extra_headers=(
@@ -105,7 +119,7 @@ def stream(messages: list[Message], model: str) -> Generator[str, None, None]:
     stop_reason = None
     for chunk in openai.chat.completions.create(
         model=model,
-        messages=msgs2dicts(_prep_o1(messages), openai=True),  # type: ignore
+        messages=msgs2dicts(_prep_o1(messages), provider=get_provider()),  # type: ignore
         temperature=TEMPERATURE,
         top_p=TOP_P,
         stream=True,


### PR DESCRIPTION
This also potentially unblocks: https://github.com/ErikBjare/gptme/pull/180

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactored provider handling in `msgs2dicts` and related functions to improve support for different providers in `llm_anthropic.py`, `llm_openai.py`, and `message.py`.
> 
>   - **Behavior**:
>     - Updated `msgs2dicts` function in `message.py` to use `provider` parameter instead of `openai` and `anthropic` boolean flags.
>     - Added `get_provider` function in `llm_openai.py` to determine the provider based on `base_url`.
>     - Modified `chat` and `stream` functions in `llm_anthropic.py` and `llm_openai.py` to use `provider` parameter.
>   - **Models**:
>     - Added `ProvidersWithFiles` list in `message.py` to specify providers supporting files.
>     - Updated `_content_files_list` and `to_dict` methods in `Message` class to handle providers using `ProvidersWithFiles`.
>   - **Misc**:
>     - Removed `openai` and `anthropic` flags from `msgs2dicts` calls in `llm_anthropic.py` and `llm_openai.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 909d08a0b4d8fcbf24108476d2ca7377e250189f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->