### PR TITLE
fix: prompt to reinforce correct placement of filename parameter in patch tool

### DIFF
--- a/gptme/tools/patch.py
+++ b/gptme/tools/patch.py
@@ -22,6 +22,8 @@ Try to keep the patch as small as possible. Avoid placeholders, as they may make
 To keep the patch small, try to scope the patch to imports/function/class.
 If the patch is large, consider using the save tool to rewrite the whole file.
 
+The $FILENAME parameter MUST be on the same line as the code block start, not on the line after.
+
 The patch block should be written in the following format:
 
 {ToolUse("patch", ["$FILENAME"], '''


### PR DESCRIPTION
For some reasons, Chatgpt place the patch `$FILENAME` parameter on the line after the first code block line. This breaks the patch tool.

In this MR I tried to enforce the LLM to add the patch filename parameter after the code block start by improving the tool prompt. it helps to prevent issue #153 

It tested multiple versions and that's the version with the best results, all of my tests were successful with it.

Using the [tool API](!219) should fix that in a better way, but in the meantime we have a quick fix.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates `patch.py` instructions to enforce `$FILENAME` parameter placement on the same line as the code block start, preventing issues like #153.
> 
>   - **Instructions Update**:
>     - In `patch.py`, updated `instructions` to enforce `$FILENAME` parameter placement on the same line as the code block start.
>     - Aims to prevent issues like #153 by improving tool prompt.
>   - **Testing**:
>     - Multiple versions tested; current version yields successful results.
>   - **Future Work**:
>     - Suggests using the tool API for a more robust solution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for e76bf5dddb64d06eed18f8fd0880e1d21e7f21e5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->