### PR TITLE
fix: retry on anthropic overloaded

### DIFF
--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -1,6 +1,8 @@
 import base64
 import logging
+import time
 from collections.abc import Generator
+from functools import wraps
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -19,11 +21,39 @@ if TYPE_CHECKING:
     import anthropic.types  # fmt: skip
     from anthropic import Anthropic  # fmt: skip
 
+
 logger = logging.getLogger(__name__)
 
 _anthropic: "Anthropic | None" = None
 
 ALLOWED_FILE_EXTS = ["jpg", "jpeg", "png", "gif"]
+
+
+def retry_generator_on_overloaded(max_retries: int = 5, base_delay: float = 1.0):
+    """Decorator to retry generator functions on Anthropic API overloaded errors with exponential backoff."""
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            from anthropic import APIStatusError  # fmt: skip
+
+            for attempt in range(max_retries):
+                try:
+                    yield from func(*args, **kwargs)
+                    break  # If generator completes successfully, exit retry loop
+                except APIStatusError as e:
+                    if e.status_code != 503 or attempt == max_retries - 1:
+                        raise
+
+                    delay = base_delay * (2**attempt)
+                    logger.warning(
+                        f"Anthropic API overloaded, retrying in {delay}s (attempt {attempt + 1}/{max_retries})"
+                    )
+                    time.sleep(delay)
+
+        return wrapper
+
+    return decorator
 
 
 def init(config):
@@ -69,6 +99,7 @@ def chat(messages: list[Message], model: str, tools: list[ToolSpec] | None) -> s
     return content[0].text  # type: ignore
 
 
+@retry_generator_on_overloaded()
 def stream(
     messages: list[Message], model: str, tools: list[ToolSpec] | None
 ) -> Generator[str, None, None]:


### PR DESCRIPTION
Attempt at fixing https://github.com/ErikBjare/gptme/issues/345

Untested since it's hard to reproduce.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds retry mechanisms with exponential backoff for handling Anthropic API overload errors in `llm_anthropic.py`.
> 
>   - **Behavior**:
>     - Adds `retry_on_overloaded` and `retry_generator_on_overloaded` decorators in `llm_anthropic.py` for retrying on `APIStatusError` with status code 503 using exponential backoff.
>     - Applies `retry_on_overloaded` to `chat()` and `retry_generator_on_overloaded` to `stream()` in `llm_anthropic.py` to handle Anthropic API overloads.
>   - **Imports**:
>     - Adds `time` and `wraps` imports in `llm_anthropic.py` for implementing retry logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 5b4406157e0a3cc6dd9eb76bdf179e8eaed89384. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->