### PR TITLE
fix: prevent duplicate tool loading warnings in evals

### DIFF
--- a/gptme/tools/__init__.py
+++ b/gptme/tools/__init__.py
@@ -130,8 +130,7 @@ def init_tools(
                 allowlist = config.chat.tools
 
         for tool in get_toolchain(allowlist):
-            if tool in loaded_tools:
-                # logger.warning("Tool '%s' already loaded", tool.name)
+            if has_tool(tool.name):
                 continue
             if tool.init:
                 tool = tool.init()

--- a/tests/test_tool_loading_duplicate.py
+++ b/tests/test_tool_loading_duplicate.py
@@ -1,0 +1,55 @@
+"""Test that tools don't get loaded multiple times."""
+
+import logging
+
+from gptme.tools import init_tools, get_tools, _get_loaded_tools
+
+
+def test_init_tools_idempotent(caplog):
+    """Test that calling init_tools multiple times doesn't reload tools."""
+    # Clear any previously loaded tools
+    _get_loaded_tools().clear()
+
+    # Initialize tools first time
+    with caplog.at_level(logging.WARNING):
+        tools1 = init_tools(allowlist=["shell", "save"])
+
+    # Verify no warnings
+    assert "already loaded" not in caplog.text
+
+    # Get loaded tools count
+    loaded_count1 = len(get_tools())
+    assert loaded_count1 == 2  # shell and save
+
+    # Initialize tools second time (should be idempotent)
+    with caplog.at_level(logging.WARNING):
+        tools2 = init_tools(allowlist=["shell", "save"])
+
+    # Verify no warnings about duplicate loading
+    assert "already loaded" not in caplog.text
+
+    # Verify tools count hasn't changed
+    loaded_count2 = len(get_tools())
+    assert loaded_count2 == loaded_count1
+
+    # Verify same tools returned
+    assert len(tools1) == len(tools2)
+    assert all(t1.name == t2.name for t1, t2 in zip(tools1, tools2))
+
+
+def test_init_tools_evals_scenario(caplog):
+    """Test the evals scenario where init_tools is called multiple times."""
+    # Clear any previously loaded tools
+    _get_loaded_tools().clear()
+
+    # Simulate running 4 evals (as in issue #403)
+    with caplog.at_level(logging.WARNING):
+        for _ in range(4):
+            init_tools(allowlist=["shell", "save", "patch"])
+
+    # Verify no duplicate loading warnings
+    assert "already loaded" not in caplog.text
+
+    # Verify tools loaded only once
+    loaded_tools = get_tools()
+    assert len(loaded_tools) == 3  # shell, save, patch


### PR DESCRIPTION
Fixes #403

## Problem

When running evals, tools were being loaded multiple times, causing warnings like:
```
WARNING - gptme.tools - Tool 'shell' already loaded
WARNING - gptme.tools - Tool 'save' already loaded
...
```

## Root Cause

The `init_tools()` function was checking tool equality using object identity:
```python
if tool in loaded_tools:  # ToolSpec has eq=False
    continue
```

Since `ToolSpec` has `eq=False`, Python uses object identity (memory address) for comparison. When `get_toolchain()` returns new ToolSpec instances, they're considered different objects even if they represent the same tool.

## Solution

Changed the check to use the existing `has_tool()` function which checks by tool name:
```python
if has_tool(tool.name):  # Check by name
    continue
```

## Testing

Added comprehensive tests in `tests/test_tool_loading_duplicate.py`:
- `test_init_tools_idempotent`: Verifies calling init_tools twice doesn't cause warnings
- `test_init_tools_evals_scenario`: Simulates the exact issue scenario (4 consecutive init_tools calls)

All tests pass, confirming tools are loaded only once and no duplicate warnings occur.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes duplicate tool loading warnings in `init_tools()` by checking tool existence by name, with tests added for verification.
> 
>   - **Behavior**:
>     - Fixes duplicate tool loading warnings in `init_tools()` by using `has_tool()` to check tool existence by name.
>   - **Testing**:
>     - Adds `test_init_tools_idempotent` in `test_tool_loading_duplicate.py` to ensure `init_tools` is idempotent.
>     - Adds `test_init_tools_evals_scenario` in `test_tool_loading_duplicate.py` to simulate multiple `init_tools` calls without warnings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 75f7f75ed0a6c3298a41416c227ddcaded2accec. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->