### PR TITLE
fix: convert GEPA output_dir to absolute path

### DIFF
--- a/gptme/eval/dspy/experiments.py
+++ b/gptme/eval/dspy/experiments.py
@@ -259,7 +259,7 @@ class OptimizationExperiment:
     def __init__(self, name: str, output_dir: Path, model: str, dry_run: bool = False):
         self.name = name
         self.model = model
-        self.output_dir = output_dir
+        self.output_dir = output_dir.resolve()  # Convert to absolute path
         self.dry_run = dry_run
         self.output_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
Fixes #783

## Problem

GEPA experiments failed when trying to write results because `output_dir` was a relative path (`Path('experiments')`). When gptme changes working directory during test execution, relative paths become invalid, causing FileNotFoundError.

## Solution

Convert `output_dir` to absolute path using `.resolve()` in `OptimizationExperiment.__init__`. This ensures the path always points to the correct location regardless of working directory changes.

## Testing

Use existing `--dry-run` flag for quick validation without API cost:
```bash
poetry run python -m gptme.eval.dspy optimize-gepa --name test --train-size 5 --val-size 5 --dry-run
```

The fix is minimal and surgical - just one line change to make paths absolute.

## Impact

- ✅ GEPA experiments can now complete without FileNotFoundError
- ✅ Lost results from Phase 3.3 can be recovered by re-running
- ✅ No API changes or breaking changes
- ✅ Works with existing --dry-run testing
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Convert `output_dir` to absolute path in `OptimizationExperiment` to prevent errors from working directory changes.
> 
>   - **Behavior**:
>     - Convert `output_dir` to absolute path using `.resolve()` in `OptimizationExperiment.__init__` to prevent `FileNotFoundError` when working directory changes.
>   - **Impact**:
>     - Ensures GEPA experiments complete without errors related to invalid paths.
>     - Allows recovery of lost results by re-running experiments.
>     - No API or breaking changes; compatible with existing `--dry-run` testing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 8ff297e9220baf3081276179b405759a3ba3bea7. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->