### PR TITLE
feat: use gnome-screenshot in wayland

### DIFF
--- a/gptme/tools/screenshot.py
+++ b/gptme/tools/screenshot.py
@@ -1,5 +1,5 @@
 """
-A simple screenshot tool, using `screencapture` on macOS and `scrot` on Linux.
+A simple screenshot tool, using `screencapture` on macOS and `scrot` or `gnome-screenshot` on Linux.
 """
 
 import os
@@ -19,8 +19,10 @@ def _screenshot(path: Path) -> Path:
             subprocess.run(["screencapture", str(path)], check=True)
         else:  # Linux
             # TODO: add support for specifying window/fullscreen?
-            # TODO: support other screenshot tools
-            subprocess.run(["scrot", "--overwrite", str(path)], check=True)  # --focused
+            if os.environ.get("XDG_SESSION_TYPE") == 'wayland':
+                subprocess.run(["gnome-screenshot", "-f", str(path)], check=True)
+            else:
+                subprocess.run(["scrot", "--overwrite", str(path)], check=True)  # --focused
     else:
         raise NotImplementedError(
             "Screenshot functionality is only available on macOS and Linux."


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `screenshot.py` to use `gnome-screenshot` for Wayland sessions on Linux, while retaining `scrot` for other sessions.
> 
>   - **Behavior**:
>     - In `screenshot.py`, `_screenshot()` now uses `gnome-screenshot` for Wayland sessions on Linux, determined by `XDG_SESSION_TYPE` environment variable.
>     - Retains `scrot` for non-Wayland Linux sessions.
>   - **Documentation**:
>     - Updates docstring in `screenshot.py` to reflect the use of `gnome-screenshot` on Linux.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 5b2c222db175b3c09c6d66d26640dbc73025ec05. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->