### PR TITLE
fix(tests): skip test_subagent for claude-haiku-4-5 due to timeout

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -355,7 +355,8 @@ def test_tmux(args: list[str], runner: CliRunner):
 @pytest.mark.requires_api
 @pytest.mark.flaky(retries=2, delay=5)
 @pytest.mark.skipif(
-    os.environ.get("MODEL") == "openai/gpt-4o-mini", reason="unreliable for gpt-4o-mini"
+    os.environ.get("MODEL") in ["openai/gpt-4o-mini", "anthropic/claude-haiku-4-5"],
+    reason="unreliable/slow for gpt-4o-mini and claude-haiku-4-5",
 )
 def test_subagent(args: list[str], runner: CliRunner):
     # f14: 377


### PR DESCRIPTION
Extracted from #720

Skip test_subagent for anthropic/claude-haiku-4-5 due to timeout issues.

The test already skips for openai/gpt-4o-mini for the same reason - both models struggle with this test's complexity, causing timeouts that block CI.

Closes #720
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Skip `test_subagent` for `anthropic/claude-haiku-4-5` in `tests/test_cli.py` due to timeout issues.
> 
>   - **Tests**:
>     - Skip `test_subagent` in `tests/test_cli.py` for `anthropic/claude-haiku-4-5` due to timeout issues, similar to existing skip for `openai/gpt-4o-mini`.
>     - Update skip reason to "unreliable/slow for gpt-4o-mini and claude-haiku-4-5".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 28fc27cabe56f339a60f242ebf627cb7cae73add. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->