### PR TITLE
feat: added gptme-wut

### DIFF
--- a/gptme/wut.py
+++ b/gptme/wut.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+gptme-wut - Start a gptme session with the current tmux pane content
+
+This script captures the content of the current tmux pane and starts a gptme session
+with that content as input, making it easy to get AI assistance with terminal output.
+"""
+
+import argparse
+import subprocess
+import sys
+
+
+def get_tmux_content(lines: int | None = None):
+    """Get content from current tmux pane
+
+    Args:
+        lines: Number of lines to capture from the end. If None, captures all lines.
+    """
+    try:
+        # Check if we're in tmux
+        subprocess.run(
+            ["tmux", "display-message"],
+            capture_output=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print("Error: Not in a tmux session or tmux not installed", file=sys.stderr)
+        sys.exit(1)
+
+    # Capture pane content
+    cmd = ["tmux", "capture-pane", "-p"]
+    if lines:
+        cmd.extend(["-S", f"-{lines}"])
+
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, text=True, check=True)
+    return result.stdout
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-l", "--lines", type=int, help="Number of lines to capture from the end"
+    )
+    parser.add_argument(
+        "gptme_args", nargs="*", help="Additional arguments to pass to gptme"
+    )
+    args = parser.parse_args()
+
+    content = get_tmux_content(args.lines)
+
+    # Start gptme with the content and any additional arguments
+    cmd = [
+        "gptme",
+        "<system>The user has some terminal output they need help with and have thus run `gptme-wut` to start this session (ignore it in the output)</system>",
+    ] + args.gptme_args
+    subprocess.run(cmd, input=content, text=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/gptme/wut.py
+++ b/gptme/wut.py
@@ -7,6 +7,7 @@ with that content as input, making it easy to get AI assistance with terminal ou
 """
 
 import argparse
+import os
 import subprocess
 import sys
 
@@ -17,15 +18,9 @@ def get_tmux_content(lines: int | None = None):
     Args:
         lines: Number of lines to capture from the end. If None, captures all lines.
     """
-    try:
-        # Check if we're in tmux
-        subprocess.run(
-            ["tmux", "display-message"],
-            capture_output=True,
-            check=True,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        print("Error: Not in a tmux session or tmux not installed", file=sys.stderr)
+    # Check if we're in tmux by checking environment variables
+    if not os.environ.get("TMUX") or not os.environ.get("TMUX_PANE"):
+        print("Error: Not in a tmux session", file=sys.stderr)
         sys.exit(1)
 
     # Capture pane content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ gptme-server = "gptme.server.cli:main"
 gptme-eval = "gptme.eval.main:main"
 gptme-util = "gptme.util.cli:main"
 gptme-nc = "gptme.ncurses:main"
+gptme-wut = "gptme.wut:main"
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
Fixes https://github.com/ErikBjare/gptme/issues/386

It's not ideal how it will try to include any paths present in the pane content. Will have to think about better ways to deal with it.

Should also add `screen` support.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `gptme-wut` script to capture tmux pane content and start a gptme session, with configuration in `pyproject.toml`.
> 
>   - **Feature**:
>     - Add `gptme-wut` script in `gptme/wut.py` to capture tmux pane content and start a gptme session.
>     - Supports capturing a specified number of lines or all lines from the tmux pane.
>     - Checks for tmux environment variables to ensure execution within a tmux session.
>   - **Configuration**:
>     - Add `gptme-wut` entry to `[project.scripts]` in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 7dec3c0c455454ba6ce47ecd277766a9e60df183. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->