### PR TITLE
fix: use quadruple backticks in markdown codeblocks to avoid conflicts

### DIFF
--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -93,7 +93,8 @@ def file_to_display_path(f: Path, workspace: Path | None = None) -> Path:
 
 def md_codeblock(lang: str | Path, content: str) -> str:
     """Wrap content in a markdown codeblock."""
-    return f"```{lang}\n{content}\n```"
+    # we use quadruple backticks to avoid conflicts with triple backticks in the content
+    return f"````{lang}\n{content}\n````"
 
 
 def textfile_as_codeblock(path: Path) -> str | None:


### PR DESCRIPTION
- Update md_codeblock() to use quadruple backticks instead of triple
- Refactor workspace prompt generation to use md_codeblock helper
- Fix context command execution to run in workspace directory
- Remove unnecessary tools validation in get_prompt()

Broke my tests locally
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update markdown codeblocks to use quadruple backticks and refactor workspace prompt generation in `prompts.py`.
> 
>   - **Behavior**:
>     - Update `md_codeblock()` in `context.py` to use quadruple backticks for markdown codeblocks.
>     - Refactor `get_workspace_prompt()` in `prompts.py` to use `md_codeblock()` for file content and tree output.
>     - Fix `get_project_context_cmd_output()` in `prompts.py` to execute commands in the workspace directory.
>   - **Misc**:
>     - Remove tools validation in `get_prompt()` in `prompts.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for c80560ae0456b4b2dbd07afab3b654afeb832699. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->