### PR TITLE
fix: ensure MCP tools reload with updated config

### DIFF
--- a/gptme/config.py
+++ b/gptme/config.py
@@ -670,6 +670,12 @@ def reload_config() -> Config:
         _thread_local.config = Config.from_workspace(workspace=workspace)
     else:
         _thread_local.config = Config()
+
+    # Clear tools cache so MCP tools are recreated with new config
+    from gptme.tools import clear_tools
+
+    clear_tools()
+
     assert _thread_local.config
     return _thread_local.config
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -711,3 +711,23 @@ workspace = "{str(workspace)}"
         assert (
             config.chat.model != "openrouter/test-model"
         ), "Should not use saved model for new conversation"
+
+
+def test_reload_config_clears_tools(monkeypatch, tmp_path):
+    """Test that reload_config() clears the tools cache so MCP tools are recreated."""
+    from unittest.mock import MagicMock
+
+    from gptme.config import _thread_local, reload_config, Config
+
+    # Set up initial config
+    _thread_local.config = Config()
+
+    # Mock clear_tools in the tools module
+    mock_clear_tools = MagicMock()
+    monkeypatch.setattr("gptme.tools.clear_tools", mock_clear_tools)
+
+    # Call reload_config
+    reload_config()
+
+    # Verify clear_tools was called
+    assert mock_clear_tools.called, "reload_config() should call clear_tools()"


### PR DESCRIPTION
## Summary

Fixes #605

MCP tools were not being recreated when project/chat config was loaded via `Config.from_workspace()`, causing project-level MCP server configuration to be ignored.

## Changes

- Added `clear_tools()` call in `reload_config()` to invalidate the tools cache
- This ensures MCP tools are recreated with the full config (user + project + chat) instead of just user config
- Added test to verify that `reload_config()` properly clears the tools cache

## Technical Details

The issue occurred because:
1. User config is loaded first
2. Tools are initialized and cached (with user config only)
3. Project/chat config is loaded via `Config.from_workspace()`
4. `reload_config()` is called
5. ❌ MCP tools are NOT recreated (they're cached)

With this fix:
1. User config is loaded first
2. Tools are initialized and cached (with user config only)
3. Project/chat config is loaded via `Config.from_workspace()`
4. `reload_config()` is called
5. ✅ `clear_tools()` invalidates the cache
6. ✅ Next call to `get_available_tools()` recreates tools with full config

## Testing

- Added `test_reload_config_clears_tools` to verify the fix
- All existing config and MCP tests pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `clear_tools()` in `reload_config()` to ensure MCP tools reload with updated config, fixing issue #605.
> 
>   - **Behavior**:
>     - Adds `clear_tools()` call in `reload_config()` in `config.py` to invalidate tools cache, ensuring MCP tools are recreated with full config.
>     - Fixes issue where project-level MCP server configuration was ignored after `Config.from_workspace()`.
>   - **Testing**:
>     - Adds `test_reload_config_clears_tools` in `test_config.py` to verify `reload_config()` clears tools cache.
>     - All existing config and MCP tests pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 89cb19d0b9a5f353f8a412b078da236196c7812c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->