### PR TITLE
fix(openai): preserve tool results in gpt-5 models

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -157,7 +157,9 @@ def _prep_o1(msgs: Iterable[Message]) -> Generator[Message, None, None]:
     # prepare messages for OpenAI O1, which doesn't support the system role
     # and requires the first message to be from the user
     for msg in msgs:
-        if msg.role == "system":
+        # Don't convert system messages that have call_id (tool results)
+        # as they need to be converted to tool messages by _handle_tools
+        if msg.role == "system" and msg.call_id is None:
             msg = msg.replace(
                 role="user", content=f"<system>\n{msg.content}\n</system>"
             )


### PR DESCRIPTION
## Problem

Issue #650 reported that gpt-5 and gpt-5-codex models fail with "No tool output found for function call" error after the first tool use when using `--tool-format tool`.

## Root Cause

The `_prep_o1` function converts ALL system messages to user messages (because O1/gpt-5 models don't support the system role). However, tool result messages also use the system role but have a special `call_id` field that identifies them as tool outputs.

When these tool result messages were converted to user messages, the `_handle_tools` function could no longer recognize them (it looks for `role="system"` AND `call_id`). This caused the API to not receive the expected tool output messages, resulting in the error.

## Solution

Modified `_prep_o1` to preserve system messages that have a `call_id` field. These tool result messages are handled specially by `_handle_tools` and must maintain their system role until that conversion happens.

## Changes

- Modified `_prep_o1` function to check for `call_id` before converting system messages
- Added comprehensive regression test `test_message_conversion_gpt5_with_tool_results`
- Test verifies that tool results are correctly converted to tool messages (not user messages)
- All existing tests still pass

## Testing

```bash
poetry run pytest tests/test_llm_openai.py::test_message_conversion_gpt5_with_tool_results -v
poetry run pytest tests/test_llm_openai.py -v
```

Closes #650
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes tool result message handling in gpt-5 models by preserving system messages with `call_id` in `_prep_o1`.
> 
>   - **Behavior**:
>     - Fixes issue #650 by modifying `_prep_o1` in `llm_openai.py` to preserve system messages with `call_id`.
>     - Ensures tool result messages are correctly identified and not converted to user messages.
>   - **Testing**:
>     - Adds regression test `test_message_conversion_gpt5_with_tool_results` in `test_llm_openai.py`.
>     - Verifies tool results are preserved as tool messages in gpt-5 models.
>     - All existing tests pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 37b56b2eeb93bb016e6bc90f17ce17de3c27bbda. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->