### PR TITLE
feat: add user-level files support in config

### DIFF
--- a/gptme/config.py
+++ b/gptme/config.py
@@ -73,6 +73,11 @@ class UserPromptConfig:
     about_user: str | None = None
     response_preference: str | None = None
     project: dict[str, str] = field(default_factory=dict)
+    # Additional files to include in context. Supports:
+    # - Absolute paths
+    # - ~ expansion
+    # - Relative paths (resolved against the config directory, e.g. ~/.config/gptme)
+    files: list[str] = field(default_factory=list)
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Adds support for user-level files configuration in ~/.config/gptme/config.toml, allowing users to include additional context files across all their gptme conversations.

## Changes

- Added UserPromptConfig.files: New field to specify additional context files
- Path resolution support:
  - Absolute paths: used as-is
  - ~ expansion: supported (e.g., ~/README.md)
  - Relative paths: resolved relative to config directory (~/.config/gptme)
- Integration: Files are included in prompt_workspace alongside project files
- Deduplication: Prevents duplicate files when project and user configs overlap

## Configuration Format

[prompt]
about_user = "I am a curious human programmer."
response_preference = "Basic concepts don't need to be explained."
files = ["~/README.md", "/absolute/path/to/file.md"]

## Use Cases

- Include personal documentation/notes across all projects
- Add context files outside project directories
- Share common context between multiple projects
- Include VM/server documentation for agent deployments

## Testing

- All existing config tests pass (15/15)
- Maintains backward compatibility
- No breaking changes to existing functionality

Co-authored-by: Bob <bob@superuserlabs.org>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds user-level file support in `~/.config/gptme/config.toml`, integrating additional context files into the prompt workspace with path resolution and deduplication.
> 
>   - **Behavior**:
>     - Adds `files` field to `UserPromptConfig` in `gptme/config.py` for user-level context files.
>     - Supports absolute paths, `~` expansion, and relative paths (resolved against `~/.config/gptme`).
>     - Integrates user files into `prompt_workspace()` in `gptme/prompts.py`, alongside project files.
>     - Deduplicates files when user and project configs overlap.
>   - **Configuration**:
>     - Example config in `~/.config/gptme/config.toml` includes `files` field for user-level context.
>   - **Testing**:
>     - All existing config tests pass (15/15).
>     - Maintains backward compatibility with no breaking changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for d2997b96236cf3e5546dfa3b5f6ab8cae9e8af2e. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->