### PR TITLE
fix(autocompact): prevent backup filename growth with repeated compactions

### DIFF
--- a/tests/test_auto_compact.py
+++ b/tests/test_auto_compact.py
@@ -221,6 +221,25 @@ def test_get_backup_name_uniqueness():
     assert name3.startswith("my-conversation-before-compact-")
 
 
+def test_get_backup_name_with_hex_suffix():
+    """Test that backup names with hex suffixes are correctly stripped.
+
+    This is a regression test for the bug where:
+    "my-conversation-before-compact-a7c9" would become
+    "my-conversation-before-compact-a7c9-before-compact-k2p5"
+    instead of
+    "my-conversation-before-compact-k2p5"
+    """
+    import re
+
+    # Test with a backup that has a valid hex suffix (only 0-9a-f)
+    name = _get_backup_name("my-conversation-before-compact-a7c9")
+    # Should strip the old suffix and add a new one
+    assert re.match(r"^my-conversation-before-compact-[0-9a-f]{4}$", name)
+    # Should NOT contain the old hex suffix
+    assert "a7c9" not in name
+
+
 def test_get_backup_name_empty_string():
     """Test backup name generation with empty string raises ValueError."""
     with pytest.raises(ValueError, match="conversation name cannot be empty"):


### PR DESCRIPTION
Fixes #692

## Problem

When auto-compacting conversations multiple times, the backup filename was growing indefinitely by repeatedly appending `-before-compact`:

```
2025-10-13-my-conv
→ 2025-10-13-my-conv-before-compact
→ 2025-10-13-my-conv-before-compact-before-compact
→ 2025-10-13-my-conv-before-compact-before-compact-before-compact
...
```

This could eventually hit filesystem name length limits (typically 255 characters) and cause errors.

## Solution

- Extracts backup name generation into a helper function `_get_backup_name()`
- Strips any existing `-before-compact` suffixes before adding one
- Ensures backup names have exactly one `-before-compact` suffix
- Adds comprehensive tests covering normal and edge cases

## Testing

Added 4 new test cases:
- ✅ Normal case: no suffix → adds one suffix
- ✅ One suffix: doesn't add another
- ✅ Multiple suffixes: strips all and adds only one
- ✅ Edge cases: short names, names containing 'compact', similar suffixes

## Benefits

- Prevents filesystem name length limits
- Cleaner, more predictable backup naming
- No confusion about which backup is which
- Fully backward compatible
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes backup filename growth issue in auto-compaction by introducing `_get_backup_name()` to ensure a single `-before-compact` suffix.
> 
>   - **Behavior**:
>     - Introduces `_get_backup_name()` in `autocompact.py` to manage backup filenames, ensuring only one `-before-compact` suffix is present.
>     - Modifies `autocompact_hook()` to use `_get_backup_name()` for backup naming.
>   - **Testing**:
>     - Adds tests in `test_auto_compact.py` for `_get_backup_name()` covering no suffix, one suffix, multiple suffixes, edge cases, uniqueness, hex suffix stripping, and empty string handling.
>   - **Misc**:
>     - Fixes issue #692 by preventing filename growth and potential filesystem errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for d0045e5dd81f845ce1cecb90743fca1a21c16183. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->