### PR TITLE
fix(shell): include heredoc content when splitting compound commands

### DIFF
--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -584,3 +584,17 @@ EOF2""",
             reason is not None
         ), f"Should have reason for dangerous command: {cmd[:50]}..."
         assert matched_cmd is not None, f"Should have matched command: {cmd[:50]}..."
+
+
+def test_heredoc_in_compound_command(shell):
+    """Test that heredocs work correctly in compound commands with &&."""
+    # Issue #703: This should not get stuck
+    ret, out, err = shell.run(
+        """echo "test" && python3 <<'EOF'
+print('0')
+EOF"""
+    )
+    assert ret == 0
+    assert "test" in out
+    assert "0" in out
+    assert err.strip() == ""


### PR DESCRIPTION
## Summary

Fixes #703 - Shell tool no longer hangs on heredocs in compound commands with &&.

## Problem

The shell tool would hang when executing commands like:
```bash
echo "test" && python3 <<'EOF'
print('0')
EOF
```

## Root Cause

The `split_commands()` function used bashlex's `part.pos` to extract command text, which only captures the command line itself (e.g., `echo "test" && python3 <<'EOF'`), not the heredoc content. The heredoc content is stored in nested `RedirectNode.heredoc` objects with positions that extend beyond `part.pos`.

When the incomplete command was executed, bash would wait indefinitely for the missing heredoc content, causing the hang.

## Solution

Added `_find_max_heredoc_pos()` helper function that:
1. Recursively searches the bashlex parse tree for heredoc nodes
2. Returns the maximum position from any heredoc content
3. Ensures complete command extraction including heredoc content and closing delimiters

Modified `split_commands()` to use this maximum position when extracting "list", "pipeline", and "function" kind parts.

## Testing

**New test**: `test_heredoc_in_compound_command`
- Previously: hung (timeout)
- After fix: passes in 0.39s

**All tests pass**: 28/28 shell tests ✅

## Impact

- ✅ Heredocs in compound commands now work correctly
- ✅ No regressions (all existing tests pass)
- ✅ Fixes a blocking issue for shell tool reliability
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes hanging issue in `split_commands()` for compound commands with heredocs by including heredoc content, verified by new and existing tests.
> 
>   - **Behavior**:
>     - Fixes hanging issue in `split_commands()` in `shell.py` for compound commands with heredocs by including heredoc content.
>     - Adds `_find_max_heredoc_pos()` to recursively find maximum heredoc position in bashlex parse tree.
>   - **Testing**:
>     - Adds `test_heredoc_in_compound_command` to verify heredoc handling in compound commands.
>     - Confirms all 28 shell tests pass, ensuring no regressions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for d4a118a6eee0b4a7150ff42dc8d144425e8b714d. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->