### PR TITLE
Trigger tool detection only on complete lines to help nested code block start detection

### DIFF
--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -58,6 +58,16 @@ callme()
     ]
 
 
+def test_extract_codeblocks_unfinished_nested():
+    markdown = """
+```python
+def print_readme():
+    print('''Usage:
+```javascript
+"""
+    assert Codeblock.iter_from_markdown(markdown) == []
+
+
 def test_extract_codeblocks_empty():
     assert Codeblock.iter_from_markdown("") == []
 


### PR DESCRIPTION
TL;DR; This MR fixes the bug when you have a markdown code block nested in another tooluse code block in streaming mode.

I think it's related to this issue #111 

# To reproduce

- Start gptme
- Submit the following prompt: `Create the file foo.md and add a small explanation on how works the async in python with a code example`

The response of this prompt looks something like that:

```markdown
    [Some introduction text]

    ```save foo.md
    [In file explanation]

    ```python
    [python code block] 
    ```
    [In file conclusion]
    ```
    [end of llm answer]
```

If you are using streaming mode, the tooluse detection will stop immediately after the three back quotes preceding the `python` code block type because the check is executed after every single char.

# Solution proposed

The idea of this MR is to wait for the end of a line (i.e. a `\n` char) to execute the tool check. That way, we know the next three back quotes aren't the end of the code block as they are followed by the code block type (`python` here) and the tool use detection algorithm can handle that.

It's not perfect as it still won't detect if there is no code block type but it should work in more situation waiting for a more robust solution. 

Also I think it's a good idea to wait for the end of the line to try to detect the tools. I don't think we have benefits to execute it on every single char unless I missed something.

