### PR TITLE
fix: improve smaller model response on user refusals

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -136,7 +136,11 @@ def chat(
                         )
                     except KeyboardInterrupt:
                         console.log("Interrupted. Stopping current execution.")
-                        manager.append(Message("system", "Interrupted"))
+                        manager.append(
+                            Message(
+                                "system", "User hit Ctrl-c to interrupt the process"
+                            )
+                        )
                         break
                     finally:
                         clear_interruptible()
@@ -237,7 +241,7 @@ def step(
             yield from execute_msg(msg_response, confirm)
     except KeyboardInterrupt:
         clear_interruptible()
-        yield Message("system", "Interrupted")
+        yield Message("system", "User hit Ctrl-c to interrupt the process")
     finally:
         clear_interruptible()
 

--- a/gptme/commands.py
+++ b/gptme/commands.py
@@ -183,7 +183,7 @@ def edit(manager: LogManager) -> Generator[Message, None, None]:  # pragma: no c
             try:
                 sleep(1)
             except KeyboardInterrupt:
-                yield Message("system", "Interrupted")
+                yield Message("system", "User hit Ctrl-c to interrupt the process")
                 return
     manager.edit(list(reversed(res)))
     print("Applied edited messages, write /log to see the result")

--- a/gptme/prompts.py
+++ b/gptme/prompts.py
@@ -128,6 +128,7 @@ Use `<thinking>` tags to think before you answer.
 You are in interactive mode. The user is available to provide feedback.
 You should show the user how you can use your tools to write code, interact with the terminal, and access the internet.
 The user can execute the suggested commands so that you see their output.
+If the user aborted or interrupted an operation don't try it again, ask for clarification instead.
 If clarification is needed, ask the user.
 """.strip()
 

--- a/gptme/tools/patch.py
+++ b/gptme/tools/patch.py
@@ -241,7 +241,7 @@ def execute_patch(
         code = kwargs.get("patch", code)
 
     if not code:
-        yield Message("system", "No patch provided")
+        yield Message("system", "No patch provided by the assistant")
         return
 
     yield from execute_with_confirmation(

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -114,7 +114,7 @@ def execute_python(
     print_preview(code, "python")
     if not confirm("Execute this code?"):
         # early return
-        yield Message("system", "Aborted, user chose not to run command.")
+        yield Message("system", "Execution aborted: user chose not to run this code.")
         return
 
     # Create an IPython instance if it doesn't exist yet

--- a/gptme/tools/save.py
+++ b/gptme/tools/save.py
@@ -97,13 +97,15 @@ def execute_save_impl(
     # Check if file exists
     if path.exists():
         if not confirm("File exists, overwrite?"):
-            yield Message("system", "Save cancelled.")
+            yield Message("system", "Save aborted: user refused to overwrite the file.")
             return
 
     # Check if folder exists
     if not path.parent.exists():
         if not confirm("Folder doesn't exist, create it?"):
-            yield Message("system", "Save cancelled.")
+            yield Message(
+                "system", "Save aborted: user refused to create a missing folder."
+            )
             return
         path.parent.mkdir(parents=True)
 
@@ -122,7 +124,10 @@ def execute_append_impl(
     path = path.expanduser()
     if not path.exists():
         if not confirm(f"File {path_display} doesn't exist, create it?"):
-            yield Message("system", "Append cancelled.")
+            yield Message(
+                "system",
+                "Append aborted: user refused to create the missing destination file.",
+            )
             return
 
     # strip leading newlines

--- a/gptme/tools/tmux.py
+++ b/gptme/tools/tmux.py
@@ -170,7 +170,7 @@ def execute_tmux(
 
     print_preview(f"Command: {cmd}", "bash", copy=True)
     if not confirm(f"Execute command: {cmd}?"):
-        yield Message("system", "Command execution cancelled.")
+        yield Message("system", "Execution aborted: user chose not to run the command.")
         return
 
     parts = cmd.split(maxsplit=1)

--- a/gptme/util/ask_execute.py
+++ b/gptme/util/ask_execute.py
@@ -246,7 +246,9 @@ def execute_with_confirmation(
         try:
             # Get confirmation
             if not confirm_fn(confirm_msg or f"Execute on {path}?"):
-                yield Message("system", "Operation cancelled.")
+                yield Message(
+                    "system", "Operation aborted: user chose not to run the operation."
+                )
                 return
 
             # Get potentially edited content


### PR DESCRIPTION
I noticed that when you refuse the operation when asked for confirmation, small models (at least gpt-o4-mini) are a bit lost and try again the same command without any modification multiple times which make the confirmation useless. 

To test it, with a `gpt-o4-mini` just use a prompt like "Create the file foo.txt with random content.` and say `No` when the tool ask for confirmation to save and the mode will call the tool again with the same parameters.

In this MR I tweaked a bit the initial prompt and the response message in these cases to prevent that behavior.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves response behavior for smaller models by updating prompts and messages to prevent redundant command execution after user refusals.
> 
>   - **Behavior**:
>     - Updates confirmation messages in `chat.py`, `commands.py`, `tools/patch.py`, `tools/python.py`, `tools/save.py`, `tools/tmux.py`, and `util/ask_execute.py` to specify user-initiated interruptions and refusals.
>     - Modifies `prompt_gptme()` in `prompts.py` to instruct the model not to retry operations after user refusal and to ask for clarification instead.
>   - **Prompts**:
>     - Adds a line in `prompt_gptme()` to handle user-aborted operations by asking for clarification rather than retrying.
>   - **Messages**:
>     - Changes various system messages to clarify when a user has aborted an operation, e.g., "User hit Ctrl-c to interrupt the process" and "Aborted, user chose not to run this code."
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 3f54a027bd316b3e2b87cd562c49ee3cd2ace9d7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->