### PR TITLE
refactor: make computer tool share logic with screenshot tool

### DIFF
--- a/gptme/tools/computer.py
+++ b/gptme/tools/computer.py
@@ -66,12 +66,11 @@ import shlex
 import shutil
 import subprocess
 from enum import Enum
-from pathlib import Path
 from typing import Literal, TypedDict
 
 from ..message import Message
 from .base import ToolSpec, ToolUse
-from .screenshot import _screenshot
+from .screenshot import screenshot
 from .vision import view_image
 
 logger = logging.getLogger(__name__)
@@ -84,7 +83,6 @@ IS_MACOS = platform.system() == "Darwin"
 # Constants from Anthropic's implementation
 TYPING_DELAY_MS = 12
 TYPING_GROUP_SIZE = 50
-OUTPUT_DIR = "/tmp/outputs"
 
 Action = Literal[
     "key",
@@ -482,18 +480,7 @@ def computer(
         print(f"Performed {action}")
         return None
     elif action == "screenshot":
-        # TODO: refactor to share logic with screenshot tool
-        output_dir = Path(OUTPUT_DIR)
-        output_dir.mkdir(parents=True, exist_ok=True)
-        path = output_dir / "screenshot.png"
-
-        if IS_MACOS:
-            # Use native macOS screencapture
-            subprocess.run(["screencapture", "-x", str(path)], check=True)
-        elif shutil.which("gnome-screenshot"):
-            subprocess.run(["gnome-screenshot", "-f", str(path)], check=True)
-        else:
-            path = _screenshot(path)  # Use existing screenshot function
+        path = screenshot()  # Use existing screenshot function
 
         # Scale if needed
         # TODO: also scale in screenshot tool for these situations

--- a/gptme/tools/screenshot.py
+++ b/gptme/tools/screenshot.py
@@ -4,51 +4,59 @@ A simple screenshot tool, using `screencapture` on macOS and `scrot` or `gnome-s
 
 import os
 import platform
+import shutil
 import subprocess
 from datetime import datetime
 from pathlib import Path
 
 from .base import ToolSpec
 
+OUTPUT_DIR = Path("/tmp/outputs")
+IS_MACOS = platform.system() == "Darwin"
+IS_WAYLAND = os.environ.get("XDG_SESSION_TYPE") == "wayland"
 
-def _screenshot(path: Path) -> Path:
-    path = Path(path).resolve()
-
-    if os.name == "posix":
-        if os.uname().sysname == "Darwin":  # macOS
-            subprocess.run(["screencapture", str(path)], check=True)
-        else:  # Linux
-            # TODO: add support for specifying window/fullscreen?
-            if os.environ.get("XDG_SESSION_TYPE") == 'wayland':
-                subprocess.run(["gnome-screenshot", "-f", str(path)], check=True)
-            else:
-                subprocess.run(["scrot", "--overwrite", str(path)], check=True)  # --focused
-    else:
-        raise NotImplementedError(
-            "Screenshot functionality is only available on macOS and Linux."
-        )
-
-    return path
+# TODO: check for this instead of prompting the llm
+INSTRUCTIONS = (
+    "If all you see is a wallpaper, the user may have to allow screen capture in `System Preferences -> Security & Privacy -> Screen Recording`."
+    if IS_MACOS
+    else ""
+)
 
 
 def screenshot(path: Path | None = None) -> Path:
     """
     Take a screenshot and save it to a file.
     """
-    if path is None:
-        # TODO: store in log folder or tmp?
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        path = Path(f"screenshot_{timestamp}.png")
 
-    return _screenshot(path)
+    if path is None:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        path = OUTPUT_DIR / f"screenshot_{timestamp}.png"
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path = path.resolve()
+
+    if IS_MACOS:
+        subprocess.run(["screencapture", str(path)], check=True)
+        return path
+    elif os.name == "posix":
+        # TODO: add support for specifying window/fullscreen?
+        if shutil.which("gnome-screenshot"):
+            subprocess.run(["gnome-screenshot", "-f", str(path)], check=True)
+            return path
+        elif not IS_WAYLAND and shutil.which("scrot"):
+            subprocess.run(["scrot", "--overwrite", str(path)], check=True)
+            return path
+        else:
+            raise NotImplementedError("No supported screenshot method available")
+    else:
+        raise NotImplementedError(
+            "Screenshot functionality is only available on macOS and Linux."
+        )
 
 
 tool = ToolSpec(
     name="screenshot",
     desc="Take a screenshot",
-    # TODO: check for this instead of prompting the llm
-    instructions="If all you see is a wallpaper, the user may have to allow screen capture in `System Preferences -> Security & Privacy -> Screen Recording`."
-    if platform.system() == "Darwin"
-    else "",
+    instructions=INSTRUCTIONS,
     functions=[screenshot],
 )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `computer.py` to use `screenshot()` from `screenshot.py`, removing redundant logic and ensuring consistent screenshot behavior.
> 
>   - **Refactoring**:
>     - In `computer.py`, replace custom screenshot logic with `screenshot()` from `screenshot.py`.
>     - Remove `_screenshot` function from `screenshot.py` and integrate its logic into `screenshot()`.
>   - **Behavior**:
>     - `computer()` in `computer.py` now uses `screenshot()` for taking screenshots, ensuring consistent behavior across tools.
>     - `screenshot()` in `screenshot.py` handles both macOS and Linux, checking for available tools (`screencapture`, `gnome-screenshot`, `scrot`).
>   - **Misc**:
>     - Remove `OUTPUT_DIR` constant from `computer.py` as it's now defined in `screenshot.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for f31c40e0dfbbc995f6fdfcc5560f1836520b219a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->