### PR TITLE
fix: better error output when loading locked conversation

### DIFF
--- a/gptme/cli.py
+++ b/gptme/cli.py
@@ -261,19 +261,23 @@ def main(
     set_interruptible()  # prepare, user should be able to Ctrl+C until user prompt ready
     signal.signal(signal.SIGINT, handle_keyboard_interrupt)
 
-    chat(
-        prompt_msgs,
-        initial_msgs,
-        logdir,
-        model,
-        stream,
-        no_confirm,
-        interactive,
-        show_hidden,
-        workspace_path,
-        tool_allowlist,
-        tool_format,
-    )
+    try:
+        chat(
+            prompt_msgs,
+            initial_msgs,
+            logdir,
+            model,
+            stream,
+            no_confirm,
+            interactive,
+            show_hidden,
+            workspace_path,
+            tool_allowlist,
+            tool_format,
+        )
+    except RuntimeError as e:
+        logger.error(e)
+        sys.exit(1)
 
 
 def get_name(name: str) -> str:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves error handling for locked conversation loading by catching `RuntimeError` in `gptme/cli.py` and enhances `_lock_fd` management in `LogManager`.
> 
>   - **Error Handling**:
>     - Wraps `chat()` call in `gptme/cli.py` with try-except to catch `RuntimeError`, logs error, and exits with status 1.
>   - **LogManager Enhancements**:
>     - Initializes `_lock_fd` to `None` in `LogManager` in `gptme/logmanager.py`.
>     - Ensures `_lock_fd` is set to `None` if lock acquisition fails in `LogManager` constructor.
>     - Updates `__del__` method in `LogManager` to check `_lock_fd` directly instead of using `hasattr`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for bbff4074e4fd03b1bf0d04f324f28ccd92e662b5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->