### PR TITLE
fix: rename python tool to ipython for better tooluse format adherence

### DIFF
--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -77,7 +77,7 @@ def init_tools(allowlist: frozenset[str] | None = None) -> None:
     """Runs initialization logic for tools."""
     # init python tool last
     tools = list(
-        sorted(ToolSpec.get_tools().values(), key=lambda tool: tool.name != "python")
+        sorted(ToolSpec.get_tools().values(), key=lambda tool: tool.name != "ipython")
     )
     loaded_tool_names = [tool.name for tool in loaded_tools]
     for tool in tools:

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -28,6 +28,7 @@ from .base import (
 if TYPE_CHECKING:
     from IPython.core.interactiveshell import InteractiveShell  # fmt: skip
 
+
 logger = getLogger(__name__)
 
 # TODO: launch the IPython session in the current venv, if any, instead of the pipx-managed gptme venv (for example) in which gptme itself runs
@@ -245,7 +246,7 @@ Available functions:
 
 
 tool = ToolSpec(
-    name="python",
+    name="ipython",
     desc="Execute Python code",
     instructions=instructions,
     examples=examples,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -326,7 +326,7 @@ def test_subagent(args: list[str], runner: CliRunner):
     # f14: 377
     # f15: 610
     # f16: 987
-    args.extend(["--tools", "python,subagent"])
+    args.extend(["--tools", "ipython,subagent"])
     args.extend(
         [
             "We are in a test. Use the subagent tool to compute `fib(15)`, where `fib(1) = 1` and `fib(2) = 1`.",

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -137,9 +137,9 @@ def test_tools_info():
     runner = CliRunner()
 
     # Test valid tool
-    result = runner.invoke(main, ["tools", "info", "python"])
+    result = runner.invoke(main, ["tools", "info", "ipython"])
     assert result.exit_code == 0
-    assert "Tool: python" in result.output
+    assert "Tool: ipython" in result.output
     assert "Description:" in result.output
     assert "Instructions:" in result.output
 


### PR DESCRIPTION
Attempt at improving https://github.com/ErikBjare/gptme/issues/327

No idea if it actually performs better.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Renames the 'python' tool to 'ipython' for better tool use format adherence, updating initialization and tests accordingly.
> 
>   - **Behavior**:
>     - Renames tool from `python` to `ipython` in `gptme/tools/__init__.py` and `gptme/tools/python.py`.
>     - Updates tool initialization logic in `init_tools()` to sort by `ipython`.
>   - **Tests**:
>     - Updates `test_tools_info()` in `test_util_cli.py` to check for `ipython` instead of `python`.
>     - Updates `test_subagent()` in `test_cli.py` to use `ipython` in tool list.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for fd8ea4ddf57813c363793893a7df9b28d3b6a4c6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->