### PR TITLE
build: install poetry-plugin-export needed in Docker script

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -18,7 +18,8 @@ COPY pyproject.toml poetry.lock README.md ./
 COPY gptme gptme/
 
 # Install dependencies and export requirements for server
-RUN /opt/poetry/bin/poetry export --without-hashes --without dev -f requirements.txt -o requirements.txt && \
+RUN /opt/poetry/bin/poetry self add poetry-plugin-export && \
+    /opt/poetry/bin/poetry export --without-hashes --without dev -f requirements.txt -o requirements.txt && \
     /opt/poetry/bin/poetry export --without-hashes --without dev -E server -f requirements.txt -o requirements-server.txt && \
     /opt/poetry/bin/poetry build
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `poetry-plugin-export` installation in Dockerfile to enable `poetry export` functionality.
> 
>   - **Dockerfile Changes**:
>     - Add `poetry-plugin-export` installation in `scripts/Dockerfile` to enable `poetry export` functionality.
>     - Modify `RUN` command to include `poetry self add poetry-plugin-export` before exporting requirements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for cdc05a54abedf240f0c93961d693c65f637c4f5c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->