### PR TITLE
docs: add installing from source instructions to contributing guide

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -30,6 +30,7 @@ Install
 You can now start ``gptme`` from your development environment using the regular commands.
 
 You can also install it in editable mode with ``pipx`` using ``pipx install -e .`` which will let you use your development version of gptme regardless of venv.
+
 Tests
 -----
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -12,32 +12,24 @@ We welcome contributions to the project. Here is some information to get you sta
 Install
 -------
 
-Checkout the code and, at the root of the project, create a virtual environment:
-
 .. code-block:: bash
 
-   python3 -m venv .venv
+   # checkout the code and navigate to the root of the project
+   git clone https://github.com/ErikBjare/gptme.git
+   cd gptme
+   
+   # install poetry (if not installed)
+   pipx install poetry
+   
+   # activate the virtualenv
+   poetry shell
 
-Activate the virtual environment:
-
-.. code-block:: bash
-
-   source .venv/bin/activate
-
-Install Poetry:
-
-.. code-block:: bash
-
-   pip install poetry
-
-Build the project:
-
-.. code-block:: bash
-
+   # build the project
    make build
 
 You can now start ``gptme`` from your development environment using the regular commands.
 
+You can also install it in editable mode with ``pipx`` using ``pipx install -e .`` which will let you use your development version of gptme regardless of venv.
 Tests
 -----
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -9,6 +9,35 @@ We welcome contributions to the project. Here is some information to get you sta
 .. contents::
    :local:
 
+Install
+-------
+
+Checkout the code and, at the root of the project, create a virtual environment:
+
+.. code-block:: bash
+
+   python3 -m venv .venv
+
+Activate the virtual environment:
+
+.. code-block:: bash
+
+   source .venv/bin/activate
+
+Install Poetry:
+
+.. code-block:: bash
+
+   pip install poetry
+
+Build the project:
+
+.. code-block:: bash
+
+   make build
+
+You can now start ``gptme`` from your development environment using the regular commands.
+
 Tests
 -----
 


### PR DESCRIPTION
This is a proposition for the installation process documentation. This is how it worked for me. Let me know if it can be improved.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds installation instructions to `contributing.rst` for setting up a development environment.
> 
>   - **Documentation**:
>     - Adds `Install` section to `contributing.rst`.
>     - Details steps to create a virtual environment, activate it, install Poetry, and build the project.
>     - Provides command examples for each step.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 9983c2914b6f5f5bc74c84011cd0f14c9780cd13. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->