### PR TITLE
fix: support heredoc/EOF syntax in shell tool

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -410,6 +410,7 @@ def _shorten_stdout(
 
     return "\n".join(lines)
 
+
 def split_commands(script: str) -> list[str]:
     # TODO: write proper tests
     parts = bashlex.parse(script)

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -178,9 +178,9 @@ class ShellSession:
 
         self.process.stdin.flush()
 
-        stdout = []
-        stderr = []
-        return_code = None
+        stdout: list[str] = []
+        stderr: list[str] = []
+        return_code: int | None = None
 
         while True:
             rlist, _, _ = select.select([self.stdout_fd, self.stderr_fd], [], [])

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -105,6 +105,7 @@ multiline command"
     commands = split_commands(script_loop)
     assert len(commands) == 1
 
+
 def test_heredoc_complex(shell):
     # Test nested heredocs
     ret, out, err = shell.run("""
@@ -130,6 +131,7 @@ EOF
     assert err.strip() == ""
     assert out.strip() == "Hello, World!"
     assert ret == 0
+
 
 def test_function():
     script = """


### PR DESCRIPTION
Fixes #108 
Fixes #331

My gptme agent (Jake :D) attempted to fix this autonomously, wasn't able to quite get there, but it did 70% of the work, I just cleaned things up. Learnt a lot doing this and I have a branch with a lot of hacks and experiments. I think there should be a mechanism for the agent to monitor commands. Eg. in this case, the command was hanging and I had to manually interrupt the process. It would be cool to have a heartbeat mechanism where the agent gets updates on long-running commands with the option to interrupt it.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes heredoc syntax handling in `ShellSession._run()` and adds tests for various heredoc cases in `test_shell.py`.
> 
>   - **Behavior**:
>     - Fixes heredoc syntax handling in `ShellSession._run()` in `shell.py` by adjusting command execution logic.
>     - Removes unnecessary `read_delimiter` flag and simplifies return code handling.
>   - **Tests**:
>     - Adds tests for heredoc syntax, including basic, stripped, nested, and variable substitution cases in `test_shell.py`.
>     - Updates `test_echo_multiline()` and adds `test_heredoc_complex()` to cover new cases.
>   - **Imports**:
>     - Changes relative imports to absolute imports in `shell.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 5e0d368d43a5355be98ecb21bb1b977822bc048f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->