### PR TITLE
fix: tool api call broken when user answer no to when asked for confirmation

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from .commands import action_descriptions, execute_cmd
 from .config import get_config
-from .constants import PROMPT_USER
+from .constants import INTERRUPT_CONTENT, PROMPT_USER
 from .init import init
 from .llm import reply
 from .llm.models import get_model
@@ -148,11 +148,7 @@ def chat(
                         )
                     except KeyboardInterrupt:
                         console.log("Interrupted. Stopping current execution.")
-                        manager.append(
-                            Message(
-                                "system", "User hit Ctrl-c to interrupt the process"
-                            )
-                        )
+                        manager.append(Message("system", INTERRUPT_CONTENT))
                         break
                     finally:
                         clear_interruptible()
@@ -225,7 +221,7 @@ def step(
     if (
         not last_msg
         or (last_msg.role in ["assistant"])
-        or last_msg.content == "Interrupted"
+        or last_msg.content == INTERRUPT_CONTENT
         or last_msg.pinned
         or not any(role == "user" for role in [m.role for m in log])
     ):  # pragma: no cover

--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -255,9 +255,6 @@ def step(
         if msg_response:
             yield msg_response.replace(quiet=True)
             yield from execute_msg(msg_response, confirm)
-    except KeyboardInterrupt:
-        clear_interruptible()
-        yield Message("system", "User hit Ctrl-c to interrupt the process")
     finally:
         clear_interruptible()
 

--- a/gptme/commands.py
+++ b/gptme/commands.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from time import sleep
 from typing import Literal
 
+from .constants import INTERRUPT_CONTENT
+
 from . import llm
 from .logmanager import LogManager, prepare_messages
 from .message import (
@@ -182,7 +184,7 @@ def edit(manager: LogManager) -> Generator[Message, None, None]:  # pragma: no c
             try:
                 sleep(1)
             except KeyboardInterrupt:
-                yield Message("system", "User hit Ctrl-c to interrupt the process")
+                yield Message("system", INTERRUPT_CONTENT)
                 return
     manager.edit(list(reversed(res)))
     print("Applied edited messages, write /log to see the result")

--- a/gptme/constants.py
+++ b/gptme/constants.py
@@ -26,3 +26,6 @@ PROMPT_USER = f"[bold {ROLE_COLOR['user']}]User[/bold {ROLE_COLOR['user']}]"
 PROMPT_ASSISTANT = (
     f"[bold {ROLE_COLOR['assistant']}]Assistant[/bold {ROLE_COLOR['assistant']}]"
 )
+
+
+INTERRUPT_CONTENT = "Interrupted by user"

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -113,7 +113,15 @@ def execute_msg(msg: Message, confirm: ConfirmFunc) -> Generator[Message, None, 
 
     for tooluse in ToolUse.iter_from_content(msg.content):
         if tooluse.is_runnable:
-            yield from tooluse.execute(confirm)
+            try:
+                for tool_response in tooluse.execute(confirm):
+                    yield tool_response.replace(call_id=tooluse.call_id)
+            except KeyboardInterrupt:
+                yield Message(
+                    "system",
+                    "User hit Ctrl-c to interrupt the process",
+                    call_id=tooluse.call_id,
+                )
 
 
 # Called often when checking streaming output for executable blocks,

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -4,6 +4,8 @@ from collections.abc import Generator
 
 from gptme.config import get_config
 
+from gptme.constants import INTERRUPT_CONTENT
+
 from ..util.interrupt import clear_interruptible
 
 from ..message import Message
@@ -122,7 +124,7 @@ def execute_msg(msg: Message, confirm: ConfirmFunc) -> Generator[Message, None, 
                 clear_interruptible()
                 yield Message(
                     "system",
-                    "User hit Ctrl-c to interrupt the process",
+                    INTERRUPT_CONTENT,
                     call_id=tooluse.call_id,
                 )
                 break

--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -4,6 +4,8 @@ from collections.abc import Generator
 
 from gptme.config import get_config
 
+from ..util.interrupt import clear_interruptible
+
 from ..message import Message
 from .base import (
     ToolFormat,
@@ -117,11 +119,13 @@ def execute_msg(msg: Message, confirm: ConfirmFunc) -> Generator[Message, None, 
                 for tool_response in tooluse.execute(confirm):
                     yield tool_response.replace(call_id=tooluse.call_id)
             except KeyboardInterrupt:
+                clear_interruptible()
                 yield Message(
                     "system",
                     "User hit Ctrl-c to interrupt the process",
                     call_id=tooluse.call_id,
                 )
+                break
 
 
 # Called often when checking streaming output for executable blocks,

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -287,10 +287,9 @@ class ToolUse:
                     confirm,
                 )
                 if isinstance(ex, Generator):
-                    for msg in ex:
-                        yield msg.replace(call_id=self.call_id)
+                    yield from ex
                 else:
-                    yield ex.replace(call_id=self.call_id)
+                    yield ex
             except Exception as e:
                 # if we are testing, raise the exception
                 logger.exception(e)

--- a/tests/test_llm_anthropic.py
+++ b/tests/test_llm_anthropic.py
@@ -97,6 +97,7 @@ def test_message_conversion_with_tools():
             content='<thinking>\nSomething\n</thinking>\n@save(tool_call_id): {"path": "path.txt", "content": "file_content"}',
         ),
         Message(role="system", content="Saved to toto.txt", call_id="tool_call_id"),
+        Message(role="system", content="(Modified by user)", call_id="tool_call_id"),
     ]
 
     tool_save = get_tool("save")
@@ -152,7 +153,12 @@ def test_message_conversion_with_tools():
             "content": [
                 {
                     "type": "tool_result",
-                    "content": [{"type": "text", "text": "Saved to toto.txt"}],
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Saved to toto.txt\n\n(Modified by user)",
+                        }
+                    ],
                     "tool_use_id": "tool_call_id",
                     "cache_control": {"type": "ephemeral"},
                 }

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -116,6 +116,7 @@ def test_message_conversion_with_tools():
             content='\n@save(tool_call_id): {"path": "path.txt", "content": "file_content"}',
         ),
         Message(role="system", content="Saved to toto.txt", call_id="tool_call_id"),
+        Message(role="system", content="(Modified by user)", call_id="tool_call_id"),
     ]
 
     set_default_model("openai/gpt-4o")
@@ -193,7 +194,10 @@ def test_message_conversion_with_tools():
         },
         {
             "role": "tool",
-            "content": [{"type": "text", "text": "Saved to toto.txt"}],
+            "content": [
+                {"type": "text", "text": "Saved to toto.txt"},
+                {"type": "text", "text": "(Modified by user)"},
+            ],
             "tool_call_id": "tool_call_id",
         },
     ]


### PR DESCRIPTION
This MR fixes a few bug regarding tool call in tool format:
- When the user choose answer on when asked for confirmation
- When user edit the file before saving
- When the user uses `Ctrl+c` to interrupt gptme

The underlying problems where that sometimes the `call_id` wasn't set in certain situations or multiple messages where returned by the `tooluse.execute` call but all were the response from the tool so we needed to merge them.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes tool API call issues by ensuring `call_id` is set and merging tool responses, with updates to message handling and tests.
> 
>   - **Behavior**:
>     - Fixes tool API call issues when users answer "no" to confirmation, edit files before saving, or interrupt with `Ctrl+c`.
>     - Ensures `call_id` is set correctly in `execute_msg()` in `tools/__init__.py` and `ToolUse.execute()` in `tools/base.py`.
>     - Merges multiple tool responses with the same `call_id` in `_merge_tool_results_with_same_call_id()` in `llm_openai.py` and `llm_anthropic.py`.
>   - **Functions**:
>     - Updates `_handle_tools()` in `llm_anthropic.py` and `llm_openai.py` to handle user role messages with `call_id`.
>     - Modifies `_transform_system_messages()` in `llm_anthropic.py` to merge consecutive user messages with the same `call_id`.
>   - **Tests**:
>     - Adds test cases in `test_llm_anthropic.py` and `test_llm_openai.py` to verify message conversion and tool handling with `call_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 2d25236284b90f88290175329bd99032f7603c43. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->