### PR TITLE
Fix: Pin openai version in pre-commit mypy config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
   rev: v1.12.0
   hooks:
   - id: mypy
-    additional_dependencies: [types-tabulate, types-docutils, tomli, tomli_w, opentelemetry-api, opentelemetry-sdk, prometheus-client, prompt_toolkit, click, pytest, openai, rich, tomlkit, dspy]
+    additional_dependencies: [types-tabulate, types-docutils, tomli, tomli_w, opentelemetry-api, opentelemetry-sdk, prometheus-client, prompt_toolkit, click, pytest, openai==1.101.0, rich, tomlkit, dspy]
     args: [--ignore-missing-imports, --check-untyped-defs]
 - repo: local
   hooks:


### PR DESCRIPTION
## Problem
The mypy hook in pre-commit was using an unpinned openai dependency, causing it to install a newer version with updated type stubs that use `Omit` instead of `NotGiven`. This caused type errors even though the code works correctly with the project's locked openai 1.101.0.

## Solution
Pin to openai==1.101.0 in additional_dependencies to ensure mypy sees the same type signatures in pre-commit as in the actual project.

## Testing
- ✅ Pre-commit mypy now passes
- ✅ No code changes required
- ✅ Consistent with project dependencies

Fixes the mypy errors reported when running:
```bash
pre-commit run mypy --all-files
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Pin `openai` version in `mypy` pre-commit hook to prevent type errors.
> 
>   - **Configuration**:
>     - Pin `openai` version to `1.101.0` in `additional_dependencies` for `mypy` hook in `.pre-commit-config.yaml`.
>   - **Behavior**:
>     - Ensures `mypy` pre-commit hook uses the same `openai` type signatures as the project, preventing type errors.
>     - No code changes required, only configuration adjustment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 6818308f0297cc219845f2d70b3ec1bce3fa623b. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->