### PR TITLE
feat: added attempt_complete tool, giving agent ability to signal completion

### DIFF
--- a/gptme/tools/attempt_complete.py
+++ b/gptme/tools/attempt_complete.py
@@ -1,0 +1,36 @@
+from .base import ToolSpec
+
+
+class Completed:
+    """Signal that the task has been completed."""
+
+    def __init__(self, message: str, value: str | None) -> None:
+        self.message = message
+        self.value = value
+
+
+def attempt_complete(value: str | None) -> Completed | None:
+    """Attempt to complete the current task given by user."""
+    print("Attempting to complete the current task.")
+    if not check_completion():
+        print("Task not completed.")
+    # TODO: ask assistant "are you sure you want to complete the task?" to give it a chance to think some more
+    # TODO: ask assistant "was the task completed successfully?" to get feedback
+
+    # raise Completed to signal task finished, will gracefully exit
+    return Completed("Task completed successfully", value)
+
+
+def check_completion() -> bool:
+    """Check if the current task has been completed."""
+    # TODO: run actual completion checks, like pre-commit hooks, tests, etc.
+    return True
+
+
+tool = ToolSpec(
+    "attempt_complete",
+    desc="Completes the request. Used as part of autonomous operation to let the assistant signal that the request has completed.",
+    instructions="Call this to attempt to complete the current task, after running final checks. Must ALWAYS be called to signal completion when done with all tasks.",
+    functions=[attempt_complete],
+    disabled_by_default=True,
+)

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -15,9 +15,10 @@ from contextlib import contextmanager
 from logging import getLogger
 from typing import TYPE_CHECKING, TypeVar
 
-from . import get_tools
 from ..message import Message
 from ..util.ask_execute import print_preview
+from . import get_tools
+from .attempt_complete import Completed
 from .base import (
     ConfirmFunc,
     Parameter,
@@ -138,6 +139,10 @@ def execute_python(
     if isinstance(result.result, Message):
         yield result.result
         return
+    if isinstance(result.result, Completed):
+        # when we get a completion error, we exit early
+        print("Completed signal received, exiting.")
+        sys.exit(0)
 
     if result.result is not None:
         output += f"Result:\n```\n{result.result}\n```\n\n"


### PR DESCRIPTION
Played with this a couple of days ago, idea was to mimic a similar tool I saw in one of the SWE-Bench submissions.

Could be a more reliable stopping-condition (and a good place to run appropriate checks) than waiting for a non-tooluse message.

Not sure if this should be merged here or in gptme-contrib, but since it required some changes to the Python tool it'll go here for now.