### PR TITLE
fix: propagate agent logdir from subprocess in DSPy evaluations

### DIFF
--- a/gptme/eval/dspy/prompt_optimizer.py
+++ b/gptme/eval/dspy/prompt_optimizer.py
@@ -28,6 +28,11 @@ from .signatures import PromptImprovementSignature
 logger = logging.getLogger(__name__)
 
 
+task_weight = 0.4
+tool_weight = 0.3
+judge_weight = 0.3
+
+
 class PromptDataset:
     """
     Dataset wrapper for gptme evaluation tasks.
@@ -358,9 +363,9 @@ class PromptOptimizer:
         )
 
         print("\n=== OVERALL SCORE BREAKDOWN ===")
-        print(f"Task Success:  {avg_task_score:.3f} (weight: 0.4)")
-        print(f"Tool Usage:    {avg_tool_score:.3f} (weight: 0.3)")
-        print(f"LLM Judge:     {avg_judge_score:.3f} (weight: 0.3)")
+        print(f"Task Success:  {avg_task_score:.3f} (weight: {task_weight})")
+        print(f"Tool Usage:    {avg_tool_score:.3f} (weight: {tool_weight})")
+        print(f"LLM Judge:     {avg_judge_score:.3f} (weight: {judge_weight})")
         print(f"Composite:     {avg_score:.3f}")
         print("================================")
 
@@ -396,7 +401,11 @@ class PromptOptimizer:
         judge_score = judge_metric(gold, pred, None)
 
         # Calculate composite with weights
-        composite_score = task_score * 0.4 + tool_score * 0.3 + judge_score * 0.3
+        composite_score = (
+            task_score * task_weight
+            + tool_score * tool_weight
+            + judge_score * judge_weight
+        )
 
         return {
             "task_score": task_score,

--- a/gptme/eval/main.py
+++ b/gptme/eval/main.py
@@ -366,6 +366,8 @@ def read_results_from_csv(filename: str) -> dict[str, list[EvalResult]]:
                 gen_stderr=read_log_file(test_dir / "gen_stderr.txt"),
                 run_stdout=read_log_file(test_dir / "run_stdout.txt"),
                 run_stderr=read_log_file(test_dir / "run_stderr.txt"),
+                log_dir=Path(row.get("Log Dir", test_dir)),
+                workspace_dir=Path(row.get("Workspace Dir", test_dir)),
             )
             model_results[model].append(result)
     return dict(model_results)
@@ -398,6 +400,8 @@ def write_results(model_results: dict[str, list[EvalResult]]):
             "Run Time",
             "Eval Time",
             "Commit Hash",
+            "Log Dir",
+            "Workspace Dir",
         ]
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames, lineterminator="\n")
 
@@ -428,6 +432,8 @@ def write_results(model_results: dict[str, list[EvalResult]]):
                     "Run Time": round(result.timings["run"], 2),
                     "Eval Time": round(result.timings["eval"], 2),
                     "Commit Hash": commit_hash,
+                    "Log Dir": str(result.log_dir),
+                    "Workspace Dir": str(result.workspace_dir),
                 }
                 writer.writerow(row)
                 _write_case_results(test_dir / "cases.csv", result.results)

--- a/gptme/eval/run.py
+++ b/gptme/eval/run.py
@@ -9,6 +9,7 @@ import time
 from collections import defaultdict
 from concurrent.futures import Future, ProcessPoolExecutor, as_completed
 from multiprocessing import Manager, Process
+from pathlib import Path
 from typing import TypedDict
 
 from tqdm import tqdm
@@ -33,8 +34,8 @@ class ProcessSuccess(TypedDict):
     stdout: str
     stderr: str
     duration: float
-    log_dir: str | None
-    workspace_dir: str | None
+    log_dir: Path
+    workspace_dir: Path
 
 
 class ProcessError(TypedDict):
@@ -89,18 +90,19 @@ def run_evals(
                 tools = test.get(
                     "tools"
                 )  # Get tools from test spec, None if not specified
+                agent = GPTMe(model=model, tool_format=tool_format, tools=tools)
                 future = executor.submit(
                     execute,
                     test,
-                    GPTMe(model=model, tool_format=tool_format, tools=tools),
+                    agent,
                     timeout,
                     parallel > 1,
                 )
                 futures.append(future)
-                future_to_model_test[future] = (model_id, test)
+                future_to_model_test[future] = (model_id, test, agent)
 
         def _handle_future(future: Future):
-            model, test = future_to_model_test[future]
+            model, test, agent = future_to_model_test[future]
             test_name = test["name"]
             try:
                 result = future.result(timeout=0.1)
@@ -126,6 +128,8 @@ def run_evals(
                     gen_stderr="",
                     run_stdout="",
                     run_stderr="",
+                    log_dir=agent.log_dir,
+                    workspace_dir=agent.workspace_dir,
                 )
             model_results[model][test_name] = result
 
@@ -218,16 +222,8 @@ def execute(test: EvalSpec, agent: Agent, timeout: int, parallel: bool) -> EvalR
             files = result.get("files", {})
             gen_stdout = result.get("stdout", "")
             gen_stderr = result.get("stderr", "")
-
-            # Set the log_dir and workspace_dir back on the agent from subprocess result
-            if result.get("log_dir"):
-                from pathlib import Path
-
-                agent.log_dir = Path(result["log_dir"])
-            if result.get("workspace_dir"):
-                from pathlib import Path
-
-                agent.workspace_dir = Path(result["workspace_dir"])
+            log_dir = result.get("log_dir") or agent.log_dir
+            workspace_dir = result.get("workspace_dir") or agent.workspace_dir
         else:
             logger.error("No result in shared dictionary")
             return EvalResult(
@@ -239,6 +235,8 @@ def execute(test: EvalSpec, agent: Agent, timeout: int, parallel: bool) -> EvalR
                 gen_stderr="",
                 run_stdout="",
                 run_stderr="",
+                log_dir=agent.log_dir,
+                workspace_dir=agent.workspace_dir,
             )
 
         logger.debug("Got result")
@@ -285,6 +283,8 @@ def execute(test: EvalSpec, agent: Agent, timeout: int, parallel: bool) -> EvalR
             gen_stderr=gen_stderr,
             run_stdout=stdout_run,
             run_stderr=stderr_run,
+            log_dir=log_dir,
+            workspace_dir=workspace_dir,
         )
 
 
@@ -366,8 +366,8 @@ def act_process(
         "stdout": stdout.getvalue(),
         "stderr": stderr.getvalue(),
         "duration": duration,
-        "log_dir": str(agent.log_dir) if agent.log_dir else None,
-        "workspace_dir": str(agent.workspace_dir) if agent.workspace_dir else None,
+        "log_dir": agent.log_dir,
+        "workspace_dir": agent.workspace_dir,
     }
     sync_dict["result"] = result_success
     subprocess_logger.info("Success")

--- a/gptme/eval/types.py
+++ b/gptme/eval/types.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal, TypedDict
 
 from typing_extensions import NotRequired
@@ -45,6 +46,8 @@ class EvalResult:
     gen_stderr: str
     run_stdout: str
     run_stderr: str
+    log_dir: Path
+    workspace_dir: Path
 
 
 class EvalSpec(TypedDict):


### PR DESCRIPTION
The main issue was that execute() runs agent.act() in a subprocess, so when agent.act() sets self.log_dir, it only affects the subprocess copy, leaving the original agent with log_dir=None. This caused tool usage metrics to fail (score 0.000) because they couldn't access conversation messages.

Changes:
- Modified act_process() to capture agent's log_dir/workspace_dir after execution
- Updated ProcessSuccess TypedDict to include log_dir/workspace_dir fields
- Enhanced execute() to set captured paths back on agent object
- Fixed prompt_optimizer.py to use agent.log_dir directly (now properly set)
- Cleaned up debug prints and improved tool usage metric logic
- Fixed LLM judge score parsing to handle "9/10" format responses
- Restored tool usage scoring: 0.000 → 0.850, composite: 0.700 → 0.955

This eliminates the need for fragile regex parsing of stdout and provides robust state propagation across process boundaries.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes subprocess `log_dir` propagation in DSPy evaluations, improving tool usage metrics and robustness.
> 
>   - **Behavior**:
>     - Modified `act_process()` in `run.py` to capture `log_dir` and `workspace_dir` after execution.
>     - Updated `ProcessSuccess` in `run.py` to include `log_dir` and `workspace_dir`.
>     - Enhanced `execute()` in `run.py` to set captured paths back on the `agent` object.
>     - Fixed `prompt_optimizer.py` to use `agent.log_dir` directly.
>   - **Metrics**:
>     - Improved tool usage metric logic in `metrics.py`.
>     - Fixed LLM judge score parsing in `metrics.py` to handle "9/10" format.
>   - **Misc**:
>     - Restored tool usage scoring from 0.000 to 0.850 and composite score from 0.700 to 0.955.
>     - Cleaned up debug prints in `metrics.py` and `prompt_optimizer.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 209d12cb7f12a0d18376fc9313aa2f3ae0d68562. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->