### PR TITLE
docs(shell): move timeout config from agent instructions to module docstring

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1,5 +1,12 @@
 """
 The assistant can execute shell commands with bash by outputting code blocks with `shell` as the language.
+
+Configuration:
+    GPTME_SHELL_TIMEOUT: Environment variable to configure command timeout (set before starting gptme)
+        - Set to a number (e.g., 30) for timeout in seconds
+        - Set to 0 to disable timeout
+        - Invalid values default to 60 seconds
+        - If not set, commands run without timeout
 """
 
 import atexit
@@ -127,12 +134,6 @@ is_macos = sys.platform == "darwin"
 instructions = f"""
 The given command will be executed in a stateful bash shell.
 The shell tool will respond with the output of the execution.
-
-Shell commands can be configured to timeout by setting the GPTME_SHELL_TIMEOUT environment variable.
-- Set GPTME_SHELL_TIMEOUT=30 for a 30-second timeout
-- Set GPTME_SHELL_TIMEOUT=0 to disable timeout
-- Invalid values default to 60 seconds
-- If not set, commands run without timeout
 
 These programs are available, among others:
 {shell_programs_str}


### PR DESCRIPTION
## Problem

The shell tool instructions currently include GPTME_SHELL_TIMEOUT configuration details that suggest the agent can set this environment variable during execution. However, this configuration must be set before gptme starts and cannot be changed by the agent at runtime.

## Solution

- Move GPTME_SHELL_TIMEOUT documentation to the module docstring (for developers)
- Remove timeout configuration from agent-visible instructions
- Make it clear that configuration must be set before starting gptme

## Changes

- ✅ Added timeout configuration docs to module docstring
- ✅ Removed timeout info from agent instructions
- ✅ All tests and pre-commit checks pass

This ensures agents don't receive misleading information about configuration options they cannot control.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move `GPTME_SHELL_TIMEOUT` configuration details to module docstring and remove from agent instructions in `shell.py`.
> 
>   - **Documentation**:
>     - Move `GPTME_SHELL_TIMEOUT` configuration details to module docstring in `shell.py`.
>     - Remove timeout configuration details from agent instructions in `shell.py`.
>     - Clarify that `GPTME_SHELL_TIMEOUT` must be set before starting `gptme`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 1b3d7f3b41b860b4a525abcdf16a0b5b04547ce0. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->