### PR TITLE
docs: complete /edit command demo documentation

### DIFF
--- a/docs/demos.rst
+++ b/docs/demos.rst
@@ -74,4 +74,37 @@ Steps
 
 .. rubric:: Edit history with /edit
 
-TODO
+The ``/edit`` command allows you to directly edit the conversation history in your text editor. This is useful for:
+
+- Fixing typos or mistakes in previous prompts
+- Removing unwanted messages
+- Restructuring conversation flow
+- Correcting errors before they cascade
+
+**How it works:**
+
+#. The conversation is converted to TOML format
+#. Your default editor (``$EDITOR``) opens the TOML file
+#. Edit the conversation as needed (add, remove, or modify messages)
+#. Save and close the editor
+#. gptme validates and applies your changes
+#. If there are parsing errors, you'll get a chance to fix them
+
+**Example use cases:**
+
+**Fixing a typo in a prompt:**
+   If you made a typo that confused the assistant, use ``/edit`` to correct it. The assistant will see the corrected version.
+
+**Removing a mistake:**
+   If the assistant misunderstood and went down the wrong path, use ``/edit`` to remove the problematic messages and restart from a good point.
+
+**Restructuring conversation:**
+   You can reorder messages, combine prompts, or split long conversations into cleaner structure.
+
+**Tips:**
+
+- The TOML format is human-readable and easy to edit
+- Each message has a ``role`` (user/assistant/system) and ``content``
+- Be careful with TOML syntax - gptme will validate before applying
+- Use ``/undo`` instead if you just want to undo the last message
+- Press ``Ctrl+C`` in the editor to cancel without making changes


### PR DESCRIPTION
## Summary

Completes the TODO in docs/demos.rst by adding comprehensive documentation for the `/edit` command.

## Changes

- Added description of what the `/edit` command does
- Documented the TOML editing workflow (step-by-step)
- Provided example use cases:
  - Fixing typos in prompts
  - Removing unwanted messages
  - Restructuring conversation flow
- Included helpful tips for users

## Why

The `/edit` command is a powerful feature that allows users to directly modify conversation history, but it was undocumented in the demos page. This documentation helps users understand when and how to use it effectively.

## Testing

- [x] Pre-commit hooks pass
- [x] Documentation renders correctly in RST format
- [x] Use cases are clear and actionable

Resolves the TODO at the end of docs/demos.rst
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Completes `/edit` command documentation in `docs/demos.rst`, detailing functionality, workflow, use cases, and editing tips.
> 
>   - **Documentation**:
>     - Completes `/edit` command documentation in `docs/demos.rst`.
>     - Describes `/edit` command functionality and TOML editing workflow.
>     - Provides example use cases: fixing typos, removing messages, restructuring conversation.
>     - Includes tips for editing and using TOML format.
>   - **Testing**:
>     - Ensures documentation renders correctly in RST format.
>     - Validates clarity and actionability of use cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 710edc76039314b54606da9cc8a48b40d34765ad. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->