### PR TITLE
fix(tests): update remaining lesson tests to mock _get_lesson_index

### DIFF
--- a/tests/test_lessons_tool.py
+++ b/tests/test_lessons_tool.py
@@ -96,10 +96,10 @@ class TestAutoIncludeLessonsHook:
     def test_hook_no_lessons_in_index(self, conversation_log, mock_config):
         """Test hook when no lessons exist."""
         with patch("gptme.tools.lessons.HAS_LESSONS", True):
-            with patch("gptme.tools.lessons.LessonIndex") as mock_index_class:
+            with patch("gptme.tools.lessons._get_lesson_index") as mock_get_index:
                 mock_index = MagicMock()
                 mock_index.lessons = []
-                mock_index_class.return_value = mock_index
+                mock_get_index.return_value = mock_index
 
                 messages = list(auto_include_lessons_hook(conversation_log))
                 assert len(messages) == 0
@@ -109,11 +109,11 @@ class TestAutoIncludeLessonsHook:
     ):
         """Test hook when no lessons match."""
         with patch("gptme.tools.lessons.HAS_LESSONS", True):
-            with patch("gptme.tools.lessons.LessonIndex") as mock_index_class:
+            with patch("gptme.tools.lessons._get_lesson_index") as mock_get_index:
                 with patch("gptme.tools.lessons.LessonMatcher") as mock_matcher_class:
                     mock_index = MagicMock()
                     mock_index.lessons = [sample_lesson]
-                    mock_index_class.return_value = mock_index
+                    mock_get_index.return_value = mock_index
 
                     mock_matcher = MagicMock()
                     mock_matcher.match.return_value = []
@@ -173,11 +173,11 @@ class TestAutoIncludeLessonsHook:
         mock_config.get_env.return_value = "3"  # Limit to 3
 
         with patch("gptme.tools.lessons.HAS_LESSONS", True):
-            with patch("gptme.tools.lessons.LessonIndex") as mock_index_class:
+            with patch("gptme.tools.lessons._get_lesson_index") as mock_get_index:
                 with patch("gptme.tools.lessons.LessonMatcher") as mock_matcher_class:
                     mock_index = MagicMock()
                     mock_index.lessons = lessons
-                    mock_index_class.return_value = mock_index
+                    mock_get_index.return_value = mock_index
 
                     mock_matcher = MagicMock()
                     mock_matcher.match.return_value = matches
@@ -199,11 +199,11 @@ class TestAutoIncludeLessonsHook:
         mock_config.get_env.return_value = "invalid"
 
         with patch("gptme.tools.lessons.HAS_LESSONS", True):
-            with patch("gptme.tools.lessons.LessonIndex") as mock_index_class:
+            with patch("gptme.tools.lessons._get_lesson_index") as mock_get_index:
                 with patch("gptme.tools.lessons.LessonMatcher") as mock_matcher_class:
                     mock_index = MagicMock()
                     mock_index.lessons = []
-                    mock_index_class.return_value = mock_index
+                    mock_get_index.return_value = mock_index
 
                     mock_matcher = MagicMock()
                     mock_matcher.match.return_value = []


### PR DESCRIPTION
Four tests were still mocking LessonIndex directly instead of _get_lesson_index, causing them to fail after the thread-local caching changes in bc3364c3.

This completes the fix started in 78743917 by updating all remaining tests:
- test_hook_no_lessons_in_index
- test_hook_no_matching_lessons
- test_hook_limits_max_lessons (the failing test)
- test_hook_handles_invalid_max_lessons

Fixes the test failure on master branch.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update tests in `tests/test_lessons_tool.py` to mock `_get_lesson_index` instead of `LessonIndex`, fixing test failures due to caching changes.
> 
>   - **Tests**:
>     - Update `test_hook_no_lessons_in_index`, `test_hook_no_matching_lessons`, `test_hook_limits_max_lessons`, and `test_hook_handles_invalid_max_lessons` in `tests/test_lessons_tool.py` to mock `gptme.tools.lessons._get_lesson_index` instead of `LessonIndex`.
>     - Fixes test failures caused by thread-local caching changes in commit `bc3364c3`.
>     - Completes the fix started in commit `78743917`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for d8783e624dfbfd58d76e4c55963729c8862ce02e. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->