### PR TITLE
fix(auto-naming): strip think tags from LLM responses

### DIFF
--- a/gptme/util/auto_naming.py
+++ b/gptme/util/auto_naming.py
@@ -157,6 +157,18 @@ Title:"""
             naming_model,
             None,
         )
+
+        # Strip think tags (Claude models may use these)
+        response = response.strip()
+        think_end = response.find("</think>")
+        if think_end != -1:
+            # Remove everything before and including </think>
+            response = response[think_end + len("</think>") :]
+        elif "<think>" in response:
+            # Incomplete think tag, skip this response
+            logger.debug("Incomplete think tag in response, skipping")
+            return None
+
         name = response.strip().strip('"').strip("'").split("\n")[0][:50]
         if name:
             return name


### PR DESCRIPTION
## Problem

Multiple PRs (#711, #715, others) are failing the `test_auto_naming_meaningful_content` test when using Claude Haiku 4.5. The test expects contextually relevant conversation names but gets `<think>` instead.

**Root cause**: Claude models use `<think>` tags for extended thinking. When generating conversation names, these tags were being picked up as the name instead of the actual content.

**Example failure**:
```
AssertionError: Generated name '<think>' doesn't seem contextually relevant.
Expected keywords: ['css', 'div', 'center', 'centering', 'layout', 'styling', 'web']
```

## Solution

Strip `<think>...</ think>` tags from LLM responses before extracting the conversation name, following the same pattern used in `codeblock.py`:

- If complete `<think>...</think>` tags exist, remove everything before and including `</think>`
- If incomplete think tag (no closing tag), return None to fall back to random name generation
- Extract name from the cleaned response

## Testing

- ✅ `test_auto_naming_meaningful_content` now passes with Haiku model
- ✅ Auto-generated name is contextually relevant: 'CSS div centering'
- ✅ All pre-commit checks pass

## Impact

This fix unblocks multiple PRs that are currently failing CI due to this issue.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes LLM response handling in `auto_naming.py` by stripping `<think>` tags to ensure meaningful conversation names.
> 
>   - **Behavior**:
>     - Strips `<think>...</think>` tags from LLM responses in `_generate_llm_name()` in `auto_naming.py`.
>     - If complete `<think>` tags exist, removes everything before and including `</think>`.
>     - If incomplete `<think>` tag is found, returns `None` to trigger fallback name generation.
>   - **Testing**:
>     - `test_auto_naming_meaningful_content` now passes with Haiku model.
>     - Auto-generated names are contextually relevant.
>   - **Impact**:
>     - Unblocks multiple PRs failing CI due to this issue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for d29e0a4c7c638a402018eecf611dd40fb74a91e0. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->