### PR TITLE
feat(lessons): implement status filtering for lesson lifecycle management

### DIFF
--- a/gptme/lessons/index.py
+++ b/gptme/lessons/index.py
@@ -81,6 +81,12 @@ class LessonIndex:
 
             try:
                 lesson = parse_lesson(md_file)
+                # Filter based on status - only include active lessons
+                if lesson.metadata.status != "active":
+                    logger.debug(
+                        f"Skipping {lesson.metadata.status} lesson: {md_file.relative_to(directory)}"
+                    )
+                    continue
                 self.lessons.append(lesson)
             except Exception as e:
                 logger.warning(f"Failed to parse lesson {md_file}: {e}")

--- a/gptme/lessons/parser.py
+++ b/gptme/lessons/parser.py
@@ -18,6 +18,7 @@ class LessonMetadata:
 
     keywords: list[str] = field(default_factory=list)
     tools: list[str] = field(default_factory=list)
+    status: str = "active"  # active, automated, deprecated, or archived
     # Future extensions:
     # globs: list[str] = field(default_factory=list)
     # semantic: list[str] = field(default_factory=list)
@@ -104,9 +105,12 @@ def parse_lesson(path: Path) -> Lesson:
                 if frontmatter:
                     # Extract match section
                     match_data = frontmatter.get("match", {})
+                    # Extract status (defaults to "active" if not present)
+                    status = frontmatter.get("status", "active")
                     metadata = LessonMetadata(
                         keywords=match_data.get("keywords", []),
                         tools=match_data.get("tools", []),
+                        status=status,
                     )
             except yaml.YAMLError as e:
                 raise ValueError(f"Invalid YAML frontmatter in {path}: {e}") from e

--- a/tests/test_lessons_status.py
+++ b/tests/test_lessons_status.py
@@ -1,0 +1,276 @@
+"""Tests for lesson status filtering."""
+
+import tempfile
+from pathlib import Path
+
+from gptme.lessons.index import LessonIndex
+from gptme.lessons.parser import LessonMetadata, parse_lesson
+
+
+class TestLessonStatus:
+    """Tests for lesson status field in parser."""
+
+    def test_status_default_active(self):
+        """Test that lessons without status field default to 'active'."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lesson_dir = Path(tmpdir)
+            lesson_file = lesson_dir / "test.md"
+
+            content = """---
+match:
+  keywords: [test]
+---
+
+# Test Lesson
+
+Description.
+"""
+            lesson_file.write_text(content)
+
+            lesson = parse_lesson(lesson_file)
+            assert lesson.metadata.status == "active"
+
+    def test_status_explicit_active(self):
+        """Test lesson with explicit 'active' status."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lesson_dir = Path(tmpdir)
+            lesson_file = lesson_dir / "test.md"
+
+            content = """---
+status: active
+match:
+  keywords: [test]
+---
+
+# Test Lesson
+
+Description.
+"""
+            lesson_file.write_text(content)
+
+            lesson = parse_lesson(lesson_file)
+            assert lesson.metadata.status == "active"
+
+    def test_status_automated(self):
+        """Test lesson with 'automated' status."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lesson_dir = Path(tmpdir)
+            lesson_file = lesson_dir / "test.md"
+
+            content = """---
+status: automated
+automated_by: scripts/context.sh
+match:
+  keywords: [test]
+---
+
+# Test Lesson
+
+Description.
+"""
+            lesson_file.write_text(content)
+
+            lesson = parse_lesson(lesson_file)
+            assert lesson.metadata.status == "automated"
+
+    def test_status_deprecated(self):
+        """Test lesson with 'deprecated' status."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lesson_dir = Path(tmpdir)
+            lesson_file = lesson_dir / "test.md"
+
+            content = """---
+status: deprecated
+deprecated_by: lessons/new-approach.md
+match:
+  keywords: [test]
+---
+
+# Test Lesson
+
+Description.
+"""
+            lesson_file.write_text(content)
+
+            lesson = parse_lesson(lesson_file)
+            assert lesson.metadata.status == "deprecated"
+
+    def test_status_archived(self):
+        """Test lesson with 'archived' status."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lesson_dir = Path(tmpdir)
+            lesson_file = lesson_dir / "test.md"
+
+            content = """---
+status: archived
+archived_reason: "No longer relevant"
+match:
+  keywords: [test]
+---
+
+# Test Lesson
+
+Description.
+"""
+            lesson_file.write_text(content)
+
+            lesson = parse_lesson(lesson_file)
+            assert lesson.metadata.status == "archived"
+
+    def test_status_no_frontmatter(self):
+        """Test lesson without frontmatter defaults to active."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lesson_dir = Path(tmpdir)
+            lesson_file = lesson_dir / "test.md"
+
+            content = """# Test Lesson
+
+Description.
+"""
+            lesson_file.write_text(content)
+
+            lesson = parse_lesson(lesson_file)
+            assert lesson.metadata.status == "active"
+
+
+class TestLessonStatusFiltering:
+    """Tests for status-based lesson filtering in index."""
+
+    def test_index_includes_active_lessons(self):
+        """Test that index includes lessons with active status."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lesson_dir = Path(tmpdir)
+
+            # Create active lesson
+            active_lesson = lesson_dir / "active.md"
+            active_lesson.write_text("""---
+status: active
+match:
+  keywords: [test]
+---
+
+# Active Lesson
+
+Description.
+""")
+
+            index = LessonIndex(lesson_dirs=[lesson_dir])
+            assert len(index.lessons) == 1
+            assert index.lessons[0].title == "Active Lesson"
+
+    def test_index_excludes_automated_lessons(self):
+        """Test that index excludes lessons with automated status."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lesson_dir = Path(tmpdir)
+
+            # Create automated lesson
+            automated_lesson = lesson_dir / "automated.md"
+            automated_lesson.write_text("""---
+status: automated
+match:
+  keywords: [test]
+---
+
+# Automated Lesson
+
+Description.
+""")
+
+            index = LessonIndex(lesson_dirs=[lesson_dir])
+            assert len(index.lessons) == 0
+
+    def test_index_excludes_deprecated_lessons(self):
+        """Test that index excludes lessons with deprecated status."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lesson_dir = Path(tmpdir)
+
+            # Create deprecated lesson
+            deprecated_lesson = lesson_dir / "deprecated.md"
+            deprecated_lesson.write_text("""---
+status: deprecated
+match:
+  keywords: [test]
+---
+
+# Deprecated Lesson
+
+Description.
+""")
+
+            index = LessonIndex(lesson_dirs=[lesson_dir])
+            assert len(index.lessons) == 0
+
+    def test_index_excludes_archived_lessons(self):
+        """Test that index excludes lessons with archived status."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lesson_dir = Path(tmpdir)
+
+            # Create archived lesson
+            archived_lesson = lesson_dir / "archived.md"
+            archived_lesson.write_text("""---
+status: archived
+match:
+  keywords: [test]
+---
+
+# Archived Lesson
+
+Description.
+""")
+
+            index = LessonIndex(lesson_dirs=[lesson_dir])
+            assert len(index.lessons) == 0
+
+    def test_index_mixed_status_lessons(self):
+        """Test index with mix of active and non-active lessons."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lesson_dir = Path(tmpdir)
+
+            # Create multiple lessons with different statuses
+            lessons_data = [
+                ("active1.md", "active", "Active Lesson 1"),
+                ("active2.md", "active", "Active Lesson 2"),
+                ("automated.md", "automated", "Automated Lesson"),
+                ("deprecated.md", "deprecated", "Deprecated Lesson"),
+                ("archived.md", "archived", "Archived Lesson"),
+                ("default.md", None, "Default Lesson"),  # No status = active
+            ]
+
+            for filename, status, title in lessons_data:
+                status_line = f"status: {status}\n" if status else ""
+                lesson_file = lesson_dir / filename
+                lesson_file.write_text(f"""---
+{status_line}match:
+  keywords: [test]
+---
+
+# {title}
+
+Description.
+""")
+
+            index = LessonIndex(lesson_dirs=[lesson_dir])
+
+            # Should only include 3 active lessons (2 explicit + 1 default)
+            assert len(index.lessons) == 3
+
+            titles = {lesson.title for lesson in index.lessons}
+            assert titles == {"Active Lesson 1", "Active Lesson 2", "Default Lesson"}
+
+
+class TestLessonMetadataStatus:
+    """Tests for LessonMetadata status field."""
+
+    def test_metadata_default_status(self):
+        """Test that LessonMetadata defaults to 'active' status."""
+        metadata = LessonMetadata()
+        assert metadata.status == "active"
+
+    def test_metadata_explicit_status(self):
+        """Test LessonMetadata with explicit status."""
+        metadata = LessonMetadata(
+            keywords=["test"], tools=["shell"], status="automated"
+        )
+        assert metadata.status == "automated"
+        assert metadata.keywords == ["test"]
+        assert metadata.tools == ["shell"]


### PR DESCRIPTION
## Problem

Lessons can become outdated or automated over time, but we want to keep them for reference without cluttering the active context.

## Solution

Implemented status filtering for lessons to support lifecycle management:

### Features
- Parse `status` field from YAML frontmatter (defaults to 'active')
- Filter lessons during indexing (only include 'active' status)
- Support status values: active, automated, deprecated, archived
- Log when lessons are filtered out (debug level)

### Implementation
- Added `status` field to `LessonMetadata` dataclass
- Updated `parse_lesson()` to extract status from frontmatter
- Modified `_index_directory()` to filter non-active lessons
- Added comprehensive test suite (13 tests, all passing)

## Testing

All tests pass (123/123):
- 13 new tests for status filtering
- All existing lesson tests remain passing
- Covers parsing, filtering, and edge cases

## Example Usage

```yaml
---
status: automated
automated_by: scripts/context-gh.sh
automated_date: 2025-10-15
match:
  keywords: [github, issues]
---
```

Lessons with non-active status are excluded from context but preserved for reference.

Resolves #700
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Implement lesson status filtering for lifecycle management, adding status parsing and filtering logic, with comprehensive tests.
> 
>   - **Behavior**:
>     - Parse `status` field from YAML frontmatter in `parse_lesson()` in `parser.py`, defaulting to 'active'.
>     - Filter lessons in `_index_directory()` in `index.py` to include only 'active' lessons.
>     - Log filtered lessons at debug level.
>   - **Models**:
>     - Add `status` field to `LessonMetadata` dataclass in `parser.py`.
>   - **Testing**:
>     - Add `test_lessons_status.py` with 13 tests for status filtering, covering parsing, filtering, and edge cases.
>   - **Misc**:
>     - Change API timeout default to 300 seconds in `llm_anthropic.py` and `llm_openai.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 1ca948300c5f998d6af22e1338cb464e56c181d7. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->