### PR TITLE
fix: detect tooluses with common path characters when cleaning for speech

### DIFF
--- a/gptme/tools/tts.py
+++ b/gptme/tools/tts.py
@@ -43,7 +43,7 @@ current_speed = 1.3
 
 
 re_thinking = re.compile(r"<thinking>.*?(\n</thinking>|$)", flags=re.DOTALL)
-re_tool_use = re.compile(r"```[\w\. ~/\-]+\n[^`]*(\n```|$)", flags=re.DOTALL)
+re_tool_use = re.compile(r"```[\w\. ~/\-]+\n(.*?)(\n```|$)", flags=re.DOTALL)
 
 
 def set_speed(speed):

--- a/gptme/tools/tts.py
+++ b/gptme/tools/tts.py
@@ -43,7 +43,7 @@ current_speed = 1.3
 
 
 re_thinking = re.compile(r"<thinking>.*?(\n</thinking>|$)", flags=re.DOTALL)
-re_tool_use = re.compile(r"```[\w\. ]+\n[^`]*(\n```|$)", flags=re.DOTALL)
+re_tool_use = re.compile(r"```[\w\. ~/\-]+\n[^`]*(\n```|$)", flags=re.DOTALL)
 
 
 def set_speed(speed):

--- a/tests/test_tools_tts.py
+++ b/tests/test_tools_tts.py
@@ -78,7 +78,7 @@ def test_clean_for_speech():
     assert re_tool_use.search("```tool\ncontents\n```")
 
     # with arg
-    assert re_tool_use.search("```save test.txt\ncontents\n```")
+    assert re_tool_use.search("```save ~/path_to/test-file1.txt\ncontents\n```")
 
     # incomplete
     assert re_thinking.search("\n<thinking>thinking")

--- a/tests/test_tools_tts.py
+++ b/tests/test_tools_tts.py
@@ -80,6 +80,16 @@ def test_clean_for_speech():
     # with arg
     assert re_tool_use.search("```save ~/path_to/test-file1.txt\ncontents\n```")
 
+    # with `text` contents
+    assert re_tool_use.search("```file.md\ncontents with `code` string\n```")
+
     # incomplete
     assert re_thinking.search("\n<thinking>thinking")
     assert re_tool_use.search("```savefile.txt\ncontents")
+
+    # make sure spoken content is correct
+    assert (
+        re_tool_use.sub("", "Using tool\n```tool\ncontents\n```").strip()
+        == "Using tool"
+    )
+    assert re_tool_use.sub("", "```tool\ncontents\n```\nRan tool").strip() == "Ran tool"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update regex in `gptme/tools/tts.py` to detect tool use blocks with path characters and add tests in `tests/test_tools_tts.py`.
> 
>   - **Behavior**:
>     - Update `re_tool_use` regex in `gptme/tools/tts.py` to detect tool use blocks with common path characters like `~`, `/`, and `-`.
>     - Ensure `clean_for_speech()` correctly removes tool use blocks with these characters.
>   - **Tests**:
>     - Add test cases in `tests/test_tools_tts.py` to verify `re_tool_use` handles paths with `~`, `/`, and `-`.
>     - Validate that `clean_for_speech()` removes tool use blocks and retains surrounding text correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 89486b3e618967d7d56a6a2ce3cfae815396bbe7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->