### PR TITLE
feat: add option to override base prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ __pycache__
 *.png
 .aider*
 .env
+
+# MacOS
+.DS_Store
+
+# VSCode
+.vscode

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -63,8 +63,24 @@ The project configuration file is intended to let the user configure how gptme w
 
 gptme will look for a ``gptme.toml`` file in the workspace root (this is the working directory if not overridden by the ``--workspace`` option). This file contains project-specific configuration options.
 
-This file currently supports a single option, ``files``, which is a list of paths that gptme will always include in the context:
+This file currently supports a few options:
+
+- ``files``, which is a list of paths that gptme will always include in the context:
 
 .. code-block:: toml
 
     files = ["README.md", "Makefile"]
+
+- ``base_prompt``, which is a string that will be used as the base prompt for the project. This will override the global base prompt ("You are gptme v{__version__}, a general-purpose AI assistant powered by LLMs. [...]"):
+
+.. code-block:: toml
+
+    base_prompt = "You are an AI agent that can help me with my programming tasks."
+
+- ``prompt``, which is a string that will be used as the prompt for the project. This will be added to the system prompt with a ``# Current Project`` header:
+
+.. code-block:: toml
+
+    prompt = "This is gptme."
+
+- ``rag``, which is a dictionary to configure the RAG tool. See :ref:`RAG Tool <rag-tool>` for more information.

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -122,6 +122,8 @@ Computer
     :members:
     :noindex:
 
+.. _rag-tool:
+
 RAG
 ---
 

--- a/gptme/config.py
+++ b/gptme/config.py
@@ -41,6 +41,7 @@ class Config:
 class ProjectConfig:
     """Project-level configuration, such as which files to include in the context by default."""
 
+    base_prompt: str | None = None
     prompt: str | None = None
     files: list[str] = field(default_factory=list)
     rag: dict = field(default_factory=dict)

--- a/gptme/prompts.py
+++ b/gptme/prompts.py
@@ -90,7 +90,7 @@ def prompt_gptme(interactive: bool) -> Generator[Message, None, None]:
      - Mention the ability to self-correct and ask clarifying questions
     """
 
-    base_prompt = f"""
+    default_base_prompt = f"""
 You are gptme v{__version__}, a general-purpose AI assistant powered by LLMs.
 You are designed to help users with programming tasks, such as writing code, debugging, and learning new concepts.
 You can run code, execute terminal commands, and access the filesystem on the local machine.
@@ -138,6 +138,10 @@ All code blocks you suggest will be automatically executed.
 Do not provide examples or ask for permission before running commands.
 Proceed directly with the most appropriate actions to complete the task.
 """.strip()
+
+    projectdir = get_project_dir()
+    project_config = get_project_config(projectdir)
+    base_prompt = project_config.base_prompt if project_config and project_config.base_prompt else default_base_prompt
 
     full_prompt = (
         base_prompt


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `base_prompt` option to project configuration, allowing override of default base prompt in `prompt_gptme()`.
> 
>   - **Behavior**:
>     - Adds `base_prompt` option in `gptme.toml` to override the default base prompt in `prompt_gptme()` in `prompts.py`.
>     - Updates `prompt_gptme()` to use `base_prompt` from `ProjectConfig` if available, otherwise defaults to `default_base_prompt`.
>   - **Configuration**:
>     - Adds `base_prompt` attribute to `ProjectConfig` in `config.py`.
>   - **Documentation**:
>     - Updates `docs/config.rst` to include `base_prompt` option in project configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for eca5a67aaaece356ad86d1247e5d117a97ad7bcc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->