### PR TITLE
fix: better anthropic cost logging

### DIFF
--- a/gptme/init.py
+++ b/gptme/init.py
@@ -84,8 +84,11 @@ def init_logging(verbose):
         datefmt="[%X]",
         handlers=[handler],
     )
+    # anthropic spams debug logs for every request
+    logging.getLogger("anthropic").setLevel(logging.INFO)
     # set httpx logging to WARNING
     logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
 
     # Register cleanup handler
 


### PR DESCRIPTION
Also set a bunch of loglevels for libs higher, so now `-v` output is actually readable.

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance logging in `llm_anthropic.py` to capture usage data and chunk types, and adjust logging levels in `init.py`.
> 
>   - **Logging Enhancements in `llm_anthropic.py`**:
>     - Add `logger.debug(response.usage)` in `chat()` to log usage data.
>     - Add `logger.debug(chunk.message.usage)` in `stream()` for `message_start` case.
>     - Add `logger.debug(chunk.usage)` in `stream()` for `message_delta` case.
>   - **Logging Configuration in `init.py`**:
>     - Set `anthropic` logger level to `INFO` to reduce debug log spam.
>     - Set `httpcore` logger level to `WARNING`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for f07470619b97e77066519afc04182aeb9b121c48. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->