### PR TITLE
fix(hooks): make TOOL_POST_EXECUTE hook consistent with other hooks

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -467,7 +467,7 @@ def step(
         # log response and run tools
         if msg_response:
             yield msg_response.replace(quiet=True)
-            yield from execute_msg(msg_response, confirm)
+            yield from execute_msg(msg_response, confirm, log, workspace)
 
         # Reset interrupt flag after successful completion
         _recently_interrupted = False

--- a/gptme/commands.py
+++ b/gptme/commands.py
@@ -276,7 +276,9 @@ def cmd_replay(ctx: CommandContext) -> None:
         print(f"Replaying all {len(assistant_messages)} assistant messages...")
 
     for msg in messages_to_replay:
-        for reply_msg in execute_msg(msg, ctx.confirm):
+        for reply_msg in execute_msg(
+            msg, ctx.confirm, ctx.manager.log, None, ctx.manager
+        ):
             print_msg(reply_msg, oneline=False)
 
 
@@ -337,7 +339,13 @@ def cmd_impersonate(ctx: CommandContext) -> Generator[Message, None, None]:
     content = ctx.full_args if ctx.full_args else input("[impersonate] Assistant: ")
     msg = Message("assistant", content)
     yield msg
-    yield from execute_msg(msg, confirm=lambda _: True)
+    yield from execute_msg(
+        msg,
+        confirm=lambda _: True,
+        log=ctx.manager.log,
+        workspace=None,
+        manager=ctx.manager,
+    )
 
 
 @command("tokens")

--- a/gptme/server/api.py
+++ b/gptme/server/api.py
@@ -288,7 +288,9 @@ def api_conversation_generate(logfile: str):
             manager.append(msg)
 
             # Execute any tools
-            reply_msgs = list(execute_msg(msg, confirm_func))
+            reply_msgs = list(
+                execute_msg(msg, confirm_func, manager.log, None, manager)
+            )
             for reply_msg in reply_msgs:
                 manager.append(reply_msg)
 
@@ -355,7 +357,9 @@ def api_conversation_generate(logfile: str):
             yield f"data: {flask.json.dumps({'role': 'assistant', 'content': output, 'stored': True})}\n\n"
 
             # Execute any tools and stream their output
-            tool_replies = list(execute_msg(msg, confirm_func))
+            tool_replies = list(
+                execute_msg(msg, confirm_func, manager.log, None, manager)
+            )
             for reply_msg in tool_replies:
                 logger.debug(
                     f"Tool output: {reply_msg.role} - {reply_msg.content[:100]}..."

--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -22,6 +22,7 @@ import json_repair
 from lxml import etree
 
 from ..codeblock import Codeblock
+from ..logmanager import Log, LogManager
 from ..message import Message
 from ..util import clean_example, transform_examples_to_chat_directives
 
@@ -322,7 +323,13 @@ class ToolUse:
     start: int | None = None
     _format: ToolFormat | None = "markdown"
 
-    def execute(self, confirm: ConfirmFunc) -> Generator[Message, None, None]:
+    def execute(
+        self,
+        confirm: ConfirmFunc,
+        log: "Log | None" = None,
+        workspace: "Path | None" = None,
+        manager: "LogManager | None" = None,
+    ) -> Generator[Message, None, None]:
         """Executes a tool-use tag and returns the output."""
         # noreorder
         from ..hooks import HookType, trigger_hook  # fmt: skip
@@ -388,6 +395,9 @@ class ToolUse:
                     # Trigger post-execution hooks
                     if post_hook_msgs := trigger_hook(
                         HookType.TOOL_POST_EXECUTE,
+                        log=log,
+                        workspace=workspace,
+                        manager=manager,
                         tool_name=self.tool,
                         tool_use=self,
                     ):


### PR DESCRIPTION
## Problem

Currently, hooks receive different context depending on their type:
- `MESSAGE_POST_PROCESS`: Receives `log`, `workspace`, `manager`
- `TOOL_POST_EXECUTE`: Only receives `tool_name` and `tool_use`

This inconsistency prevents awareness tools from accessing conversation state during individual tool executions.

## Changes

- ✅ Add `log`, `workspace`, `manager` parameters to `ToolUse.execute()`
- ✅ Update `execute_msg()` to accept and pass these parameters
- ✅ Update `TOOL_POST_EXECUTE` trigger to pass all context
- ✅ Update all `execute_msg()` call sites to pass available context
- ✅ Maintain backward compatibility with optional parameters

## Benefits

- Enables awareness tools (token/time) to provide feedback after individual tool executions
- Makes hook system more consistent and predictable
- Reduces coupling between hook types and their capabilities

## Testing

- All pre-commit hooks pass (ruff, mypy, formatting)
- Backward compatible - existing calls work without changes
- New parameters are optional, preserving existing behavior

## Related

- Fixes #748
- Related to #665 (Token and time awareness tools)

Co-authored-by: Bob <bob@superuserlabs.org>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `log`, `workspace`, `manager` parameters to `ToolUse.execute()` and update `execute_msg()` to make `TOOL_POST_EXECUTE` hook consistent with other hooks.
> 
>   - **Behavior**:
>     - Add `log`, `workspace`, `manager` parameters to `ToolUse.execute()` in `base.py`.
>     - Update `execute_msg()` in `__init__.py` to accept and pass these parameters.
>     - Update `TOOL_POST_EXECUTE` trigger to pass all context in `base.py`.
>     - Update all `execute_msg()` call sites in `chat.py`, `commands.py`, and `api.py` to pass available context.
>     - Maintain backward compatibility with optional parameters.
>   - **Testing**:
>     - All pre-commit hooks pass (ruff, mypy, formatting).
>     - Backward compatible - existing calls work without changes.
>     - New parameters are optional, preserving existing behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for c2a8810a892495a5c94c1ab729ea84a1b3c7be9d. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->