### PR TITLE
test(codeblock): remove xfail markers from passing header tests

### DIFF
--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -814,9 +814,6 @@ More `inline code`.
     assert "x = `backtick`" in blocks[0].content
 
 
-@pytest.mark.xfail(
-    reason="Known limitation: bare backticks after headers cause premature tool closure - Issue #658"
-)
 def test_save_with_structure_header_and_bare_backticks():
     """
     Common failure from autonomous run logs: save/append with content containing
@@ -851,9 +848,6 @@ Even more content here.
     assert "Even more content here" in content
 
 
-@pytest.mark.xfail(
-    reason="Known limitation: bare backticks after markdown headers cause premature tool closure - Issue #658"
-)
 def test_append_with_markdown_header_and_bare_backticks():
     """
     Another common failure from autonomous runs: append with markdown headers
@@ -886,9 +880,6 @@ More content that gets lost.
     assert "More content that gets lost" in content
 
 
-@pytest.mark.xfail(
-    reason="Known limitation: header-like structures followed by bare backticks - Issue #658"
-)
 def test_save_with_bold_text_and_bare_backticks():
     """
     Variation on the common failure: any header-like structure (bold text, markdown


### PR DESCRIPTION
## Summary

Three codeblock parser tests are now passing thanks to recent parser improvements (PR #711). This PR removes the `@pytest.mark.xfail` decorators from these tests.

## Tests Updated

- ✅ `test_save_with_structure_header_and_bare_backticks`
- ✅ `test_append_with_markdown_header_and_bare_backticks`
- ✅ `test_save_with_bold_text_and_bare_backticks`

All three tests validate proper handling of markdown headers followed by bare backticks, which were common failure modes in autonomous runs.

The fourth xfail test (`test_nested_with_same_language_tag`) remains marked as xfail as it still fails legitimately.

## Test Results

```
35 passed, 1 xfailed ✅
```

## Related

- Fixes #658 (partially - header cases resolved)
- Related to PR #711 (codeblock parser improvements)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `@pytest.mark.xfail` from three passing tests in `tests/test_codeblock.py` related to markdown headers and bare backticks.
> 
>   - **Tests Updated**:
>     - Remove `@pytest.mark.xfail` from `test_save_with_structure_header_and_bare_backticks`, `test_append_with_markdown_header_and_bare_backticks`, and `test_save_with_bold_text_and_bare_backticks` in `tests/test_codeblock.py`.
>     - These tests now pass due to parser improvements in handling markdown headers followed by bare backticks.
>   - **Tests Unchanged**:
>     - `test_nested_with_same_language_tag` remains marked as xfail due to legitimate failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 1138f969a45a92be16f240dde6e5ba9252b7db11. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->