### PR TITLE
fix: broken mixed tool formats execution while using  `tool` format

### DIFF
--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -246,19 +246,24 @@ def _handle_tools(message_dicts: Iterable[dict]) -> Generator[dict, None, None]:
                     # them so we can't have more.
                     assert len(tooluses) == 1
                     tooluse = tooluses[0]
-                    before_tool = text[: tooluse.start]
+                    # We only want to add a tool call if we have a call_id which
+                    # means it is a tool response
+                    if tooluse.call_id:
+                        before_tool = text[: tooluse.start]
 
-                    if before_tool:
-                        content.append({"type": "text", "text": before_tool})
+                        if before_tool:
+                            content.append({"type": "text", "text": before_tool})
 
-                    content.append(
-                        {
-                            "type": "tool_use",
-                            "id": tooluse.call_id or "",
-                            "name": tooluse.tool,
-                            "input": tooluse.kwargs or {},
-                        }
-                    )
+                        content.append(
+                            {
+                                "type": "tool_use",
+                                "id": tooluse.call_id or "",
+                                "name": tooluse.tool,
+                                "input": tooluse.kwargs or {},
+                            }
+                        )
+                    else:
+                        content.append({"type": "text", "text": text})
                     # The text is emptied to start over with the next lines if any.
                     text = ""
 

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -252,21 +252,27 @@ def _handle_tools(message_dicts: Iterable[dict]) -> Generator[dict, None, None]:
                     # them so we can't have more.
                     assert len(tooluses) == 1
                     tooluse = tooluses[0]
-                    before_tool = text[: tooluse.start]
 
-                    if before_tool.replace("\n", ""):
-                        content.append({"type": "text", "text": before_tool})
+                    # We only want to add a tool call if we have a call_id which
+                    # means it is a tool response
+                    if tooluse.call_id:
+                        before_tool = text[: tooluse.start]
 
-                    tool_calls.append(
-                        {
-                            "id": tooluse.call_id or "",
-                            "type": "function",
-                            "function": {
-                                "name": tooluse.tool,
-                                "arguments": json.dumps(tooluse.kwargs or {}),
-                            },
-                        }
-                    )
+                        if before_tool.replace("\n", ""):
+                            content.append({"type": "text", "text": before_tool})
+
+                        tool_calls.append(
+                            {
+                                "id": tooluse.call_id or "",
+                                "type": "function",
+                                "function": {
+                                    "name": tooluse.tool,
+                                    "arguments": json.dumps(tooluse.kwargs or {}),
+                                },
+                            }
+                        )
+                    else:
+                        content.append({"type": "text", "text": text})
                     # The text is emptied to start over with the next lines if any.
                     text = ""
 

--- a/tests/test_llm_anthropic.py
+++ b/tests/test_llm_anthropic.py
@@ -165,3 +165,86 @@ def test_message_conversion_with_tools():
             ],
         },
     ]
+
+
+def test_message_conversion_with_tool_and_non_tool():
+    init_tools(allowlist=frozenset(["save", "shell"]))
+
+    messages = [
+        Message(role="system", content="Initial Message", pinned=True, hide=True),
+        Message(role="system", content="Project prompt", hide=True),
+        Message(
+            role="assistant",
+            content='\n@save(tool_call_id): {"path": "path.txt", "content": "file_content"}',
+        ),
+        Message(role="system", content="Saved to toto.txt", call_id="tool_call_id"),
+        Message(
+            role="assistant",
+            content=(
+                "The script `hello.py` has been created. "
+                "Run it using the command:\n\n```shell\npython hello.py\n```\n"
+            ),
+        ),
+        Message(
+            role="system",
+            content="Ran command: `python hello.py`\n\n `Hello, world!`\n\n",
+        ),
+    ]
+
+    tool_save = get_tool("save")
+    tool_shell = get_tool("shell")
+
+    assert tool_save and tool_shell
+
+    messages_dicts, _, _ = _prepare_messages_for_api(messages, [tool_save, tool_shell])
+
+    print(messages_dicts)
+
+    assert messages_dicts == [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "<system>Project prompt</system>"}],
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "\n"},
+                {
+                    "type": "tool_use",
+                    "id": "tool_call_id",
+                    "name": "save",
+                    "input": {"path": "path.txt", "content": "file_content"},
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "content": [{"type": "text", "text": "Saved to toto.txt"}],
+                    "tool_use_id": "tool_call_id",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "The script `hello.py` has been created. Run it using the command:\n\n```shell\npython hello.py\n```\n",
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "<system>Ran command: `python hello.py`\n\n `Hello, world!`\n\n</system>",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+    ]

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -100,7 +100,6 @@ def test_message_conversion_without_tools():
 
 
 def test_message_conversion_with_tools():
-    # clear_tools()
     init_tools(allowlist=frozenset(["save"]))
 
     messages = [
@@ -199,5 +198,78 @@ def test_message_conversion_with_tools():
                 {"type": "text", "text": "(Modified by user)"},
             ],
             "tool_call_id": "tool_call_id",
+        },
+    ]
+
+
+def test_message_conversion_with_tool_and_non_tool():
+    init_tools(allowlist=frozenset(["save", "shell"]))
+
+    messages = [
+        Message(role="user", content="First user prompt"),
+        Message(
+            role="assistant",
+            content='\n@save(tool_call_id): {"path": "path.txt", "content": "file_content"}',
+        ),
+        Message(role="system", content="Saved to toto.txt", call_id="tool_call_id"),
+        Message(
+            role="assistant",
+            content=(
+                "The script `hello.py` has been created. "
+                "Run it using the command:\n\n```shell\npython hello.py\n```\n"
+            ),
+        ),
+        Message(
+            role="system",
+            content="Ran command: `python hello.py`\n\n `Hello, world!`\n\n",
+        ),
+    ]
+
+    set_default_model("openai/gpt-4o")
+
+    tool_save = get_tool("save")
+    tool_shell = get_tool("shell")
+
+    assert tool_save and tool_shell
+
+    messages_dicts, _ = _prepare_messages_for_api(messages, [tool_save, tool_shell])
+
+    assert messages_dicts == [
+        {"role": "user", "content": [{"type": "text", "text": "First user prompt"}]},
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "tool_call_id",
+                    "type": "function",
+                    "function": {
+                        "name": "save",
+                        "arguments": '{"path": "path.txt", "content": "file_content"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "content": [{"type": "text", "text": "Saved to toto.txt"}],
+            "tool_call_id": "tool_call_id",
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "The script `hello.py` has been created. Run it using the command:\n\n```shell\npython hello.py\n```\n",
+                }
+            ],
+        },
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Ran command: `python hello.py`\n\n `Hello, world!`\n\n",
+                }
+            ],
         },
     ]


### PR DESCRIPTION
Fix #381 

This MR helps to make sure that if a tool use wasn't an API tool call we don't respond with a tool result.