### PR TITLE
fix: fix anthropic non-streaming requests being denied during auto renames

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -327,6 +327,8 @@ def _process_message_conversation(
                         chat_config.name = display_name
                         chat_config.save()
                         logger.info(f"Auto-generated conversation name: {display_name}")
+                    else:
+                        logger.warning("Auto-naming failed")
                 except Exception as e:
                     logger.warning(f"Failed to auto-generate name: {e}")
 

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -233,6 +233,9 @@ def chat(messages: list[Message], model: str, tools: list[ToolSpec] | None) -> s
             if use_thinking
             else NOT_GIVEN
         ),
+        # We set a timeout for non-streaming requests to prevent Anthropic's
+        # "Streaming is strongly recommended" warning/error.
+        timeout=60,
     )
     content = response.content
     _record_usage(response.usage, model)

--- a/gptme/util/auto_naming.py
+++ b/gptme/util/auto_naming.py
@@ -97,7 +97,7 @@ def _generate_llm_name(
                 summary_model_name = get_summary_model(current_model.provider)
                 naming_model = f"{current_model.provider}/{summary_model_name}"
         except Exception:
-            pass
+            logger.exception("exception during auto-name")
 
         # Create context from recent messages
         context = ""
@@ -109,6 +109,7 @@ def _generate_llm_name(
                 context += f"{msg.role.title()}: {content}\n"
 
         if not context.strip():
+            logger.warning("no context for auto-name")
             return None
 
         # Create prompt based on format
@@ -166,7 +167,7 @@ Title:"""
             response = response[think_end + len("</think>") :]
         elif "<think>" in response:
             # Incomplete think tag, skip this response
-            logger.debug("Incomplete think tag in response, skipping")
+            logger.warning("Incomplete think tag in response, skipping")
             return None
 
         name = response.strip().strip('"').strip("'").split("\n")[0][:50]
@@ -174,7 +175,7 @@ Title:"""
             return name
 
     except Exception as e:
-        logger.debug(f"LLM naming failed: {e}")
+        logger.warning(f"LLM naming failed: {e}")
 
     return None
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set timeout for non-streaming requests and improve logging for auto-naming failures.
> 
>   - **Behavior**:
>     - Set a 60-second timeout for non-streaming requests in `chat()` in `llm_anthropic.py` to prevent Anthropic's warning/error about streaming.
>     - Log a warning if auto-naming fails in `_process_message_conversation()` in `chat.py`.
>   - **Logging**:
>     - Change log level from `debug` to `warning` for incomplete think tag and LLM naming failures in `_generate_llm_name()` in `auto_naming.py`.
>     - Add warning for no context in `_generate_llm_name()` in `auto_naming.py`.
>   - **Misc**:
>     - Add warning for auto-naming failure in `_process_message_conversation()` in `chat.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 509a2712d45b0c6b6bcf55e603f8c6af3032bfad. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->