### PR TITLE
fix: correct Linux distro version in systeminfo prompt

### DIFF
--- a/gptme/prompts.py
+++ b/gptme/prompts.py
@@ -216,7 +216,7 @@ def prompt_systeminfo() -> Generator[Message, None, None]:
     """Generate the system information prompt."""
     if platform.system() == "Linux":
         os_info = get_system_distro()
-        os_version = platform.uname().release
+        os_version = get_system_distro_version()
     elif platform.system() == "Windows":
         os_info = "Windows"
         os_version = platform.version()
@@ -245,6 +245,18 @@ def get_system_distro() -> str:
                 if matches:
                     return matches.string[matches.start(1) : matches.end(1)]
     return "Linux"
+
+
+def get_system_distro_version() -> str:
+    """Get the system distribution version."""
+    regex = re.compile(r"^BUILD_ID=\"?([^\"]+)\"?")
+    if os.path.exists("/etc/os-release"):
+        with open("/etc/os-release") as f:
+            for line in f:
+                matches = re.search(regex, line)
+                if matches:
+                    return matches.string[matches.start(1) : matches.end(1)]
+    return ""
 
 
 document_prompt_function(interactive=True)(prompt_gptme)

--- a/gptme/prompts.py
+++ b/gptme/prompts.py
@@ -6,7 +6,6 @@ When prompting, it is important to provide clear instructions and avoid any ambi
 """
 
 import logging
-import re
 import os
 import platform
 import subprocess
@@ -215,8 +214,10 @@ def prompt_tools(examples: bool = True) -> Generator[Message, None, None]:
 def prompt_systeminfo() -> Generator[Message, None, None]:
     """Generate the system information prompt."""
     if platform.system() == "Linux":
-        os_info = get_system_distro()
-        os_version = get_system_distro_version()
+        os_info = platform.freedesktop_os_release().get("NAME", "Linux")
+        os_version = platform.freedesktop_os_release().get(
+            "VERSION_ID", platform.freedesktop_os_release().get("BUILD_ID", "")
+        )
     elif platform.system() == "Windows":
         os_info = "Windows"
         os_version = platform.version()
@@ -233,30 +234,6 @@ def prompt_systeminfo() -> Generator[Message, None, None]:
         "system",
         prompt,
     )
-
-
-def get_system_distro() -> str:
-    """Get the system distribution name."""
-    regex = re.compile(r"^NAME=\"?([^\"]+)\"?")
-    if os.path.exists("/etc/os-release"):
-        with open("/etc/os-release") as f:
-            for line in f:
-                matches = re.search(regex, line)
-                if matches:
-                    return matches.string[matches.start(1) : matches.end(1)]
-    return "Linux"
-
-
-def get_system_distro_version() -> str:
-    """Get the system distribution version."""
-    regex = re.compile(r"^BUILD_ID=\"?([^\"]+)\"?")
-    if os.path.exists("/etc/os-release"):
-        with open("/etc/os-release") as f:
-            for line in f:
-                matches = re.search(regex, line)
-                if matches:
-                    return matches.string[matches.start(1) : matches.end(1)]
-    return ""
 
 
 document_prompt_function(interactive=True)(prompt_gptme)

--- a/gptme/prompts.py
+++ b/gptme/prompts.py
@@ -214,10 +214,9 @@ def prompt_tools(examples: bool = True) -> Generator[Message, None, None]:
 def prompt_systeminfo() -> Generator[Message, None, None]:
     """Generate the system information prompt."""
     if platform.system() == "Linux":
-        os_info = platform.freedesktop_os_release().get("NAME", "Linux")
-        os_version = platform.freedesktop_os_release().get(
-            "VERSION_ID", platform.freedesktop_os_release().get("BUILD_ID", "")
-        )
+        release_info = platform.freedesktop_os_release()
+        os_info = release_info.get("NAME", "Linux")
+        os_version = release_info.get("VERSION_ID") or release_info.get("BUILD_ID", "")
     elif platform.system() == "Windows":
         os_info = "Windows"
         os_version = platform.version()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Corrects Linux OS version retrieval in `prompt_systeminfo()` by using `get_system_distro_version()` instead of `platform.uname().release`.
> 
>   - **Behavior**:
>     - Corrects the method to obtain Linux OS version in `prompt_systeminfo()` by replacing `platform.uname().release` with `get_system_distro_version()`.
>   - **Functions**:
>     - Adds `get_system_distro_version()` to extract the Linux distribution version from `/etc/os-release` using regex.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for f57e55af42e5bba1998deca47722cde3ca35107a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->