### PR TITLE
fix(llm): update deepseek models context window to 128k

### DIFF
--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -245,14 +245,14 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
     # https://api-docs.deepseek.com/quick_start/pricing
     "deepseek": {
         "deepseek-chat": {
-            "context": 64_000,
+            "context": 128_000,
             "max_output": 8192,
             # 10x better price for cache hits
             "price_input": 0.14,
             "price_output": 1.1,
         },
         "deepseek-reasoner": {
-            "context": 64_000,
+            "context": 128_000,
             "max_output": 8192,
             "price_input": 0.55,
             "price_output": 2.19,


### PR DESCRIPTION
Both deepseek-chat and deepseek-reasoner now support 128,000 token context window as of 2025.

**Changes:**
- Updated deepseek-chat context from 64,000 to 128,000 tokens
- Updated deepseek-reasoner context from 64,000 to 128,000 tokens

**Research:**
Verified via Perplexity that DeepSeek models (including V3.x) support 128K context window as of 2025. This applies to both the chat and reasoning models.

**Reference:**
- https://api-docs.deepseek.com/quick_start/pricing

Fixes #741
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `deepseek-chat` and `deepseek-reasoner` context window to 128,000 tokens in `gptme/llm/models.py`.
> 
>   - **Behavior**:
>     - Updated `deepseek-chat` and `deepseek-reasoner` context window from 64,000 to 128,000 tokens in `gptme/llm/models.py`.
>   - **Research**:
>     - Verified DeepSeek models support 128K context window as of 2025.
>   - **Reference**:
>     - Fixes #741.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 9961f1c3103d2dd9b9173fa2ec9b53c99f027a31. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->