### PR TITLE
feat: allow to load tools from external modules

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -42,6 +42,11 @@ Here is an example:
     #MODEL = "local/<model-name>"
     #OPENAI_BASE_URL = "http://localhost:11434/v1"
 
+    # Uncomment to change tool configuration
+    #TOOL_FORMAT = "markdown" # Select the tool formal. One of `markdown`, `xml`, `tool`
+    #TOOL_ALLOW_LIST = "save,append,patch,python" # Comma separated list of allowed tools
+    #TOOL_MODULES = "gptme.tools,custom.tools" # List of python comma separated python module path
+
 The ``prompt`` section contains options for the prompt.
 
 The ``env`` section contains environment variables that gptme will fall back to if they are not set in the shell environment. This is useful for setting the default model and API keys for :doc:`providers`.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -44,7 +44,7 @@ Here is an example:
 
     # Uncomment to change tool configuration
     #TOOL_FORMAT = "markdown" # Select the tool formal. One of `markdown`, `xml`, `tool`
-    #TOOL_ALLOWLIST = "save,append,patch,python"  # Comma separated list of allowed tools
+    #TOOL_ALLOWLIST = "save,append,patch,ipython,shell,browser"  # Comma separated list of allowed tools
     #TOOL_MODULES = "gptme.tools,custom.tools" # List of python comma separated python module path
 
 The ``prompt`` section contains options for the prompt.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -44,7 +44,7 @@ Here is an example:
 
     # Uncomment to change tool configuration
     #TOOL_FORMAT = "markdown" # Select the tool formal. One of `markdown`, `xml`, `tool`
-    #TOOL_ALLOW_LIST = "save,append,patch,python" # Comma separated list of allowed tools
+    #TOOL_ALLOWLIST = "save,append,patch,python"  # Comma separated list of allowed tools
     #TOOL_MODULES = "gptme.tools,custom.tools" # List of python comma separated python module path
 
 The ``prompt`` section contains options for the prompt.

--- a/docs/custom_tool.rst
+++ b/docs/custom_tool.rst
@@ -9,7 +9,7 @@ This guide will walk you through the process of creating and registering a custo
 
 Creating a Custom Tool
 -----------------------
-To create a custom tool, you need to define a new instance of the `ToolSpec` class.
+To create a custom tool, you need to define a new instance of the ``ToolSpec`` class.
 This class requires several parameters:
 
 - **name**: The name of the tool.
@@ -63,17 +63,18 @@ Here is a basic example of defining a custom tool:
 
 Registering the Tool
 ---------------------
-To ensure your tool is available for use, you can specify the module in the `TOOL_MODULES` env variable or
+To ensure your tool is available for use, you can specify the module in the ``TOOL_MODULES`` env variable or
 setting in your :doc:`project configuration file <config>`, which will automatically load your custom tools.
 
 .. code-block:: toml
 
     TOOL_MODULES = "gptme.tools,path.to.your.custom_tool_module"
 
-Don't remove the `gptme.tools` package unless you know exactly what you are doing.
+Don't remove the ``gptme.tools`` package unless you know exactly what you are doing.
 
-Ensure your module is in the Python path by either installing it (e.g., with `pip install .`) or
-by temporarily modifying the `PYTHONPATH` environment variable. For example:
+Ensure your module is in the Python path by either installing it
+(e.g. with ``pip install .`` or ``pipx runpip gptme install .``, depending on installation method)
+or by temporarily modifying the `PYTHONPATH` environment variable. For example:
 
 .. code-block:: bash
 

--- a/docs/custom_tool.rst
+++ b/docs/custom_tool.rst
@@ -1,0 +1,83 @@
+Creating a Custom Tool for gptme
+=================================
+
+Introduction
+------------
+In gptme, a custom tool allows you to extend the functionality of the assistant by
+defining new tools that can be executed.
+This guide will walk you through the process of creating and registering a custom tool.
+
+Creating a Custom Tool
+-----------------------
+To create a custom tool, you need to define a new instance of the `ToolSpec` class.
+This class requires several parameters:
+
+- **name**: The name of the tool.
+- **desc**: A description of what the tool does.
+- **instructions**: Instructions on how to use the tool.
+- **examples**: Example usage of the tool.
+- **execute**: A function that defines the tool's behavior when executed.
+- **block_types**: The block types to detects.
+- **parameters**: A list of parameters that the tool accepts.
+
+Here is a basic example of defining a custom tool:
+
+.. code-block:: python
+
+    import random
+    from gptme.tools import ToolSpec, Parameter, ToolUse
+    from gptme.message import Message
+
+    def execute(code, args, kwargs, confirm):
+
+        if code is None and kwargs is not None:
+            code = kwargs.get('side_count')
+
+        yield Message('system', f"Result: {random.randint(1,code)}")
+
+    def examples(tool_format):
+        return f"""
+    > User: Throw a dice and give me the result.
+    > Assistant:
+    {ToolUse("dice", [], "6").to_output(tool_format)}
+    > System: 3
+    > assistant: The result is 3
+    """.strip()
+
+    tool = ToolSpec(
+        name="dice",
+        desc="A dice simulator.",
+        instructions="This tool generate a random integer value like a dice.",
+        examples=examples,
+        execute=execute,
+        block_types=["dice"],
+        parameters=[
+            Parameter(
+                name="side_count",
+                type="integer",
+                description="The number of faces of the dice to throw.",
+                required=True,
+            ),
+        ],
+    )
+
+Registering the Tool
+---------------------
+To ensure your tool is available for use, you can specify the module in the `TOOL_MODULES` env variable or
+setting in your :doc:`project configuration file <config>`, which will automatically load your custom tools.
+
+.. code-block:: toml
+
+    TOOL_MODULES = "gptme.tools,path.to.your.custom_tool_module"
+
+Don't remove the `gptme.tools` package unless you know exactly what you are doing.
+
+Ensure your module is in the Python path by either installing it (e.g., with `pip install .`) or
+by temporarily modifying the `PYTHONPATH` environment variable. For example:
+
+.. code-block:: bash
+
+    export PYTHONPATH=$PYTHONPATH:/path/to/your/module
+
+
+This lets Python locate your module during development and testing without requiring installation.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,7 @@ See the `README <https://github.com/ErikBjare/gptme/blob/master/README.md>`_ fil
    evals
    bot
    finetuning
+   custom_tool
    arewetiny
    timeline
    alternatives

--- a/gptme/cli.py
+++ b/gptme/cli.py
@@ -11,9 +11,9 @@ from typing import Literal
 import click
 from pick import pick
 
-from gptme.config import get_config
 
 from .chat import chat
+from .config import get_config
 from .commands import _gen_help
 from .constants import MULTIPROMPT_SEPARATOR
 from .dirs import get_logs_dir
@@ -22,12 +22,7 @@ from .llm.models import get_recommended_model
 from .logmanager import ConversationMeta, get_user_conversations
 from .message import Message
 from .prompts import get_prompt
-from .tools import (
-    ToolFormat,
-    ToolSpec,
-    init_tools,
-    set_tool_format,
-)
+from .tools import ToolFormat, init_tools, get_available_tools
 from .util import epoch_to_age
 from .util.generate_name import generate_name
 from .util.interrupt import handle_keyboard_interrupt, set_interruptible
@@ -39,7 +34,7 @@ logger = logging.getLogger(__name__)
 script_path = Path(os.path.realpath(__file__))
 commands_help = "\n".join(_gen_help(incl_langtags=False))
 available_tool_names = ", ".join(
-    sorted([tool.name for tool in ToolSpec.get_tools().values() if tool.available])
+    sorted([tool.name for tool in get_available_tools() if tool.available])
 )
 
 
@@ -189,7 +184,6 @@ def main(
     selected_tool_format: ToolFormat = (
         tool_format or config.get_env("TOOL_FORMAT") or "markdown"  # type: ignore
     )
-    set_tool_format(selected_tool_format)
 
     # early init tools to generate system prompt
     init_tools(frozenset(tool_allowlist) if tool_allowlist else None)

--- a/gptme/commands.py
+++ b/gptme/commands.py
@@ -15,8 +15,7 @@ from .message import (
     print_msg,
     toml_to_msgs,
 )
-from .tools import ToolUse, execute_msg, loaded_tools
-from .tools.base import ConfirmFunc, get_tool_format
+from .tools import ToolUse, execute_msg, get_tools, ConfirmFunc, get_tool_format
 from .util.cost import log_costs
 from .util.export import export_chat_to_html
 from .util.useredit import edit_text_with_editor
@@ -138,7 +137,7 @@ def handle_cmd(
         case "tools":
             manager.undo(1, quiet=True)
             print("Available tools:")
-            for tool in loaded_tools:
+            for tool in get_tools():
                 print(
                     f"""
   # {tool.name}
@@ -220,7 +219,7 @@ def _gen_help(incl_langtags: bool = True) -> Generator[str, None, None]:
         yield "  /python print('hello')"
         yield ""
         yield "Supported langtags:"
-        for tool in loaded_tools:
+        for tool in get_tools():
             if tool.block_types:
                 yield f"  - {tool.block_types[0]}" + (
                     f"  (alias: {', '.join(tool.block_types[1:])})"

--- a/gptme/config.py
+++ b/gptme/config.py
@@ -19,11 +19,11 @@ class Config:
     env: dict
 
     def get_env(self, key: str, default: str | None = None) -> str | None:
-        """Gets an enviromnent variable, checks the config file if it's not set in the environment."""
+        """Gets an environment variable, checks the config file if it's not set in the environment."""
         return os.environ.get(key) or self.env.get(key) or default
 
     def get_env_required(self, key: str) -> str:
-        """Gets an enviromnent variable, checks the config file if it's not set in the environment."""
+        """Gets an environment variable, checks the config file if it's not set in the environment."""
         if val := os.environ.get(key) or self.env.get(key):
             return val
         raise KeyError(  # pragma: no cover

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, cast
 from ..config import Config
 from ..constants import TEMPERATURE, TOP_P
 from ..message import Message, msgs2dicts
-from ..tools.base import Parameter, ToolSpec, ToolUse
+from ..tools import Parameter, ToolSpec, ToolUse
 from .models import ModelMeta, Provider, get_model
 
 if TYPE_CHECKING:

--- a/gptme/prompts.py
+++ b/gptme/prompts.py
@@ -200,14 +200,14 @@ def prompt_tools(
     examples: bool = True, tool_format: ToolFormat = "markdown"
 ) -> Generator[Message, None, None]:
     """Generate the tools overview prompt."""
-    from .tools import loaded_tools  # fmt: skip
+    from .tools import get_tools  # fmt: skip
 
-    assert loaded_tools, "No tools loaded"
+    assert get_tools(), "No tools loaded"
 
     use_tool = tool_format == "tool"
 
     prompt = "# Tools aliases" if use_tool else "# Tools Overview"
-    for tool in loaded_tools:
+    for tool in get_tools():
         if not use_tool or not tool.is_runnable():
             prompt += tool.get_tool_prompt(examples, tool_format)
 

--- a/gptme/server/api.py
+++ b/gptme/server/api.py
@@ -24,8 +24,7 @@ from ..llm import _stream
 from ..llm.models import get_model
 from ..logmanager import LogManager, get_user_conversations, prepare_messages
 from ..message import Message
-from ..tools import execute_msg
-from ..tools.base import ToolUse
+from ..tools import ToolUse, execute_msg
 
 logger = logging.getLogger(__name__)
 

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -86,7 +86,7 @@ def init_tools(
     config = get_config()
 
     if allowlist is None:
-        env_allowlist = config.get_env("TOOL_ALLOW_LIST")
+        env_allowlist = config.get_env("TOOL_ALLOWLIST")
         if env_allowlist:
             allowlist = frozenset(env_allowlist.split(","))
 

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -34,8 +34,6 @@ __all__ = [
     "set_tool_format",
 ]
 
-from .save import tool_save
-
 _loaded_tools: list[ToolSpec] = []
 _available_tools: list[ToolSpec] | None = None
 
@@ -128,10 +126,6 @@ def get_tool_for_langtag(lang: str) -> ToolSpec | None:
     for tool in _loaded_tools:
         if block_type in tool.block_types:
             return tool
-    is_filename = "." in lang or "/" in lang
-    if is_filename:
-        # NOTE: special case
-        return tool_save
     return None
 
 

--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -290,6 +290,7 @@ tool = ToolSpec(
     instructions=instructions,
     examples=examples,
     functions=[computer],
+    disabled_by_default=True,
 )
 
 __doc__ = tool.get_doc(__doc__)

--- a/gptme/tools/patch.py
+++ b/gptme/tools/patch.py
@@ -42,7 +42,8 @@ $ORIGINAL_CONTENT
 $UPDATED_CONTENT
 >>>>>>> UPDATED
 '''.strip()).to_output("markdown")}
-"""
+""",
+    "tool": "The `patch` parameter must be a string containing conflict markers without any code block.",
 }
 
 ORIGINAL = "<<<<<<< ORIGINAL\n"
@@ -275,7 +276,7 @@ tool = ToolSpec(
         Parameter(
             name="patch",
             type="string",
-            description="The patch to apply.",
+            description=f"The patch to apply. Use conflict markers! Example:\n{patch_content}",
             required=True,
         ),
     ],

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager
 from logging import getLogger
 from typing import TYPE_CHECKING, TypeVar
 
+from . import get_tools
 from ..message import Message
 from ..util.ask_execute import print_preview
 from .base import (
@@ -226,6 +227,12 @@ fib(10)
 
 
 def init() -> ToolSpec:
+    # Register python functions from other tools
+    for loaded_tool in get_tools():
+        if loaded_tool.functions:
+            for func in loaded_tool.functions:
+                register_function(func)
+
     python_libraries = get_installed_python_libraries()
     python_libraries_str = (
         "\n".join(f"- {lib}" for lib in python_libraries)
@@ -265,5 +272,6 @@ tool = ToolSpec(
             required=True,
         ),
     ],
+    load_priority=10,
 )
 __doc__ = tool.get_doc(__doc__)

--- a/gptme/tools/subagent.py
+++ b/gptme/tools/subagent.py
@@ -163,5 +163,6 @@ tool = ToolSpec(
     desc="Create and manage subagents",
     examples=examples,
     functions=[subagent, subagent_status, subagent_wait],
+    disabled_by_default=True,
 )
 __doc__ = tool.get_doc(__doc__)

--- a/gptme/util/ask_execute.py
+++ b/gptme/util/ask_execute.py
@@ -13,7 +13,7 @@ from rich.console import Console
 from rich.syntax import Syntax
 
 from ..message import Message
-from ..tools.base import ConfirmFunc
+from ..tools import ConfirmFunc
 from . import print_bell
 from .clipboard import copy, set_copytext
 from .prompt import get_prompt_session

--- a/gptme/util/cli.py
+++ b/gptme/util/cli.py
@@ -134,7 +134,7 @@ def tools():
 def tools_list(available: bool, langtags: bool):
     """List available tools."""
     from ..commands import _gen_help  # fmt: skip
-    from ..tools import init_tools, loaded_tools  # fmt: skip
+    from ..tools import init_tools, get_tools  # fmt: skip
 
     # Initialize tools
     init_tools()
@@ -150,7 +150,7 @@ def tools_list(available: bool, langtags: bool):
         return
 
     print("Available tools:")
-    for tool in loaded_tools:
+    for tool in get_tools():
         if not available or tool.available:
             status = "✓" if tool.available else "✗"
             print(
@@ -164,7 +164,7 @@ def tools_list(available: bool, langtags: bool):
 @click.argument("tool_name")
 def tools_info(tool_name: str):
     """Show detailed information about a tool."""
-    from ..tools import get_tool, init_tools, loaded_tools  # fmt: skip
+    from ..tools import get_tool, init_tools, get_tools  # fmt: skip
 
     # Initialize tools
     init_tools()
@@ -172,7 +172,7 @@ def tools_info(tool_name: str):
     tool = get_tool(tool_name)
     if not tool:
         print(f"Tool '{tool_name}' not found. Available tools:")
-        for t in loaded_tools:
+        for t in get_tools():
             print(f"- {t.name}")
         sys.exit(1)
 
@@ -197,7 +197,7 @@ def tools_info(tool_name: str):
 )
 def tools_call(tool_name: str, function_name: str, arg: list[str]):
     """Call a tool with the given arguments."""
-    from ..tools import get_tool, init_tools, loaded_tools  # fmt: skip
+    from ..tools import get_tool, init_tools, get_tools  # fmt: skip
 
     # Initialize tools
     init_tools()
@@ -205,7 +205,7 @@ def tools_call(tool_name: str, function_name: str, arg: list[str]):
     tool = get_tool(tool_name)
     if not tool:
         print(f"Tool '{tool_name}' not found. Available tools:")
-        for t in loaded_tools:
+        for t in get_tools():
             print(f"- {t.name}")
         sys.exit(1)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 
 import pytest
 from gptme.tools.rag import _has_gptme_rag
+from gptme.tools import clear_tools, init_tools
 
 
 def pytest_sessionstart(session):
@@ -26,6 +27,13 @@ def download_model():
     ef = embedding_functions.DefaultEmbeddingFunction()
     if ef:
         ef._download_model_if_not_exists()  # type: ignore
+
+
+@pytest.fixture(autouse=True)
+def clear_tools_before():
+    # Clear all tools and cache to prevent test conflicts
+    clear_tools()
+    init_tools.cache_clear()
 
 
 @pytest.fixture

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -4,7 +4,7 @@ from gptme.prompts import get_prompt
 from gptme.tools import init_tools
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(autouse=True)
 def init():
     init_tools()
 

--- a/tests/test_tool_use.py
+++ b/tests/test_tool_use.py
@@ -1,7 +1,7 @@
 import json_repair
 import pytest
 from gptme.tools import init_tools
-from gptme.tools.base import ToolUse, extract_json, toolcall_re
+from gptme.tools.base import ToolUse, extract_json, set_tool_format, toolcall_re
 
 
 @pytest.mark.parametrize(
@@ -148,5 +148,6 @@ def test_toolcall_regex(content, expected_tool, expected_json):
 )
 def test_toolcall_regex_invalid(content):
     # No ToolUse should be created for invalid content
+    set_tool_format("tool")
     tool_uses = list(ToolUse.iter_from_content(content))
     assert len(tool_uses) == 0

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,143 @@
+import pytest
+from unittest.mock import patch
+from gptme.tools import (
+    _discover_tools,
+    init_tools,
+    get_tools,
+    has_tool,
+    get_tool,
+    get_available_tools,
+    is_supported_langtag,
+    get_tool_for_langtag,
+)
+
+
+def test_init_tools():
+    init_tools()
+
+    assert len(get_tools()) > 1
+
+
+def test_init_tools_allowlist():
+    init_tools(allowlist=frozenset(("save",)))
+
+    assert len(get_tools()) == 1
+
+    assert get_tools()[0].name == "save"
+
+    # let's trigger a tool reloading
+    init_tools.cache_clear()
+
+    init_tools(allowlist=frozenset(("save",)))
+
+    assert len(get_tools()) == 1
+
+
+def test_init_tools_allowlist_from_env():
+    # Define the behavior for get_env based on the input key
+    def mock_get_env(key, default=None):
+        if key == "TOOL_ALLOW_LIST":
+            return "save,patch"
+        return default  # Return the default value for other keys
+
+    with patch("gptme.tools.get_config") as mock_get_config:
+        # Mock the get_config function to return a mock object
+        mock_config = mock_get_config.return_value
+        # Mock the get_env method to return the custom_env_value
+        mock_config.get_env.side_effect = mock_get_env
+
+        init_tools()
+
+    assert len(get_tools()) == 2
+
+
+def test_init_tools_fails():
+    with pytest.raises(ValueError):
+        init_tools(allowlist=frozenset(("save", "missing_tool")))
+
+
+def test_tool_loading_with_package():
+    found = _discover_tools(["gptme.tools"])
+
+    found_names = [t.name for t in found]
+
+    assert "save" in found_names
+    assert "python" in found_names
+
+
+def test_tool_loading_with_module():
+    found = _discover_tools(["gptme.tools.save"])
+
+    found_names = [t.name for t in found]
+
+    assert "save" in found_names
+    assert "python" not in found_names
+
+
+def test_tool_loading_with_missing_package():
+    found = _discover_tools(["gptme.fake_"])
+
+    assert len(found) == 0
+
+
+def test_get_available_tools():
+    custom_env_value = "gptme.tools.save,gptme.tools.patch"
+
+    with patch("gptme.tools.get_config") as mock_get_config:
+        # Mock the get_config function to return a mock object
+        mock_config = mock_get_config.return_value
+        # Mock the get_env method to return the custom_env_value
+        mock_config.get_env.return_value = custom_env_value
+
+        tools = get_available_tools()
+
+    assert len(tools) == 3
+    assert [t.name for t in tools] == ["append", "patch", "save"]
+
+
+def test_has_tool():
+    init_tools(allowlist=frozenset(("save",)))
+
+    assert has_tool("save")
+    assert not has_tool("anothertool")
+
+
+def test_get_tool():
+    init_tools(allowlist=frozenset(("save",)))
+
+    tool_save = get_tool("save")
+
+    assert tool_save
+    assert tool_save.name == "save"
+
+    assert not get_tool("anothertool")
+
+
+def test_get_tool_for_lang_tag():
+    init_tools(
+        allowlist=frozenset(
+            (
+                "save",
+                "python",
+            )
+        )
+    )
+
+    assert (tool_python := get_tool_for_langtag("ipython"))
+    assert tool_python.name == "python"
+
+    # Also test special use cases
+    assert (tool_save := get_tool_for_langtag("test.txt"))
+    assert tool_save.name == "save"
+
+    assert (tool_save := get_tool_for_langtag("/src/test"))
+    assert tool_save.name == "save"
+
+    assert not get_tool_for_langtag("randomtag")
+
+
+def test_is_supported_lang_tag():
+    init_tools(allowlist=frozenset(("save",)))
+
+    assert is_supported_langtag("save")
+    assert not is_supported_langtag("randomtag")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -57,25 +57,25 @@ def test_init_tools_fails():
 
 
 def test_tool_loading_with_package():
-    found = _discover_tools(["gptme.tools"])
+    found = _discover_tools(frozenset(("gptme.tools",)))
 
     found_names = [t.name for t in found]
 
     assert "save" in found_names
-    assert "python" in found_names
+    assert "ipython" in found_names
 
 
 def test_tool_loading_with_module():
-    found = _discover_tools(["gptme.tools.save"])
+    found = _discover_tools(frozenset(("gptme.tools.save",)))
 
     found_names = [t.name for t in found]
 
     assert "save" in found_names
-    assert "python" not in found_names
+    assert "ipython" not in found_names
 
 
 def test_tool_loading_with_missing_package():
-    found = _discover_tools(["gptme.fake_"])
+    found = _discover_tools(frozenset(("gptme.fake_",)))
 
     assert len(found) == 0
 
@@ -118,13 +118,13 @@ def test_get_tool_for_lang_tag():
         allowlist=frozenset(
             (
                 "save",
-                "python",
+                "ipython",
             )
         )
     )
 
     assert (tool_python := get_tool_for_langtag("ipython"))
-    assert tool_python.name == "python"
+    assert tool_python.name == "ipython"
 
     assert not get_tool_for_langtag("randomtag")
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -126,13 +126,6 @@ def test_get_tool_for_lang_tag():
     assert (tool_python := get_tool_for_langtag("ipython"))
     assert tool_python.name == "python"
 
-    # Also test special use cases
-    assert (tool_save := get_tool_for_langtag("test.txt"))
-    assert tool_save.name == "save"
-
-    assert (tool_save := get_tool_for_langtag("/src/test"))
-    assert tool_save.name == "save"
-
     assert not get_tool_for_langtag("randomtag")
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -36,7 +36,7 @@ def test_init_tools_allowlist():
 def test_init_tools_allowlist_from_env():
     # Define the behavior for get_env based on the input key
     def mock_get_env(key, default=None):
-        if key == "TOOL_ALLOW_LIST":
+        if key == "TOOL_ALLOWLIST":
             return "save,patch"
         return default  # Return the default value for other keys
 


### PR DESCRIPTION
@ErikBjare this MR is ready for review. It allows to load contributed tools from any python module. Read the added documentation for more information. Let me know what you think.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This pull request enables loading tools from external Python modules by updating configuration and tool initialization logic.
> 
>   - **Behavior**:
>     - Allow loading tools from external Python modules specified in `TOOL_MODULES` in `config.rst`.
>     - Update `chat.py` and `cli.py` to use `TOOL_FORMAT` and `TOOL_MODULES` from configuration.
>     - Tools can be enabled/disabled by default and have a load priority.
>   - **Tool Initialization**:
>     - Refactor `init_tools()` in `tools/__init__.py` to discover tools from specified modules using `_discover_tools()`.
>     - Add `disabled_by_default` and `load_priority` attributes to `ToolSpec` in `tools/base.py`.
>   - **Misc**:
>     - Update `computer.py`, `python.py`, `rag.py`, and `subagent.py` to use new tool initialization logic.
>     - Add examples and instructions for new tool loading capabilities in `config.rst`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 8c060684972ae399a9d9f05825a4101f06eb1ff1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->