### PR TITLE
fix: model provider handling and vision support metadata

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -13,9 +13,9 @@ from .constants import PROMPT_USER
 from .init import init
 from .interrupt import clear_interruptible, set_interruptible
 from .llm import reply
+from .llm.models import get_model
 from .logmanager import Log, LogManager, prepare_messages
 from .message import Message
-from .llm.models import get_model
 from .prompts import get_workspace_prompt
 from .readline import add_history
 from .tools import ToolUse, execute_msg, has_tool
@@ -389,7 +389,7 @@ def _parse_prompt_files(prompt: str) -> Path | None:
         # check if prompt is a path, if so, replace it with the contents of that file
         p = Path(prompt)
         if p.exists() and p.is_file() and p.suffix[1:] in allowed_exts:
-            logger.warning("Attaching file to message")
+            logger.info(f"Attaching file {p} to message")
             return p
         else:
             return None

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -1,3 +1,4 @@
+import atexit
 import logging
 from typing import cast
 
@@ -58,7 +59,7 @@ def init(model: str | None, interactive: bool, tool_allowlist: list[str] | None)
     model = model or get_recommended_model(provider)
     console.log(f"Using model: {provider}/{model}")
     init_llm(provider)
-    set_default_model(model)
+    set_default_model(f"{provider}/{model}")
 
     if interactive:
         load_readline_history()
@@ -82,7 +83,6 @@ def init_logging(verbose):
     logging.getLogger("httpx").setLevel(logging.WARNING)
 
     # Register cleanup handler
-    import atexit
 
     def cleanup_logging():
         logging.getLogger().removeHandler(handler)

--- a/gptme/llm/llm_openai_models.py
+++ b/gptme/llm/llm_openai_models.py
@@ -10,6 +10,7 @@ OPENAI_MODELS: dict[str, "_ModelDictMeta"] = {
         "context": 128_000,
         "price_input": 5,
         "price_output": 15,
+        "supports_vision": True,
     },
     "gpt-4o-2024-08-06": {
         "context": 128_000,
@@ -26,6 +27,7 @@ OPENAI_MODELS: dict[str, "_ModelDictMeta"] = {
         "context": 128_000,
         "price_input": 0.15,
         "price_output": 0.6,
+        "supports_vision": True,
     },
     "gpt-4o-mini-2024-07-18": {
         "context": 128_000,

--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -29,6 +29,7 @@ class ModelMeta:
     context: int
     max_output: int | None = None
     supports_streaming: bool = True
+    supports_vision: bool = False
 
     # price in USD per 1M tokens
     # if price is not set, it is assumed to be 0
@@ -40,6 +41,7 @@ class _ModelDictMeta(TypedDict):
     context: int
     max_output: NotRequired[int]
     supports_streaming: NotRequired[bool]
+    supports_vision: NotRequired[bool]
 
     # price in USD per 1M tokens
     price_input: NotRequired[float]
@@ -66,6 +68,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "max_output": 8192,
             "price_input": 3,
             "price_output": 15,
+            "supports_vision": True,
         },
         "claude-3-5-sonnet-20240620": {
             "context": 200_000,
@@ -78,6 +81,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "max_output": 8192,
             "price_input": 1,
             "price_output": 5,
+            "supports_vision": True,
         },
         "claude-3-haiku-20240307": {
             "context": 200_000,
@@ -112,8 +116,8 @@ def get_model(model: str | None = None) -> ModelMeta:
         provider, model = cast(tuple[Provider, str], model.split("/", 1))
         if provider not in MODELS or model not in MODELS[provider]:
             if provider not in ["openrouter", "local"]:
-                logger.warning(
-                    f"Unknown model {model} from {provider}, using fallback metadata"
+                logger.info(
+                    f"Using fallback metadata for unknown model {model} from {provider}"
                 )
             return ModelMeta(provider, model, context=128_000)
     else:


### PR DESCRIPTION
Some fixes after https://github.com/ErikBjare/gptme/pull/254

- Fix bug where openrouter/deepseek/deepseek-chat wouldn't work due to incorrect model string formatting
- Add proper vision support metadata to models
- Improve vision support checks to use model metadata instead of provider
- Minor logging improvements
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix model string formatting and enhance vision support checks using metadata, with logging improvements.
> 
>   - **Behavior**:
>     - Fix incorrect model string formatting for `openrouter`, `deepseek`, and `deepseek-chat` in `init.py` and `llm_openai.py`.
>     - Enhance vision support checks in `llm_openai.py` to use model metadata instead of provider.
>   - **Models**:
>     - Add `supports_vision` metadata to models in `llm_openai_models.py` and `models.py`.
>   - **Misc**:
>     - Minor logging improvements in `chat.py` and `llm_openai.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for eff64a74e3e1cb6c97da7bf141490752cbd3c09f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->