### PR TITLE
fix: create workspace symlink in log folder, load on resume

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -73,15 +73,17 @@ def chat(
 
     # change to workspace directory
     # use if exists, create if @log, or use given path
+    # TODO: move this into LogManager? then just os.chdir(manager.workspace)
     log_workspace = logdir / "workspace"
     if log_workspace.exists():
         assert not workspace or (
             workspace == log_workspace
         ), f"Workspace already exists in {log_workspace}, wont override."
-        workspace = log_workspace
+        workspace = log_workspace.resolve()
     else:
         if not workspace:
             workspace = Path.cwd()
+            log_workspace.symlink_to(workspace, target_is_directory=True)
         assert workspace.exists(), f"Workspace path {workspace} does not exist"
     console.log(f"Using workspace at {path_with_tilde(workspace)}")
     os.chdir(workspace)


### PR DESCRIPTION
This is a step towards fixing https://github.com/ErikBjare/gptme/issues/262 by storing the workspace path in the log folder, which can then in turn be used for workspace-relative file lookups.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> In `chat()` in `gptme/chat.py`, create a symlink for the workspace in the log directory if it doesn't exist, resolving the path if it does.
> 
>   - **Behavior**:
>     - In `chat()` in `gptme/chat.py`, create a symlink `workspace` in `logdir` if it doesn't exist and `workspace` is not provided.
>     - Resolve `workspace` path if `log_workspace` symlink already exists.
>   - **Misc**:
>     - Add TODO comment to consider moving workspace logic into `LogManager`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 76c0ab806fa57a34e23248078e137ab6c1b83443. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->