### PR TITLE
Fix /export command

### DIFF
--- a/gptme/util/export.py
+++ b/gptme/util/export.py
@@ -18,7 +18,7 @@ def export_chat_to_html(name: str, chat_data: Log, output_path: Path) -> None:
 
     # Read the template files
     current_dir = Path(__file__).parent
-    template_dir = current_dir / "server" / "static"
+    template_dir = current_dir.parent / "server" / "static"
 
     with open(template_dir / "index.html") as f:
         html_template = f.read()


### PR DESCRIPTION
Closes #459

Don't know if it is the best option. I created this PR just to clarify the issue.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes path issue in `export_chat_to_html()` in `export.py` to correct `/export` command functionality.
> 
>   - **Path Fix**:
>     - Corrects the `template_dir` path in `export_chat_to_html()` in `export.py` from `current_dir / "server" / "static"` to `current_dir.parent / "server" / "static"` to fix the `/export` command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme&utm_source=github&utm_medium=referral)<sup> for aa899fe27c661db1f59ce4e968ecfd0266ba039e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->