### PR TITLE
fix(shell): redirect stdin in pipelines to prevent deadlock

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -277,15 +277,15 @@ class ShellSession:
                     pipe_idx = command_parts.index("|")
                     # Reconstruct command parts before and after pipe
                     first_parts = command_parts[:pipe_idx]
-                    rest_parts = command_parts[pipe_idx + 1:]
-                    
+                    rest_parts = command_parts[pipe_idx + 1 :]
+
                     # Join parts back with proper quoting using shlex.join()
                     first_cmd = shlex.join(first_parts)
                     rest = shlex.join(rest_parts)
                     command = f"{first_cmd} < /dev/null | {rest}"
                 except (ValueError, IndexError) as e:
                     # Fallback to raw command if parsing fails
-                    logger.warning(f"Failed to parse pipe in command: {e}")
+                    logger.warning(f"Failed to parse pipe in command '{command}': {e}")
             elif not has_stdin_redirect and "|" not in command_parts:
                 # No pipe and no stdin redirection - add /dev/null
                 command += " < /dev/null"

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -605,25 +605,52 @@ EOF"""
 def test_pipe_with_stdin_consuming_command(shell):
     """Test that piping commands that consume stdin doesn't hang (issue #684).
 
-    Commands like gptme that try to read from stdin can cause deadlocks in pipelines
-    if stdin isn't properly redirected to /dev/null for the first command.
-    """
-    # Test case that would hang before the fix: cat with no args tries to read stdin
-    # With stdin redirected to /dev/null, cat returns immediately with empty output
-    ret_code, stdout, stderr = shell.run(
-        "cat | wc -l", output=False, timeout=5.0
-    )
-    
-    assert ret_code == 0
-    assert stdout.strip() == "0"  # cat reads nothing from /dev/null
+    Reproduces the specific failing case from Erik's comment:
+    gptme "/shell gptme '/exit' | grep Assistant"
 
-    # More complex: Python trying to read stdin in a pipeline
-    # This simulates issue #684 where nested gptme would block on stdin
+    The script simulates gptme's behavior:
+    - Without stdin redirection: blocks reading from pipe stdin
+    - With stdin redirected to /dev/null: prints "Assistant" immediately
+
+    This test would hang without the fix that redirects stdin for the first
+    command in a pipeline.
+    """
+    # Create test script that simulates gptme's stdin behavior
+    test_script = """#!/usr/bin/env python3
+import sys
+import os
+
+# Check if stdin is /dev/null
+try:
+    stdin_stat = os.fstat(sys.stdin.fileno())
+    devnull_stat = os.stat('/dev/null')
+    is_devnull = (stdin_stat.st_dev == devnull_stat.st_dev and
+                  stdin_stat.st_ino == devnull_stat.st_ino)
+except:
+    is_devnull = False
+
+if not is_devnull and not sys.stdin.isatty():
+    # stdin is a pipe (not /dev/null, not terminal)
+    # This would block forever without stdin redirection
+    sys.stdin.read(1)
+    print("blocked")
+else:
+    # stdin is /dev/null or terminal - works correctly
+    print("Assistant")
+"""
+
+    # Write test script
+    shell.run("cat > /tmp/test_stdin_block.py << 'EOF'\n" + test_script + "\nEOF")
+    shell.run("chmod +x /tmp/test_stdin_block.py")
+
+    # This is the actual failing case: command that blocks on stdin | grep
+    # Without the fix, this would hang because the script waits for stdin
+    # With the fix, stdin is redirected to /dev/null for the first command
     ret_code, stdout, stderr = shell.run(
-        "python3 -c 'import sys; print(\"test\" if not sys.stdin.read() else \"blocked\")' | grep test",
+        "python3 /tmp/test_stdin_block.py | grep Assistant",
         output=False,
         timeout=5.0,
     )
 
     assert ret_code == 0
-    assert "test" in stdout
+    assert "Assistant" in stdout


### PR DESCRIPTION
## Problem

Issue #684: Shell tool hangs when executing commands that pipe to stdin-consuming processes.

**Example that hangs:**
```bash
gptme "/shell gptme '/exit' | grep bla"
```

## Root Cause

Commands in pipelines inherited bash's stdin, causing deadlocks when they tried to read input:
- gptme starts and waits for stdin input
- grep waits for gptme's output
- ShellSession waits for the delimiter
- **Deadlock!**

The previous logic skipped adding `< /dev/null` for ALL commands with pipes, allowing stdin inheritance.

## Solution

Redirect stdin to `/dev/null` for the **first command** in a pipeline, but leave the rest of the pipeline unchanged:

```bash
# Before: gptme '/exit' | grep bla
# After:  gptme '/exit' < /dev/null | grep bla
```

This allows pipes to work correctly while preventing stdin inheritance issues.

## Changes

- Modified `_run` method in `gptme/tools/shell.py`
- Added test case `test_pipe_with_stdin_consuming_command`

## Testing

- ✅ New test passes (previously timed out after 10s)
- ✅ All 28 existing shell tests pass
- ✅ No regressions

Fixes #684
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes shell pipeline deadlock by redirecting stdin to `/dev/null` for the first command in a pipeline in `gptme/tools/shell.py`.
> 
>   - **Behavior**:
>     - Fixes deadlock in shell pipelines by redirecting stdin to `/dev/null` for the first command in a pipeline in `_run()` in `gptme/tools/shell.py`.
>     - Leaves stdin unchanged for subsequent commands in the pipeline.
>     - Does not affect commands with existing stdin redirection.
>   - **Testing**:
>     - Adds `test_pipe_with_stdin_consuming_command` to `tests/test_tools_shell.py` to verify fix.
>     - Confirms no hang occurs with stdin-consuming commands in pipelines.
>     - All existing shell tests pass without regression.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 05b9a6ea10a98eef733143040eac6012a9353432. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->