### PR TITLE
fix: support piping stdin into gptme -r (resume)

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -117,11 +117,11 @@ def chat(
         if prompt_msgs:
             while prompt_msgs:
                 msg = prompt_msgs.pop(0)
-                if not msg.content.startswith("/"):
+                if not msg.content.startswith("/") and msg.role == "user":
                     msg = _include_paths(msg, workspace)
                 manager.append(msg)
                 # if prompt is a user-command, execute it
-                if execute_cmd(msg, manager, confirm_func):
+                if msg.role == "user" and execute_cmd(msg, manager, confirm_func):
                     continue
 
                 # Generate and execute response for this prompt

--- a/gptme/cli.py
+++ b/gptme/cli.py
@@ -204,12 +204,11 @@ def main(
 
     # if stdin is not a tty, we might be getting piped input, which we should include in the prompt
     was_piped = False
+    piped_input = None
     if not sys.stdin.isatty():
         # fetch prompt from stdin
-        prompt_stdin = _read_stdin()
-        if prompt_stdin:
-            # TODO: also append if existing convo loaded/resumed
-            initial_msgs += [Message("system", f"```stdin\n{prompt_stdin}\n```")]
+        piped_input = _read_stdin()
+        if piped_input:
             was_piped = True
 
             # Attempt to switch to interactive mode
@@ -237,6 +236,8 @@ def main(
 
     if resume:
         logdir = get_logdir_resume()
+        if piped_input:
+            prompt_msgs.append(Message("system", f"```stdin\n{piped_input}\n```"))
     # don't run pick in tests/non-interactive mode, or if the user specifies a name
     elif (
         interactive
@@ -248,6 +249,9 @@ def main(
         logdir = pick_log()
     else:
         logdir = get_logdir(name)
+        if piped_input:
+            # Add piped input to initial messages for new conversations
+            initial_msgs.append(Message("system", f"```stdin\n{piped_input}\n```"))
 
     if workspace == "@log":
         workspace_path: Path | None = logdir / "workspace"

--- a/gptme/cli.py
+++ b/gptme/cli.py
@@ -250,7 +250,6 @@ def main(
     else:
         logdir = get_logdir(name)
         if piped_input:
-            # Add piped input to initial messages for new conversations
             initial_msgs.append(Message("system", f"```stdin\n{piped_input}\n```"))
 
     if workspace == "@log":


### PR DESCRIPTION
Almost got it to do this autonomously, but I still had to do some cleanup :P

I added the `msg.role == "user"` checks because those functions contain asserts that the role should be user.

Fixes https://github.com/ErikBjare/gptme/issues/202

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for piping stdin into `gptme -r` (resume) by appending piped input to prompt messages in `cli.py`.
> 
>   - **Behavior**:
>     - Support piping stdin into `gptme -r` (resume) in `cli.py`.
>     - Append piped input to `prompt_msgs` if resuming a conversation in `main()`.
>   - **Functions**:
>     - Modify `main()` in `cli.py` to handle piped input and append to `initial_msgs` for new conversations.
>     - Update `confirm_func()` and `execute_cmd()` logic in `chat.py` to handle user role checks.
>   - **Misc**:
>     - Refactor stdin reading logic in `cli.py` to use `_read_stdin()` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for a69c42e69413ca689adaeb339c8999b30816cbc6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->