### PR TITLE
fix: move playwright to thread to avoid event loop conflicts

### DIFF
--- a/gptme/tools/_browser_thread.py
+++ b/gptme/tools/_browser_thread.py
@@ -1,0 +1,102 @@
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from queue import Empty, Queue
+from threading import Event, Lock, Thread
+from typing import Any, Literal, TypeVar
+
+from playwright.sync_api import sync_playwright
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+TIMEOUT = 30  # seconds
+
+
+@dataclass
+class Command:
+    func: Callable
+    args: tuple
+    kwargs: dict
+
+
+Action = Literal["stop"]
+
+
+class BrowserThread:
+    def __init__(self):
+        self.queue: Queue[tuple[Command | Action, object]] = Queue()
+        self.results: dict[object, tuple[Any, Exception | None]] = {}
+        self.lock = Lock()
+        self.ready = Event()
+        self.thread = Thread(target=self._run, daemon=True)
+        self.thread.start()
+        # Wait for browser to be ready
+        if not self.ready.wait(timeout=TIMEOUT):
+            raise TimeoutError("Browser failed to start")
+        logger.info("Browser thread started")
+
+    def _run(self):
+        try:
+            playwright = sync_playwright().start()
+            browser = playwright.chromium.launch()
+            logger.info("Browser launched")
+            self.ready.set()
+
+            while True:
+                try:
+                    cmd, cmd_id = self.queue.get(timeout=1.0)
+                    if cmd == "stop":
+                        break
+
+                    try:
+                        result = cmd.func(browser, *cmd.args, **cmd.kwargs)
+                        with self.lock:
+                            self.results[cmd_id] = (result, None)
+                    except Exception as e:
+                        logger.exception("Error in browser thread")
+                        with self.lock:
+                            self.results[cmd_id] = (None, e)
+                except Empty:
+                    # Timeout on queue.get, continue waiting
+                    continue
+        except Exception:
+            logger.exception("Fatal error in browser thread")
+            self.ready.set()  # Prevent hanging in __init__
+            raise
+        finally:
+            try:
+                browser.close()
+                playwright.stop()
+            except Exception:
+                logger.exception("Error stopping browser")
+            logger.info("Browser stopped")
+
+    def execute(self, func: Callable[..., T], *args, **kwargs) -> T:
+        if not self.thread.is_alive():
+            raise RuntimeError("Browser thread died")
+
+        cmd_id = object()  # unique id
+        self.queue.put((Command(func, args, kwargs), cmd_id))
+
+        deadline = time.monotonic() + TIMEOUT
+        while time.monotonic() < deadline:
+            with self.lock:
+                if cmd_id in self.results:
+                    result, error = self.results.pop(cmd_id)
+                    if error:
+                        raise error
+                    return result
+            time.sleep(0.1)  # Prevent busy-waiting
+
+        raise TimeoutError(f"Browser operation timed out after {TIMEOUT}s")
+
+    def stop(self):
+        """Stop the browser thread"""
+        try:
+            self.queue.put(("stop", object()))
+            self.thread.join(timeout=TIMEOUT)
+        except Exception:
+            logger.exception("Error stopping browser thread")


### PR DESCRIPTION
Fixes #351 by moving Playwright to a separate thread to isolate its event loop from prompt_toolkit.

This prevents the asyncio.run() error that occurred when trying to use prompt_toolkit after browser operations.

Changes:
- Created thread-based browser manager that keeps browser instance alive between operations
- Updated all browser operations (read_url, search, screenshot) to use the thread
- Added proper timeout and error handling
- Added browser readiness check

Tested and confirmed working with:
- read_url
- search (both Google and DuckDuckGo)
- screenshot_url
- prompt_toolkit input between operations
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Moves Playwright operations to a separate thread using `BrowserThread` to prevent event loop conflicts with `prompt_toolkit`.
> 
>   - **Behavior**:
>     - Moves Playwright operations to a separate thread using `BrowserThread` to prevent event loop conflicts with `prompt_toolkit`.
>     - Adds timeout and error handling for browser operations.
>     - Ensures browser readiness before operations.
>   - **Implementation**:
>     - Introduces `BrowserThread` class in `_browser_thread.py` to manage browser operations in a separate thread.
>     - Updates `read_url`, `search_google`, `search_duckduckgo`, and `screenshot_url` in `_browser_playwright.py` to use `BrowserThread`.
>   - **Testing**:
>     - Confirms functionality with `read_url`, `search` (Google and DuckDuckGo), and `screenshot_url`.
>     - Verifies `prompt_toolkit` input works between operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 5673f4de986d763d900c6c895320d9d6b94a7776. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->