### PR TITLE
fix: strip thinking when checking markdown for codeblocks

### DIFF
--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -68,11 +68,16 @@ def _extract_codeblocks(markdown: str) -> Generator[Codeblock, None, None]:
 
     This handles nested cases where ``` appears inside string literals or other content.
     """
-    # remove anything before </think> if it exists
+    # dont extract codeblocks from thinking blocks
     # (since claude sometimes forgets to close codeblocks in its thinking)
     think_end = markdown.find("</think>")
     if think_end != -1:
+        # remove anything before and including </think> if it exists
         markdown = markdown[think_end + len("</think>") :]
+    else:
+        # if start <think> tag but no end, early exit
+        if "<think>" in markdown:
+            return
 
     # speed check (early exit): check if message contains a code block
     if markdown.count("```") < 2:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances `_extract_codeblocks()` in `gptme/codeblock.py` to skip `<think>` tags, preventing extraction of incomplete code blocks.
> 
>   - **Behavior**:
>     - `_extract_codeblocks()` in `gptme/codeblock.py` now skips content before `</think>` and exits early if `<think>` is unclosed.
>     - Ensures code blocks are not extracted from within `<think>` tags.
>   - **Misc**:
>     - Adjusts early exit condition to check for at least two occurrences of ``` in `gptme/codeblock.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 3455ed3272a1a41675c40c2908209f7cdb21393b. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->