### PR TITLE
feat: add support for different tool formats in eval system

### DIFF
--- a/gptme/eval/agents.py
+++ b/gptme/eval/agents.py
@@ -31,7 +31,8 @@ class Agent:
 class GPTMe(Agent):
     def act(self, files: Files | None, prompt: str):
         _id = abs(hash(prompt)) % 1000000
-        name = get_name(f"gptme-evals-{self.model.replace('/', '--')}-{_id}")
+        model_fmt = f"{self.model.replace('/', '--')}-{self.tool_format}"
+        name = get_name(f"gptme-evals-{model_fmt}-{_id}")
         log_dir = get_logs_dir() / name
         workspace_dir = log_dir / "workspace"
         if workspace_dir.exists():

--- a/gptme/eval/agents.py
+++ b/gptme/eval/agents.py
@@ -8,6 +8,7 @@ from gptme.cli import get_name
 from gptme.dirs import get_logs_dir
 from gptme.tools import init_tools
 
+from ..tools import ToolFormat
 from .filestore import FileStore
 from .types import Files
 
@@ -15,8 +16,9 @@ logger = logging.getLogger(__name__)
 
 
 class Agent:
-    def __init__(self, model: str):
+    def __init__(self, model: str, tool_format: ToolFormat = "markdown"):
         self.model = model
+        self.tool_format = tool_format
 
     @abstractmethod
     def act(self, files: Files | None, prompt: str) -> Files:
@@ -60,6 +62,7 @@ class GPTMe(Agent):
                 no_confirm=True,
                 interactive=False,
                 workspace=workspace_dir,
+                tool_format=self.tool_format,
             )
         # don't exit on sys.exit()
         except (SystemExit, KeyboardInterrupt):


### PR DESCRIPTION
- Add tool_format parameter to Agent class
- Support specifying tool format in CLI (--tool-format)
- Allow tool format to be specified per model with `model@format`
- Run evals with multiple tool formats per model
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for specifying tool formats in evaluation system via CLI and per model, updating `Agent` class and evaluation logic.
> 
>   - **Behavior**:
>     - Add `tool_format` parameter to `Agent` class in `agents.py`.
>     - Support specifying tool format in CLI with `--tool-format` and per model with `model@format` in `main.py`.
>     - Run evaluations with multiple tool formats per model in `run.py`.
>   - **CLI**:
>     - Add `--tool-format` option in `main.py` to specify tool format.
>     - Parse model specifications to handle `model@format` syntax in `main.py`.
>   - **Execution**:
>     - Modify `run_evals()` in `run.py` to accept `model_configs` with tool formats.
>     - Update `execute()` in `run.py` to use `tool_format` in `Agent` initialization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 16052fe46826b68bacb91292a6a52d0dec40f7ca. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->