### PR TITLE
feat(lessons): add mode-specific configuration for lesson auto-inclusion

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -143,6 +143,7 @@ def chat(
             model,
             interactive,
             logdir,
+            no_confirm,
         )
     except SessionCompleteException as e:
         console.log(f"Autonomous mode: {e}. Exiting.")
@@ -167,6 +168,7 @@ def _run_chat_loop(
     model,
     interactive,
     logdir,
+    no_confirm,
 ):
     """Main chat loop - extracted to allow clean exception handling."""
 
@@ -186,7 +188,13 @@ def _run_chat_loop(
 
                 # Process the message and get response
                 _process_message_conversation(
-                    manager, stream, confirm_func, tool_format, workspace, model
+                    manager,
+                    stream,
+                    confirm_func,
+                    tool_format,
+                    workspace,
+                    model,
+                    no_confirm,
                 )
             else:
                 # Get user input or exit if non-interactive
@@ -211,6 +219,7 @@ def _run_chat_loop(
                             tool_format,
                             workspace,
                             model,
+                            no_confirm,
                         )
                 else:
                     # Normal case: user provided input
@@ -231,6 +240,7 @@ def _run_chat_loop(
                         tool_format,
                         workspace,
                         model,
+                        no_confirm,
                     )
 
             # Trigger LOOP_CONTINUE hooks to check if we should continue/exit
@@ -271,6 +281,7 @@ def _process_message_conversation(
     tool_format: ToolFormat,
     workspace: Path,
     model: str | None,
+    no_confirm: bool = False,
 ) -> None:
     """Process a message and generate responses until no more tools to run."""
 
@@ -280,7 +291,10 @@ def _process_message_conversation(
 
             # Trigger pre-process hooks
             if pre_msgs := trigger_hook(
-                HookType.MESSAGE_PRE_PROCESS, log=manager.log, workspace=workspace
+                HookType.MESSAGE_PRE_PROCESS,
+                log=manager.log,
+                workspace=workspace,
+                no_confirm=no_confirm,
             ):
                 for msg in pre_msgs:
                     manager.append(msg)


### PR DESCRIPTION
Implements Phase 3 configuration for autonomous/non-interactive mode behavior from issue #686.

## Overview

Adds mode-specific configuration for the lesson auto-inclusion system, allowing different behavior in interactive vs non-interactive (autonomous) mode.

## Changes

- **Hook parameter passing**: Pass `no_confirm` flag through to `MESSAGE_PRE_PROCESS` hooks
  - Updated `chat()`, `_run_chat_loop()`, and `_process_message_conversation()` to pass the flag
  
- **Mode-specific configuration**: Update `auto_include_lessons_hook` to use different settings based on mode
  - Interactive mode: Uses existing `GPTME_LESSONS_AUTO_INCLUDE` and `GPTME_LESSONS_MAX_INCLUDED` (default: 5)
  - Non-interactive mode: Uses new `GPTME_LESSONS_AUTO_INCLUDE_NONINTERACTIVE` and `GPTME_LESSONS_MAX_INCLUDED_NONINTERACTIVE` (default: 3)

- **Test coverage**: Added test for mode-specific configuration behavior

## Rationale

In non-interactive/autonomous mode:
- Agent runs without human oversight
- Token efficiency is more important
- Fewer lessons (3 vs 5) conserve tokens while still providing necessary context
- Can be configured differently via environment variables

## Environment Variables

New variables for non-interactive mode:
- `GPTME_LESSONS_AUTO_INCLUDE_NONINTERACTIVE` (default: True) - Enable auto-inclusion in non-interactive mode
- `GPTME_LESSONS_MAX_INCLUDED_NONINTERACTIVE` (default: 3) - Max lessons in non-interactive mode

Existing variables for interactive mode (unchanged):
- `GPTME_LESSONS_AUTO_INCLUDE` (default: True)
- `GPTME_LESSONS_MAX_INCLUDED` (default: 5)

## Testing

- Added test `test_mode_specific_configuration` to verify correct config is used for each mode
- All existing tests pass
- Pre-commit hooks pass (ruff, mypy, format)

## Related

- Closes #686 (Phase 3 partial - configuration for autonomous mode)
- Builds on PR #687 (Phase 1 implementation)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add mode-specific configuration for lesson auto-inclusion in `chat.py` and `lessons.py`, with tests verifying behavior for interactive and non-interactive modes.
> 
>   - **Behavior**:
>     - Pass `no_confirm` flag to `MESSAGE_PRE_PROCESS` hooks in `chat()`, `_run_chat_loop()`, and `_process_message_conversation()` in `chat.py`.
>     - Update `auto_include_lessons_hook` in `lessons.py` to use different settings for interactive and non-interactive modes.
>   - **Configuration**:
>     - Interactive mode uses `GPTME_LESSONS_AUTO_INCLUDE` and `GPTME_LESSONS_MAX_INCLUDED` (default: 5).
>     - Non-interactive mode uses `GPTME_LESSONS_AUTO_INCLUDE_NONINTERACTIVE` and `GPTME_LESSONS_MAX_INCLUDED_NONINTERACTIVE` (default: 3).
>   - **Testing**:
>     - Added `test_mode_specific_configuration` in `test_lessons_integration.py` to verify mode-specific behavior.
>     - All existing tests pass, ensuring no regressions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for ea48a3e37395b23610c801a98c9b26c44c112883. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->