### PR TITLE
fix(eval): set tool_format before LogManager.load()

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -74,6 +74,14 @@ def chat(
     # init
     init(model, interactive, tool_allowlist)
 
+    # tool_format should already be resolved by this point
+    assert (
+        tool_format is not None
+    ), "tool_format should be resolved before calling chat()"
+
+    # Set tool format early to ensure LogManager and hooks use correct format
+    set_tool_format(tool_format)
+
     # Trigger session start hooks
 
     if session_start_msgs := trigger_hook(
@@ -101,15 +109,6 @@ def chat(
     manager = LogManager.load(logdir, initial_msgs=initial_msgs, create=True)
 
     # Note: todowrite replay is now handled by the todo_replay tool via SESSION_START hook
-
-    # tool_format should already be resolved by this point
-    assert (
-        tool_format is not None
-    ), "tool_format should be resolved before calling chat()"
-
-    # By defining the tool_format at the last moment we ensure we can use the
-    # configuration for subagent
-    set_tool_format(tool_format)
 
     # Initialize workspace
     console.log(f"Using workspace: {path_with_tilde(workspace)}")


### PR DESCRIPTION
Fixes #419 - Evals were using markdown format even when xml format was specified.

Root cause: set_tool_format() was called after LogManager.load(), so message processing used default markdown format.

Solution: Move set_tool_format() to immediately after init(), before LogManager.load() is called.

This ensures eval runs with xml format actually use xml format, and token counts differ between formats.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix tool format setting in `chat.py` and improve handling of compound shell commands in `shell.py`, with tests added for verification.
> 
>   - **Behavior**:
>     - Move `set_tool_format(tool_format)` before `LogManager.load()` in `chat()` in `chat.py` to ensure correct tool format is used.
>     - Fix handling of compound shell commands (e.g., for loops, while loops) in `_run()` in `shell.py` by skipping `shlex` parsing for these commands.
>   - **Tests**:
>     - Add `test_shell_for_loop_issue724.py` to test execution of multiline shell commands like for loops and if statements.
>     - Add `test_tools_shell_multiline.py` to test `split_commands()` for keeping multiline commands intact.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 654772c3bb31acff07f2312270bbec1784156c56. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->