### PR TITLE
fix: migrated to latest anthropic version v0.42 (prompt caching now stable)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -42,13 +42,13 @@ files = [
 
 [[package]]
 name = "anthropic"
-version = "0.40.0"
+version = "0.42.0"
 description = "The official Python library for the anthropic API"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "anthropic-0.40.0-py3-none-any.whl", hash = "sha256:442028ae8790ff9e3b6f8912043918755af1230d193904ae2ef78cc22995280c"},
-    {file = "anthropic-0.40.0.tar.gz", hash = "sha256:3efeca6d9e97813f93ed34322c6c7ea2279bf0824cd0aa71b59ce222665e2b87"},
+    {file = "anthropic-0.42.0-py3-none-any.whl", hash = "sha256:46775f65b723c078a2ac9e9de44a46db5c6a4fabeacfd165e5ea78e6817f4eff"},
+    {file = "anthropic-0.42.0.tar.gz", hash = "sha256:bf8b0ed8c8cb2c2118038f29c58099d2f99f7847296cafdaa853910bfff4edf4"},
 ]
 
 [package.dependencies]
@@ -58,7 +58,7 @@ httpx = ">=0.23.0,<1"
 jiter = ">=0.4.0,<1"
 pydantic = ">=1.9.0,<3"
 sniffio = "*"
-typing-extensions = ">=4.7,<5"
+typing-extensions = ">=4.10,<5"
 
 [package.extras]
 bedrock = ["boto3 (>=1.28.57)", "botocore (>=1.31.57)"]
@@ -3384,4 +3384,4 @@ youtube = ["youtube_transcript_api"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "e6c684f2ed44722a137e5ea2bda0a8bbd89593cb99954ec16b19ca905a540a38"
+content-hash = "08f5521530bdc833366e98513d0dbb83d25ed355811e5d2411fe8d097936775d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ json-repair = "^0.30.2"
 
 # providers
 openai = "^1.0"
-anthropic = "^0.40"
+anthropic = "^0.42"
 
 # tools
 ipython = "^8.17.2"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `anthropic` library to v0.42 and remove beta prompt caching features in `llm_anthropic.py`.
> 
>   - **Library Update**:
>     - Update `anthropic` library to version 0.42 in `pyproject.toml`.
>   - **Code Changes in `llm_anthropic.py`**:
>     - Remove imports related to `beta.prompt_caching`.
>     - Update function calls from `_anthropic.beta.prompt_caching.messages.create` to `_anthropic.messages.create` and similar for `stream`.
>     - Update type references from `PromptCachingBetaTextBlockParam` to `anthropic.types.TextBlockParam` and similar for other types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for e7938082687a28422dee75ddf8609e496b2c8c58. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->