### PR TITLE
fix: deepseek provider and gptme-eval docker improvements

### DIFF
--- a/gptme/eval/main.py
+++ b/gptme/eval/main.py
@@ -6,6 +6,7 @@ Inspired by a document by Anton Osika and Axel Theorell.
 
 import csv
 import logging
+import os
 import subprocess
 import sys
 from collections import defaultdict
@@ -319,7 +320,10 @@ def write_results(model_results: dict[str, list[EvalResult]]):
         text=True,
         capture_output=True,
     ).stdout.strip()
-    results_dir = project_dir / "eval_results" / timestamp
+    eval_results_dir = Path(
+        os.environ.get("EVAL_RESULTS_DIR", project_dir / "eval_results")
+    )
+    results_dir = eval_results_dir / timestamp
     results_dir.mkdir(parents=True, exist_ok=True)
 
     csv_filename = results_dir / "eval_results.csv"

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -170,7 +170,10 @@ def handle_files(msgs: list[dict]) -> list[dict]:
 
 def _process_file(msg: dict) -> dict:
     message_content = msg["content"]
-    supports_vision = get_model().supports_vision
+    model = get_model()
+    if model.provider == "deepseek":
+        # deepseek does not support files
+        return msg
 
     # combines a content message with a list of files
     content: list[dict[str, Any]] = (
@@ -185,7 +188,7 @@ def _process_file(msg: dict) -> dict:
         if ext not in ALLOWED_FILE_EXTS:
             logger.warning("Unsupported file type: %s", ext)
             continue
-        if not supports_vision:
+        if not model.supports_vision:
             logger.warning("Model does not support vision")
             continue
         if ext == "jpg":

--- a/scripts/Dockerfile.eval
+++ b/scripts/Dockerfile.eval
@@ -34,6 +34,7 @@ RUN if [ "$PLAYWRIGHT" = "yes" ]; then \
 
 # Create eval_results directory
 RUN mkdir ./eval_results; chown appuser:appuser ./eval_results
+ENV EVAL_RESULTS_DIR="/app/eval_results"
 
 # Switch back to non-root user
 USER appuser


### PR DESCRIPTION
- Skip file handling for deepseek provider (does not support files)
- Make eval results directory configurable via EVAL_RESULTS_DIR env var
- Configure eval results directory in gptme-eval docker container
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Skip file handling for deepseek provider and make eval results directory configurable in gptme-eval Docker setup.
> 
>   - **Behavior**:
>     - Skip file handling for `deepseek` provider in `_process_file()` in `llm_openai.py`.
>     - Make eval results directory configurable via `EVAL_RESULTS_DIR` environment variable in `main.py`.
>   - **Docker**:
>     - Set `EVAL_RESULTS_DIR` in `Dockerfile.eval` to `/app/eval_results`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for cdf56fa7eef4e248e623fb8829fb58a6c94d62ba. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->