### PR TITLE
fix: stream and capture ipython output

### DIFF
--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -26,7 +26,7 @@ from .base import (
 )
 
 if TYPE_CHECKING:
-    from IPython.terminal.embed import InteractiveShellEmbed  # fmt: skip
+    from IPython.core.interactiveshell import InteractiveShell  # fmt: skip
 
 logger = getLogger(__name__)
 
@@ -35,7 +35,7 @@ logger = getLogger(__name__)
 #       https://github.com/ErikBjare/gptme/issues/29
 
 # IPython instance
-_ipython: "InteractiveShellEmbed | None" = None
+_ipython: "InteractiveShell | None" = None
 
 
 registered_functions: dict[str, Callable] = {}
@@ -54,13 +54,45 @@ def register_function(func: T) -> T:
 
 def _get_ipython():
     global _ipython
-    from IPython.terminal.embed import InteractiveShellEmbed  # fmt: skip
+    from IPython.core.interactiveshell import InteractiveShell  # fmt: skip
 
     if _ipython is None:
-        _ipython = InteractiveShellEmbed()
+        _ipython = InteractiveShell()
         _ipython.push(registered_functions)
 
     return _ipython
+
+
+class TeeIO(io.StringIO):
+    def __init__(self, original_stream):
+        super().__init__()
+        self.original_stream = original_stream
+        self.in_result_block = False
+
+    def write(self, s):
+        # hack to get rid of ipython result-prompt ("Out[0]: ...") and everything after it
+        if s.startswith("Out["):
+            self.in_result_block = True
+        if self.in_result_block:
+            if s.startswith("\n"):
+                self.in_result_block = False
+            else:
+                s = ""
+        self.original_stream.write(s)
+        self.original_stream.flush()  # Ensure immediate display
+        return super().write(s)
+
+
+@contextmanager
+def capture_and_display():
+    stdout_capture = TeeIO(sys.stdout)
+    stderr_capture = TeeIO(sys.stderr)
+    old_stdout, old_stderr = sys.stdout, sys.stderr
+    sys.stdout, sys.stderr = stdout_capture, stderr_capture
+    try:
+        yield stdout_capture, stderr_capture
+    finally:
+        sys.stdout, sys.stderr = old_stdout, old_stderr
 
 
 def execute_python(
@@ -70,6 +102,7 @@ def execute_python(
     confirm: ConfirmFunc = lambda _: True,
 ) -> Generator[Message, None, None]:
     """Executes a python codeblock and returns the output."""
+    from IPython.core.interactiveshell import ExecutionResult  # fmt: skip
 
     if code is not None and args is not None:
         code = code.strip()
@@ -88,31 +121,11 @@ def execute_python(
     _ipython = _get_ipython()
 
     # Capture and display output in real-time
-
-    class TeeIO(io.StringIO):
-        def __init__(self, original_stream):
-            super().__init__()
-            self.original_stream = original_stream
-
-        def write(self, s):
-            self.original_stream.write(s)
-            self.original_stream.flush()  # Ensure immediate display
-            return super().write(s)
-
-    @contextmanager
-    def capture_and_display():
-        stdout_capture = TeeIO(sys.stdout)
-        stderr_capture = TeeIO(sys.stderr)
-        old_stdout, old_stderr = sys.stdout, sys.stderr
-        sys.stdout, sys.stderr = stdout_capture, stderr_capture
-        try:
-            yield stdout_capture, stderr_capture
-        finally:
-            sys.stdout, sys.stderr = old_stdout, old_stderr
-
     with capture_and_display() as (stdout_capture, stderr_capture):
         # Execute the code (output will be displayed in real-time)
-        result = _ipython.run_cell(code, silent=False, store_history=False)
+        result: ExecutionResult = _ipython.run_cell(
+            code, silent=False, store_history=False
+        )
 
     captured_stdout = stdout_capture.getvalue()
     captured_stderr = stderr_capture.getvalue()

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -147,10 +147,10 @@ def execute_python(
         output += f"```stderr\n{captured_stderr.rstrip()}\n```\n\n"
     if result.error_in_exec:
         tb = result.error_in_exec.__traceback__
-        while tb.tb_next:  # type: ignore
-            tb = tb.tb_next  # type: ignore
-        # type: ignore
-        output += f"Exception during execution on line {tb.tb_lineno}:\n  {result.error_in_exec.__class__.__name__}: {result.error_in_exec}"
+        while tb and tb.tb_next:
+            tb = tb.tb_next
+        if tb:
+            output += f"Exception during execution on line {tb.tb_lineno}:\n  {result.error_in_exec.__class__.__name__}: {result.error_in_exec}"
 
     # strip ANSI escape sequences
     # TODO: better to signal to the terminal that we don't want colors?


### PR DESCRIPTION
Was needed to make the browser tool able to update the user on progress via logging/console messages. (noticed when fixing https://github.com/ErikBjare/gptme/pull/358)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance IPython output handling in `gptme/tools/python.py` by replacing `InteractiveShellEmbed` with `InteractiveShell` and adding real-time output streaming.
> 
>   - **IPython Handling**:
>     - Replace `InteractiveShellEmbed` with `InteractiveShell` for IPython instance.
>     - Modify `_get_ipython()` to use `InteractiveShell`.
>   - **Output Streaming**:
>     - Add `TeeIO` class to manage output streaming and filter IPython result prompts.
>     - Introduce `capture_and_display()` context manager to capture and display stdout and stderr in real-time.
>   - **Function Updates**:
>     - Update `execute_python()` to use `capture_and_display()` for real-time output capture and display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 5f90e0409e7a4ff9c38de7d3f290eff8c423e9a2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->