### PR TITLE
fix(tools): add support for Haiku 4.5 XML format

### DIFF
--- a/tests/test_xml_format.py
+++ b/tests/test_xml_format.py
@@ -1,0 +1,68 @@
+"""Test XML tool format parsing for both gptme and Haiku formats."""
+
+from gptme.tools.base import ToolUse
+
+
+def test_gptme_xml_format():
+    """Test original gptme XML format: <tool-use><toolname>...</toolname></tool-use>"""
+    content = """
+<tool-use>
+<complete>
+</complete>
+</tool-use>
+"""
+    tools = list(ToolUse._iter_from_xml(content))
+    assert len(tools) == 1
+    assert tools[0].tool == "complete"
+    assert tools[0].content == ""
+
+
+def test_haiku_xml_format():
+    """Test Haiku 4.5 XML format: <function_calls><invoke name="toolname">...</invoke></function_calls>"""
+    content = """
+<function_calls>
+<invoke name="complete">
+</invoke>
+</function_calls>
+"""
+    tools = list(ToolUse._iter_from_xml(content))
+    assert len(tools) == 1
+    assert tools[0].tool == "complete"
+    assert tools[0].content == ""
+
+
+def test_both_xml_formats_coexist():
+    """Test that both gptme and Haiku XML formats can coexist in same content."""
+    content = """
+<tool-use>
+<shell>
+echo "test1"
+</shell>
+</tool-use>
+
+<function_calls>
+<invoke name="complete">
+</invoke>
+</function_calls>
+"""
+    tools = list(ToolUse._iter_from_xml(content))
+    assert len(tools) == 2
+    assert tools[0].tool == "shell"
+    assert tools[0].content == 'echo "test1"'
+    assert tools[1].tool == "complete"
+    assert tools[1].content == ""
+
+
+def test_haiku_format_with_content():
+    """Test Haiku format with actual content."""
+    content = """
+<function_calls>
+<invoke name="ipython">
+print("Hello, world!")
+</invoke>
+</function_calls>
+"""
+    tools = list(ToolUse._iter_from_xml(content))
+    assert len(tools) == 1
+    assert tools[0].tool == "ipython"
+    assert tools[0].content == 'print("Hello, world!")'


### PR DESCRIPTION
## Problem

Issue #749: Haiku 4.5 produces XML tool calls in a different format than gptme expects:

**Haiku produces**:
```xml
<function_calls>
<invoke name="complete">
</invoke>
</function_calls>
```

**gptme expects**:
```xml
<tool-use>
<complete>
</complete>
</tool-use>
```

This causes tool calls to be ignored, making Haiku 4.5 "very unreliable with XML format".

## Solution

Extended `_iter_from_xml()` in `gptme/tools/base.py` to parse both formats:
1. Original gptme format: `<tool-use><toolname>...`
2. Haiku format: `<function_calls><invoke name="toolname">...`

Both formats can now coexist in the same content, ensuring backward compatibility.

## Testing

Added comprehensive test suite in `tests/test_xml_format.py`:
- ✅ gptme format parsing
- ✅ Haiku format parsing  
- ✅ Both formats coexisting
- ✅ Content extraction for both formats

## Impact

- **Backward compatible**: Existing XML format still works
- **Haiku 4.5 support**: Now works reliably with XML format
- **Future-proof**: Can handle mixed format scenarios

Fixes #749