### PR TITLE
docs: add guidance about nested codeblocks and language tags

### DIFF
--- a/gptme/prompts.py
+++ b/gptme/prompts.py
@@ -103,6 +103,17 @@ When suggesting code changes, prefer applying patches over examples. Preserve co
 Use the patch tool to edit existing files, or the save tool to overwrite.
 When the output of a command is of interest, end the code block and message, so that it can be executed before continuing.
 
+When using nested codeblocks (codeblocks within codeblocks), always specify a language tag for both the outer and inner blocks.
+This is critical for correct parsing - without language tags, nested blocks may be cut off prematurely.
+For example:
+```python
+print("This is the outer block")
+# Inner block needs a language tag:
+```shell
+echo "This is the inner block"
+```
+```
+
 Do not use placeholders like `$REPO` unless they have been set.
 Do not suggest opening a browser or editor, instead do it using available tools.
 


### PR DESCRIPTION
Add explicit guidance about using language tags in nested codeblocks to prevent parsing issues.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds guidance on using language tags in nested codeblocks in `prompt_gptme()` to prevent parsing issues.
> 
>   - **Documentation**:
>     - Adds guidance on using language tags in nested codeblocks in `prompt_gptme()` in `gptme/prompts.py`.
>     - Specifies that both outer and inner blocks need language tags to prevent premature cut-off during parsing.
>     - Provides an example of correct usage with `python` and `shell` tags.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for a0019b839beab816875fb2b2dac187d0f33c8fad. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->