### PR TITLE
feat: added /model command to list/switch models, support mixing providers

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -244,7 +244,7 @@ def step(
             tools = [t for t in get_tools() if t.is_runnable()]
 
         # generate response
-        msg_response = reply(msgs, get_model().model, stream, tools)
+        msg_response = reply(msgs, get_model().full, stream, tools)
         if os.environ.get("GPTME_COSTS") in ["1", "true"]:
             log_costs(msgs + [msg_response])
 

--- a/gptme/commands.py
+++ b/gptme/commands.py
@@ -51,7 +51,7 @@ action_descriptions: dict[Actions, str] = {
     "undo": "Undo the last action",
     "log": "Show the conversation log",
     "tools": "Show available tools",
-    "model": "Set model",
+    "model": "List or switch models",
     "edit": "Edit the conversation in your editor",
     "rename": "Rename the conversation",
     "fork": "Copy the conversation using a new name",
@@ -160,11 +160,25 @@ def handle_cmd(
                 set_default_model(args[0])
                 print(f"Set model to {args[0]}")
             else:
-                print(f"Current model: {get_default_model()}")
+                model = get_default_model()
+                assert model
+                print(f"Current model: {model.full}")
+                print(
+                    f"  price: input ${model.price_input}/Mtok, output ${model.price_output}/Mtok"
+                )
+                print(f"  context: {model.context}, max output: {model.max_output}")
+                print(
+                    f"  (streaming: {model.supports_streaming}, vision: {model.supports_vision})"
+                )
                 # TODO: list known models
                 for provider in MODELS:
-                    for model in MODELS[provider]:
-                        print(f"  {provider}/{model}")
+                    if not MODELS[provider]:
+                        continue
+                    print(f"{provider}/")
+                    for model_name in list(MODELS[provider].keys())[:10]:
+                        print(f"  {model_name}")
+                    if len(MODELS[provider]) > 10:
+                        print(f"  ... ({len(MODELS[provider]) - 10} more)")
         case "export":
             manager.undo(1, quiet=True)
             manager.write()

--- a/gptme/commands.py
+++ b/gptme/commands.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 from . import llm
 from .constants import INTERRUPT_CONTENT
+from .llm.models import MODELS, get_default_model, set_default_model
 from .logmanager import LogManager, prepare_messages
 from .message import (
     Message,
@@ -30,15 +31,16 @@ from .util.useredit import edit_text_with_editor
 logger = logging.getLogger(__name__)
 
 Actions = Literal[
-    "undo",
     "log",
-    "tools",
+    "undo",
     "edit",
     "rename",
     "fork",
-    "summarize",
+    "tools",
+    "model",
     "replay",
     "impersonate",
+    "summarize",
     "tokens",
     "export",
     "help",
@@ -49,6 +51,7 @@ action_descriptions: dict[Actions, str] = {
     "undo": "Undo the last action",
     "log": "Show the conversation log",
     "tools": "Show available tools",
+    "model": "Set model",
     "edit": "Edit the conversation in your editor",
     "rename": "Rename the conversation",
     "fork": "Copy the conversation using a new name",
@@ -151,6 +154,17 @@ def handle_cmd(
     {tool.desc.rstrip(".")}
     tokens (example): {len_tokens(tool.get_examples(get_tool_format()), "gpt-4")}"""
                 )
+        case "model" | "models":
+            manager.undo(1, quiet=True)
+            if args:
+                set_default_model(args[0])
+                print(f"Set model to {args[0]}")
+            else:
+                print(f"Current model: {get_default_model()}")
+                # TODO: list known models
+                for provider in MODELS:
+                    for model in MODELS[provider]:
+                        print(f"  {provider}/{model}")
         case "export":
             manager.undo(1, quiet=True)
             manager.write()

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 from rich.logging import RichHandler
 
 from .config import config_path, get_config, set_config_value
-from .llm import get_model_from_api_key, guess_model_from_config, init_llm
+from .llm import get_model_from_api_key, guess_provider_from_config, init_llm
 from .llm.models import (
     PROVIDERS,
     Provider,
@@ -43,7 +43,7 @@ def init(model: str | None, interactive: bool, tool_allowlist: list[str] | None)
 
     if not model:  # pragma: no cover
         # auto-detect depending on if OPENAI_API_KEY or ANTHROPIC_API_KEY is set
-        model = guess_model_from_config()
+        model = guess_provider_from_config()
 
     # ask user for API key
     if not model and interactive:

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -85,7 +85,7 @@ def _chat_complete(
     if provider in PROVIDERS_OPENAI:
         return chat_openai(messages, model, tools)
     elif provider == "anthropic":
-        return chat_anthropic(messages, model, tools)
+        return chat_anthropic(messages, _get_base_model(model), tools)
     else:
         raise ValueError(f"Unsupported provider: {provider}")
 
@@ -94,18 +94,10 @@ def _stream(
     messages: list[Message], model: str, tools: list[ToolSpec] | None
 ) -> Iterator[str]:
     provider = get_provider_from_model(model)
-    base_model = _get_base_model(model)
-
     if provider in PROVIDERS_OPENAI:
-        client = get_openai_client(provider)
-        if not client:
-            init_openai(provider, get_config())
         return stream_openai(messages, model, tools)
     elif provider == "anthropic":
-        client = get_anthropic_client()
-        if not client:
-            init_anthropic(get_config())
-        return stream_anthropic(messages, base_model, tools)
+        return stream_anthropic(messages, _get_base_model(model), tools)
     else:
         raise ValueError(f"Unsupported provider: {provider}")
 

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -31,20 +31,16 @@ from .models import (
 logger = logging.getLogger(__name__)
 
 
-def init_llm(llm: str):
-    # set up API_KEY (if openai) and API_BASE (if local)
+def init_llm(provider: Provider):
+    """Initialize LLM client for a given provider if not already initialized."""
     config = get_config()
 
-    llm = cast(Provider, llm)
-    if llm in PROVIDERS_OPENAI:
-        init_openai(llm, config)
-        assert get_openai_client()
-    elif llm == "anthropic":
+    if provider in PROVIDERS_OPENAI and not get_openai_client():
+        init_openai(provider, config)
+    elif provider == "anthropic" and not get_anthropic_client():
         init_anthropic(config)
-        assert get_anthropic_client()
     else:
-        console.log(f"Error: Unknown LLM: {llm}")
-        sys.exit(1)
+        logger.debug(f"Provider {provider} already initialized or unknown")
 
 
 def reply(
@@ -63,28 +59,61 @@ def reply(
         return Message("assistant", response)
 
 
+def get_provider_from_model(model: str) -> Provider:
+    """Extract provider from fully qualified model name."""
+    if "/" not in model:
+        raise ValueError(
+            f"Model name must be fully qualified with provider prefix: {model}"
+        )
+    provider = model.split("/")[0]
+    if provider not in MODELS:
+        raise ValueError(f"Unknown provider: {provider}")
+    return cast(Provider, provider)
+
+
+def _get_base_model(model: str) -> str:
+    """Get base model name without provider prefix."""
+    return model.split("/", 1)[1]
+
+
 def _chat_complete(
     messages: list[Message], model: str, tools: list[ToolSpec] | None
 ) -> str:
-    provider = _client_to_provider()
+    provider = get_provider_from_model(model)
+    base_model = _get_base_model(model)
+
     if provider in PROVIDERS_OPENAI:
-        return chat_openai(messages, model, tools)
+        client = get_openai_client()
+        if not client:
+            init_openai(provider, get_config())
+        return chat_openai(messages, base_model, tools)
     elif provider == "anthropic":
-        return chat_anthropic(messages, model, tools)
+        client = get_anthropic_client()
+        if not client:
+            init_anthropic(get_config())
+        return chat_anthropic(messages, base_model, tools)
     else:
-        raise ValueError("LLM not initialized")
+        raise ValueError(f"Unsupported provider: {provider}")
 
 
 def _stream(
     messages: list[Message], model: str, tools: list[ToolSpec] | None
 ) -> Iterator[str]:
-    provider = _client_to_provider()
+    provider = get_provider_from_model(model)
+    base_model = _get_base_model(model)
+
     if provider in PROVIDERS_OPENAI:
-        return stream_openai(messages, model, tools)
+        client = get_openai_client()
+        if not client:
+            init_openai(provider, get_config())
+        return stream_openai(messages, base_model, tools)
     elif provider == "anthropic":
-        return stream_anthropic(messages, model, tools)
+        client = get_anthropic_client()
+        if not client:
+            init_anthropic(get_config())
+        return stream_anthropic(messages, base_model, tools)
     else:
-        raise ValueError("LLM not initialized")
+        raise ValueError(f"Unsupported provider: {provider}")
 
 
 def _reply_stream(
@@ -142,23 +171,31 @@ def _reply_stream(
     return Message("assistant", output)
 
 
-def _client_to_provider() -> Provider:
+def get_initialized_providers() -> list[Provider]:
+    """Get list of currently initialized providers."""
+    providers: list[Provider] = []
+
     openai_client = get_openai_client()
-    anthropic_client = get_anthropic_client()
-    assert openai_client or anthropic_client, "No client initialized"
     if openai_client:
         if "openai" in openai_client.base_url.host:
-            return "openai"
+            providers.append("openai")
         elif "openrouter" in openai_client.base_url.host:
-            return "openrouter"
+            providers.append("openrouter")
         elif "gemini" in openai_client.base_url.host:
-            return "gemini"
+            providers.append("gemini")
         else:
-            return "azure"
-    elif anthropic_client:
-        return "anthropic"
-    else:
-        raise ValueError("Unknown client type")
+            providers.append("azure")
+
+    if get_anthropic_client():
+        providers.append("anthropic")
+
+    return providers
+
+
+def ensure_provider_initialized(provider: Provider) -> None:
+    """Ensure a provider is initialized, initializing it if needed."""
+    if provider not in get_initialized_providers():
+        init_llm(provider)
 
 
 def _summarize_str(content: str) -> str:
@@ -176,18 +213,24 @@ def _summarize_str(content: str) -> str:
         Message("user", content=f"Summarize this:\n{content}"),
     ]
 
-    provider = _client_to_provider()
-    model = get_summary_model(provider)
-    context_limit = MODELS[provider][model]["context"]
-    if len_tokens(messages, model) > context_limit:
+    # Try to use an already initialized provider, or initialize OpenAI as default
+    providers = get_initialized_providers()
+    provider: Provider = providers[0] if providers else "openai"
+    ensure_provider_initialized(provider)
+
+    model = f"{provider}/{get_summary_model(provider)}"
+    base_model = _get_base_model(model)
+    context_limit = MODELS[provider][base_model]["context"]
+
+    if len_tokens(messages, base_model) > context_limit:
         raise ValueError(
-            f"Cannot summarize more than {context_limit} tokens, got {len_tokens(messages, model)}"
+            f"Cannot summarize more than {context_limit} tokens, got {len_tokens(messages, base_model)}"
         )
 
     summary = _chat_complete(messages, model, None)
     assert summary
     logger.debug(
-        f"Summarized long output ({len_tokens(content, model)} -> {len_tokens(summary, model)} tokens): "
+        f"Summarized long output ({len_tokens(content, base_model)} -> {len_tokens(summary, base_model)} tokens): "
         + summary
     )
     return summary
@@ -230,7 +273,13 @@ IMPORTANT: output only the name, no preamble or postamble.
             )
         ]
     )
-    model = get_summary_model(_client_to_provider())
+
+    # Try to use an already initialized provider, or initialize OpenAI as default
+    providers = get_initialized_providers()
+    provider: Provider = providers[0] if providers else "openai"
+    ensure_provider_initialized(provider)
+
+    model = f"{provider}/{get_summary_model(provider)}"
     name = _chat_complete(msgs, model, None).strip()
     return name
 
@@ -268,11 +317,10 @@ def _summarize_helper(s: str, tok_max_start=400, tok_max_end=400) -> str:
     return summary
 
 
-def guess_model_from_config() -> Provider | None:
+def guess_provider_from_config() -> Provider | None:
     """
-    Guess the model to use from the configuration.
+    Guess the provider to use from the configuration.
     """
-
     config = get_config()
 
     if config.get_env("OPENAI_API_KEY"):

--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -53,6 +53,10 @@ class ModelMeta:
     price_input: float = 0
     price_output: float = 0
 
+    @property
+    def full(self) -> str:
+        return f"{self.provider}/{self.model}"
+
 
 class _ModelDictMeta(TypedDict):
     context: int

--- a/gptme/server/api.py
+++ b/gptme/server/api.py
@@ -102,7 +102,7 @@ def api_conversation_generate(logfile: str):
     # get model or use server default
     req_json = flask.request.json or {}
     stream = req_json.get("stream", False)  # Default to no streaming (backward compat)
-    model = req_json.get("model", get_model().model)
+    model = req_json.get("model", get_model().full)
 
     # load conversation
     manager = LogManager.load(logfile, branch=req_json.get("branch", "main"))

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -1,7 +1,7 @@
 import pytest
 from gptme.config import get_config
 from gptme.llm.llm_openai import _prepare_messages_for_api
-from gptme.llm.models import get_default_model, set_default_model
+from gptme.llm.models import get_default_model, get_model, set_default_model
 from gptme.message import Message
 from gptme.tools import get_tool, init_tools
 
@@ -21,9 +21,8 @@ def test_message_conversion():
         Message(role="user", content="First user prompt"),
     ]
 
-    set_default_model("openai/gpt-4o")
-
-    messages_dict, tools_dict = _prepare_messages_for_api(messages, None)
+    model = get_model("openai/gpt-4o")
+    messages_dict, tools_dict = _prepare_messages_for_api(messages, model.full, None)
 
     assert tools_dict is None
     assert messages_dict == [
@@ -40,9 +39,8 @@ def test_message_conversion_o1():
         Message(role="user", content="First user prompt"),
     ]
 
-    set_default_model("openai/o1-mini")
-
-    messages_dict, _ = _prepare_messages_for_api(messages, None)
+    model = get_model("openai/o1-mini")
+    messages_dict, _ = _prepare_messages_for_api(messages, model.full, None)
 
     assert messages_dict == [
         {
@@ -75,9 +73,8 @@ def test_message_conversion_without_tools():
         Message(role="system", content="Saved to toto.txt"),
     ]
 
-    set_default_model("openai/gpt-4o")
-
-    messages_dicts, _ = _prepare_messages_for_api(messages, None)
+    model = get_model("openai/gpt-4o")
+    messages_dicts, _ = _prepare_messages_for_api(messages, model.full, None)
 
     assert messages_dicts == [
         {"role": "system", "content": [{"type": "text", "text": "Initial Message"}]},
@@ -119,13 +116,13 @@ def test_message_conversion_with_tools():
         Message(role="system", content="(Modified by user)", call_id="tool_call_id"),
     ]
 
-    set_default_model("openai/gpt-4o")
-
     tool_save = get_tool("save")
-
     assert tool_save
 
-    messages_dicts, tools_dict = _prepare_messages_for_api(messages, [tool_save])
+    model = get_model("openai/gpt-4o")
+    messages_dicts, tools_dict = _prepare_messages_for_api(
+        messages, model.full, [tool_save]
+    )
 
     assert tools_dict == [
         {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -74,7 +74,7 @@ def test_api_conversation_generate(conv: str, client: FlaskClient):
     # Test regular (non-streaming) response
     response = client.post(
         f"/api/conversations/{conv}/generate",
-        json={"model": get_model().model, "stream": False},
+        json={"model": get_model().full, "stream": False},
     )
     assert response.status_code == 200
     data = response.get_data(as_text=True)


### PR DESCRIPTION
I wanted to try something similar to aider's architecture mode where one model is used for reasoning/planning and one for writing the patches/coding.

I realized it would be easy to accomplish by simply adding a `/model` command and adding it to a chained prompt. Needed some refactoring of the LLM to get rid of some globals.

## TODO

- [x] Test switching from sonnet to o1-mini (different providers)
- [x] Test switching from o1-mini to deekseek-v3 (both openai providers)
- [x] `gptme -m openai/gpt-4o 'hello, just testing switching providers, dont run tools' - '/model deepseek/deepseek-chat' - 'ive now switched to deepseek' - '/model anthropic' - 'and now finally anthropic'`
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces `/model` command to switch models across providers, refactoring model handling and command execution.
> 
>   - **Behavior**:
>     - Added `/model` command in `commands.py` to list or switch models, supporting different providers.
>     - Updated `chat.py` and `api.py` to use `get_model().full` for model identification.
>   - **Model Management**:
>     - Refactored `init_llm()` in `llm/__init__.py` to initialize models based on provider.
>     - Modified `get_model()` and `set_default_model()` in `models.py` to handle fully qualified model names.
>   - **Command Handling**:
>     - Updated `handle_cmd()` in `commands.py` to support `/model` command.
>     - Adjusted `execute_cmd()` to process new command structure.
>   - **Testing**:
>     - Added tests in `test_llm_openai.py` and `test_server.py` to verify model switching and API responses.
>   - **Misc**:
>     - Renamed `guess_model_from_config()` to `guess_provider_from_config()` in `init.py` and `llm/__init__.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 7466181295bd37e4857d5d9fdf09aa3c305bcedf. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->