### PR TITLE
fix(config): clear tools cache when loading project/chat config

### DIFF
--- a/gptme/config.py
+++ b/gptme/config.py
@@ -520,7 +520,10 @@ class Config:
     @classmethod
     def from_workspace(cls, workspace: Path) -> Self:
         """Load the configuration from a workspace directory. Clearing any cache."""
+        from gptme.tools import clear_tools  # Import here to avoid circular import
+
         get_project_config.cache_clear()
+        clear_tools()  # Clear tools cache so MCP tools reload with project config
         return cls(
             user=load_user_config(),
             project=get_project_config(workspace),
@@ -529,7 +532,10 @@ class Config:
     @classmethod
     def from_logdir(cls, logdir: Path) -> Self:
         """Load the configuration from a log directory."""
+        from gptme.tools import clear_tools  # Import here to avoid circular import
+
         chat_config = ChatConfig.from_logdir(logdir)
+        clear_tools()  # Clear tools cache so MCP tools reload with chat config
         return cls(
             user=load_user_config(),
             project=get_project_config(chat_config.workspace),


### PR DESCRIPTION
Fixes #605

## Problem
MCP tools were initialized too early using only user config, making it impossible to load MCP servers from:
- Project config (needed for agents)
- Chat config (needed on resume)

## Root Cause
`get_available_tools()` caches tools on first call, but project/chat configs are loaded later via `Config.from_workspace()` and `Config.from_logdir()`. The cached tools never get updated with the merged config.

## Solution
Clear the tools cache when loading new configurations by calling `clear_tools()` in:
- `Config.from_workspace()` - ensures project config is respected
- `Config.from_logdir()` - ensures chat config is respected on resume

This follows the existing pattern of clearing `get_project_config.cache_clear()` when loading new configs.

## Changes
- Import `clear_tools` in both config loading methods (local import to avoid circular dependency)
- Call `clear_tools()` after clearing project config cache
- Ensures MCP tools are reloaded with complete merged configuration

## Testing
- All config tests pass (`tests/test_config.py`)
- Existing test infrastructure already uses `clear_tools()` for test isolation
- No breaking changes to existing functionality
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Clear tools cache in `Config.from_workspace()` and `Config.from_logdir()` to ensure MCP tools reload with complete configuration.
> 
>   - **Behavior**:
>     - Clear tools cache in `Config.from_workspace()` and `Config.from_logdir()` to reload MCP tools with complete configuration.
>     - Ensures project and chat configurations are respected when loading tools.
>   - **Implementation**:
>     - Import `clear_tools` locally in `Config.from_workspace()` and `Config.from_logdir()` to avoid circular dependencies.
>     - Call `clear_tools()` after clearing project config cache.
>   - **Testing**:
>     - All config tests pass in `tests/test_config.py`.
>     - Existing test infrastructure uses `clear_tools()` for test isolation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 0d9d45f552bbb922feedcbe0b1a3855f72082cc3. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->