### PR TITLE
feat: added `gptme-util llm generate` command, rework `gptme-util context`

### DIFF
--- a/gptme/util/cli.py
+++ b/gptme/util/cli.py
@@ -195,7 +195,12 @@ def llm_generate(prompt: str | None, model: str | None, stream: bool):
 
     with redirect_stderr(stderr_capture):
         from ..init import init  # fmt: skip
-        from ..llm import _chat_complete, _stream, get_provider_from_model, init_llm  # fmt: skip
+        from ..llm import (  # fmt: skip
+            _chat_complete,
+            _stream,
+            get_provider_from_model,
+            init_llm,
+        )
         from ..llm.models import get_default_model  # fmt: skip
         from ..message import Message  # fmt: skip
         from ..util import console  # fmt: skip


### PR DESCRIPTION
Triggered by message by defcron in Discord:

> hello. was there any proper way to show only the model's response in non-interactive mode (like i mean, not showing the chat history or the user message at all and not having the Assistant: label at the front)? i didn't notice a way so i had a gpt help me make a filter script which works reasonably well to do it and preserves the real-time streaming, but its not perfect and so if there's a proper way that would be better.

I've been wanting this too, been using @simonw's `llm` but would prefer using gptme for stuff like that since its easier to set up, and I already have it configured everywhere.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `llm generate` command to `gptme/util/cli.py` for generating LLM responses without formatting, with tests in `tests/test_util_cli.py`.
> 
>   - **New Feature**:
>     - Adds `llm generate` command in `gptme/util/cli.py` to generate LLM responses without formatting.
>     - Supports specifying model with `--model` and streaming with `--stream`.
>     - Handles errors for missing prompts and unsupported models.
>   - **Tests**:
>     - Adds tests for `llm generate` in `tests/test_util_cli.py`.
>     - Tests include basic generation, model specification, and error handling.
>   - **Misc**:
>     - Renames `context_generate` to `context_index` in `gptme/util/cli.py`.
>     - Adds `context_retrieve` command for searching indexed documents.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 4347325235bf98f2f4692bd13e1792006723e1f2. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->