### PR TITLE
fix: remove exclusive mode

### DIFF
--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -251,7 +251,7 @@ def _handle_tools(message_dicts: Iterable[dict]) -> Generator[dict, None, None]:
                     if tooluse.call_id:
                         before_tool = text[: tooluse.start]
 
-                        if before_tool:
+                        if before_tool.strip():
                             content.append({"type": "text", "text": before_tool})
 
                         content.append(

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -302,7 +302,7 @@ def _handle_tools(message_dicts: Iterable[dict]) -> Generator[dict, None, None]:
                     if tooluse.call_id:
                         before_tool = text[: tooluse.start]
 
-                        if before_tool.replace("\n", ""):
+                        if before_tool.strip():
                             content.append({"type": "text", "text": before_tool})
 
                         tool_calls.append(

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -32,7 +32,6 @@ ToolFormat: TypeAlias = Literal["markdown", "xml", "tool"]
 
 # tooluse format
 tool_format: ToolFormat = "markdown"
-exclusive_mode = False
 
 # Match tool name and start of JSON
 toolcall_re = re.compile(r"^@(\w+)\(([\w_\-]+)\):\s*({.*)", re.M | re.S)
@@ -339,10 +338,10 @@ class ToolUse:
         """Returns all ToolUse in a message, markdown or XML, in order."""
         # collect all tool uses
         tool_uses = []
-        if tool_format == "xml" or not exclusive_mode:
+        if tool_format == "xml":
             for tool_use in cls._iter_from_xml(content):
                 tool_uses.append(tool_use)
-        if tool_format == "markdown" or not exclusive_mode:
+        if tool_format == "markdown":
             for tool_use in cls._iter_from_markdown(content):
                 tool_uses.append(tool_use)
 

--- a/tests/test_llm_anthropic.py
+++ b/tests/test_llm_anthropic.py
@@ -198,8 +198,6 @@ def test_message_conversion_with_tool_and_non_tool():
 
     messages_dicts, _, _ = _prepare_messages_for_api(messages, [tool_save, tool_shell])
 
-    print(messages_dicts)
-
     assert messages_dicts == [
         {
             "role": "user",
@@ -208,13 +206,12 @@ def test_message_conversion_with_tool_and_non_tool():
         {
             "role": "assistant",
             "content": [
-                {"type": "text", "text": "\n"},
                 {
                     "type": "tool_use",
                     "id": "tool_call_id",
                     "name": "save",
                     "input": {"path": "path.txt", "content": "file_content"},
-                },
+                }
             ],
         },
         {


### PR DESCRIPTION
This MR fixes two minor comments from previous MRs:
- https://github.com/ErikBjare/gptme/pull/407#discussion_r1922407709
- https://github.com/ErikBjare/gptme/issues/381#issuecomment-2602454431
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `exclusive_mode` and simplify tool format handling in `gptme/tools/base.py`, updating related logic in `llm_anthropic.py` and `llm_openai.py`.
> 
>   - **Behavior**:
>     - Remove `exclusive_mode` variable and related logic in `gptme/tools/base.py`.
>     - Simplify tool format handling by removing `exclusive_mode` checks in `ToolUse.iter_from_content()`.
>   - **Functions**:
>     - Update `_handle_tools()` in `llm_anthropic.py` and `llm_openai.py` to use `before_tool.strip()` instead of `before_tool.replace("\n", "")`.
>   - **Tests**:
>     - Remove `print()` statement from `test_message_conversion_with_tool_and_non_tool()` in `tests/test_llm_anthropic.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for f725110a6bae437cb68c4876c037a8b539d987e0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->