### PR TITLE
docs: added complexity metrics with radon to arewetiny docs, as makefile target

### DIFF
--- a/docs/arewetiny.rst
+++ b/docs/arewetiny.rst
@@ -77,3 +77,22 @@ LoC Total
 
 .. command-output:: make cloc-total
    :cwd: ..
+
+Code Metrics
+------------
+
+.. command-output:: make metrics
+   :cwd: ..
+
+The metrics above show:
+
+- **Project Overview**: Basic stats about the codebase size and complexity
+- **Complex Functions**: Functions rated D+ (high complexity, should be refactored)
+- **Large Files**: Files over 300 SLOC (should be split into smaller modules)
+
+We should aim to:
+
+- Keep average complexity below 4.0
+- Have no E-rated functions (extremely complex)
+- Have few D-rated functions (very complex)
+- Keep files under 300 SLOC where possible

--- a/poetry.lock
+++ b/poetry.lock
@@ -440,11 +440,11 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["main", "dev"]
-markers = "(platform_system == \"Windows\" or sys_platform == \"win32\") and (python_version <= \"3.11\" or python_version >= \"3.12\")"
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {main = "(platform_system == \"Windows\" or sys_platform == \"win32\") and (python_version <= \"3.11\" or python_version >= \"3.12\")", dev = "python_version <= \"3.11\" or python_version >= \"3.12\""}
 
 [[package]]
 name = "contourpy"
@@ -1590,6 +1590,25 @@ html-clean = ["lxml-html-clean"]
 html5 = ["html5lib"]
 htmlsoup = ["BeautifulSoup4"]
 source = ["Cython (>=3.0.11)"]
+
+[[package]]
+name = "mando"
+version = "0.7.1"
+description = "Create Python CLI apps with little to no effort at all!"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "mando-0.7.1-py2.py3-none-any.whl", hash = "sha256:26ef1d70928b6057ee3ca12583d73c63e05c49de8972d620c278a7b206581a8a"},
+    {file = "mando-0.7.1.tar.gz", hash = "sha256:18baa999b4b613faefb00eac4efadcf14f510b59b924b66e08289aa1de8c3500"},
+]
+
+[package.dependencies]
+six = "*"
+
+[package.extras]
+restructuredtext = ["rst2ansi"]
 
 [[package]]
 name = "markdown-it-py"
@@ -2932,6 +2951,26 @@ files = [
 ]
 
 [[package]]
+name = "radon"
+version = "6.0.1"
+description = "Code Metrics in Python"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
+files = [
+    {file = "radon-6.0.1-py2.py3-none-any.whl", hash = "sha256:632cc032364a6f8bb1010a2f6a12d0f14bc7e5ede76585ef29dc0cecf4cd8859"},
+    {file = "radon-6.0.1.tar.gz", hash = "sha256:d1ac0053943a893878940fedc8b19ace70386fc9c9bf0a09229a44125ebf45b5"},
+]
+
+[package.dependencies]
+colorama = {version = ">=0.4.1", markers = "python_version > \"3.4\""}
+mando = ">=0.6,<0.8"
+
+[package.extras]
+toml = ["tomli (>=2.0.1)"]
+
+[[package]]
 name = "regex"
 version = "2024.11.6"
 description = "Alternative regular expression module, to replace re."
@@ -3857,4 +3896,4 @@ youtube = ["youtube_transcript_api"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "ffb59ceb6f81f102b84e484088d9b2078ed53286477d1057479b7f90055b521d"
+content-hash = "2d89bc793c2d67e9169362080a8fda03f1ab67003b3afc0c7553608bc7716f62"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3896,4 +3896,4 @@ youtube = ["youtube_transcript_api"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "2d89bc793c2d67e9169362080a8fda03f1ab67003b3afc0c7553608bc7716f62"
+content-hash = "a4ba8081b217b149d560b6a2a49338a8bc148c4c16d69fd134d21e052a232992"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ mypy = "*"
 ruff = "*"
 pylint = "*"
 pre-commit = "*"
+radon = "*"
 
 # test
 pytest = "^8.0"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds Radon-based code complexity metrics to documentation and Makefile, updating pyproject.toml to include Radon.
> 
>   - **Makefile**:
>     - Adds `metrics` target to generate code complexity metrics using Radon.
>     - Excludes specific paths in `SRCFILES_RAW` and `RADON_ARGS`.
>   - **Documentation**:
>     - Updates `arewetiny.rst` to include code metrics section with Radon output.
>   - **Dependencies**:
>     - Adds `radon` to `pyproject.toml` under development dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 6b5fc896c5a3a6a061cd50a98b10adbf4e726262. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->