### PR TITLE
fix: fix /summarize command

### DIFF
--- a/gptme/commands.py
+++ b/gptme/commands.py
@@ -6,9 +6,8 @@ from pathlib import Path
 from time import sleep
 from typing import Literal
 
-from .constants import INTERRUPT_CONTENT
-
 from . import llm
+from .constants import INTERRUPT_CONTENT
 from .logmanager import LogManager, prepare_messages
 from .message import (
     Message,
@@ -17,7 +16,13 @@ from .message import (
     print_msg,
     toml_to_msgs,
 )
-from .tools import ToolUse, execute_msg, get_tools, ConfirmFunc, get_tool_format
+from .tools import (
+    ConfirmFunc,
+    ToolUse,
+    execute_msg,
+    get_tool_format,
+    get_tools,
+)
 from .util.cost import log_costs
 from .util.export import export_chat_to_html
 from .util.useredit import edit_text_with_editor
@@ -101,10 +106,10 @@ def handle_cmd(
             new_name = args[0] if args else input("New name: ")
             manager.fork(new_name)
         case "summarize":
+            manager.undo(1, quiet=True)
             msgs = prepare_messages(manager.log.messages)
             msgs = [m for m in msgs if not m.hide]
-            summary = llm.summarize(msgs)
-            print(f"Summary: {summary}")
+            print_msg(llm.summarize(msgs))
         case "edit":
             # edit previous messages
             # first undo the '/edit' command itself

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -171,7 +171,7 @@ def _summarize_str(content: str) -> str:
     messages = [
         Message(
             "system",
-            content="You are a helpful assistant that helps summarize messages with an AI assistant through a tool called gptme.",
+            content="You are a helpful assistant that helps summarize messages into bullet format. Dont use any preamble or heading, start directly with a bullet list.",
         ),
         Message("user", content=f"Summarize this:\n{content}"),
     ]
@@ -245,9 +245,7 @@ def summarize(msg: str | Message | list[Message]) -> Message:
     else:
         content = "\n".join(format_msgs(msg))
 
-    logger.info(f"{content[:200]=}")
     summary = _summarize_helper(content)
-    logger.info(f"{summary[:200]=}")
 
     # construct message from summary
     content = f"Here's a summary of the conversation:\n{summary}"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `/summarize` command to undo itself before summarizing and changes summary format to bullet points without preamble.
> 
>   - **Behavior**:
>     - Fixes `/summarize` command in `handle_cmd()` in `commands.py` to undo the command itself before summarizing.
>     - Changes summary format in `_summarize_str()` in `llm/__init__.py` to bullet points without preamble.
>   - **Imports**:
>     - Reorders imports in `commands.py` for better organization.
>   - **Logging**:
>     - Removes logging of content and summary in `summarize()` in `llm/__init__.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 0d595e81460398b1b4cdc4ee715fa1b7d2cae79f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->