### PR TITLE
feat: added GPTME_CONTEXT_TREE which includes `tree --gitignore .` output in initial prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ projects
 demos
 eval[_-]results*
 
+# `tree --gitignore` wont handle the [_-] above
+eval-results*
+eval_results*
+
 # logs
 *.log
 *logs/


### PR DESCRIPTION
Been doing my prompts a lot like this recently: `gptme "/shell tree --gitignore ." - "my actual prompt"`

This lets you set a environment variable `GPTME_CONTEXT_TREE` which automatically includes this in the system prompt in new conversations.

Should maybe use `git ls-files` instead (noticed the `--gitignore` flag to `tree` is not without quirks), but this works for now and is easier to glance by humans (seems readable by LLMs).