### PR TITLE
fix(tests): update test_auto_compact.py for timestamp-based naming

### DIFF
--- a/tests/test_auto_compact.py
+++ b/tests/test_auto_compact.py
@@ -9,7 +9,7 @@ import pytest
 from gptme.llm.models import get_default_model, get_model
 from gptme.message import Message, len_tokens
 from gptme.tools.autocompact import (
-    _get_backup_name,
+    _get_compacted_name,
     auto_compact_log,
     should_auto_compact,
 )
@@ -161,97 +161,97 @@ def test_auto_compact_preserves_pinned_messages():
     assert compacted[2].pinned
 
 
-def test_get_backup_name_no_suffix():
-    """Test backup name generation for conversation without existing suffix."""
+def test_get_compacted_name_no_suffix():
+    """Test compacted name generation for conversation without existing suffix."""
     import re
 
-    name = _get_backup_name("2025-10-13-flying-yellow-alien")
-    # Should match: base-name-before-compact-XXXX where XXXX is 4 hex chars
-    assert re.match(
-        r"^2025-10-13-flying-yellow-alien-before-compact-[0-9a-f]{4}$", name
-    )
+    name = _get_compacted_name("2025-10-13-flying-yellow-alien")
+    # Should match: base-name-compacted-YYYYMMDD-HHMMSS
+    assert re.match(r"^2025-10-13-flying-yellow-alien-compacted-\d{8}-\d{6}$", name)
 
 
-def test_get_backup_name_one_suffix():
-    """Test backup name generation when suffix already exists (gets new unique suffix)."""
+def test_get_compacted_name_one_suffix():
+    """Test compacted name generation when suffix already exists (gets new unique suffix)."""
     import re
 
-    name = _get_backup_name("2025-10-13-flying-yellow-alien-before-compact")
-    # Should strip old suffix and add new one with random suffix
-    assert re.match(
-        r"^2025-10-13-flying-yellow-alien-before-compact-[0-9a-f]{4}$", name
+    name = _get_compacted_name(
+        "2025-10-13-flying-yellow-alien-compacted-20251028-120000"
     )
+    # Should strip old timestamp suffix and add new timestamp
+    assert re.match(r"^2025-10-13-flying-yellow-alien-compacted-\d{8}-\d{6}$", name)
 
 
-def test_get_backup_name_multiple_suffixes():
-    """Test backup name generation with multiple accumulated suffixes (should strip all)."""
+def test_get_compacted_name_multiple_suffixes():
+    """Test compacted name generation with multiple accumulated timestamp suffixes (should strip all)."""
     import re
 
-    name = _get_backup_name(
-        "2025-10-13-flying-yellow-alien-before-compact-before-compact-before-compact"
+    name = _get_compacted_name(
+        "2025-10-13-flying-yellow-alien-compacted-20251027-100000-compacted-20251028-110000-compacted-20251028-120000"
     )
-    assert re.match(
-        r"^2025-10-13-flying-yellow-alien-before-compact-[0-9a-f]{4}$", name
-    )
+    assert re.match(r"^2025-10-13-flying-yellow-alien-compacted-\d{8}-\d{6}$", name)
 
 
-def test_get_backup_name_edge_cases():
-    """Test backup name generation with various edge cases."""
+def test_get_compacted_name_edge_cases():
+    """Test compacted name generation with various edge cases."""
     import re
 
     # Short name
-    name = _get_backup_name("conv")
-    assert re.match(r"^conv-before-compact-[0-9a-f]{4}$", name)
+    name = _get_compacted_name("conv")
+    assert re.match(r"^conv-compacted-\d{8}-\d{6}$", name)
 
     # Name containing 'compact' but not as suffix
-    name = _get_backup_name("compact-test")
-    assert re.match(r"^compact-test-before-compact-[0-9a-f]{4}$", name)
+    name = _get_compacted_name("compact-test")
+    assert re.match(r"^compact-test-compacted-\d{8}-\d{6}$", name)
 
     # Name ending with similar but different suffix
-    name = _get_backup_name("test-before-compaction")
-    assert re.match(r"^test-before-compaction-before-compact-[0-9a-f]{4}$", name)
+    name = _get_compacted_name("test-before-compaction")
+    assert re.match(r"^test-before-compaction-compacted-\d{8}-\d{6}$", name)
 
 
-def test_get_backup_name_uniqueness():
-    """Test that multiple calls produce unique backup names."""
-    name1 = _get_backup_name("my-conversation")
-    name2 = _get_backup_name("my-conversation")
-    name3 = _get_backup_name("my-conversation")
+def test_get_compacted_name_uniqueness():
+    """Test that multiple calls produce unique compacted names with timestamps."""
+    import time
 
-    # All should have the same base but different random suffixes
+    name1 = _get_compacted_name("my-conversation")
+    time.sleep(1.1)  # Ensure different second for timestamp
+    name2 = _get_compacted_name("my-conversation")
+    time.sleep(1.1)  # Ensure different second for timestamp
+    name3 = _get_compacted_name("my-conversation")
+
+    # All should have the same base but different timestamps
     assert name1 != name2
     assert name2 != name3
     assert name1 != name3
 
-    # All should start with the same base
-    assert name1.startswith("my-conversation-before-compact-")
-    assert name2.startswith("my-conversation-before-compact-")
-    assert name3.startswith("my-conversation-before-compact-")
+    # All should have compacted suffix with timestamp
+    assert name1.startswith("my-conversation-compacted-")
+    assert name2.startswith("my-conversation-compacted-")
+    assert name3.startswith("my-conversation-compacted-")
 
 
-def test_get_backup_name_with_hex_suffix():
-    """Test that backup names with hex suffixes are correctly stripped.
+def test_get_compacted_name_with_hex_suffix():
+    """Test that compacted names with timestamp suffixes are correctly stripped.
 
     This is a regression test for the bug where:
-    "my-conversation-before-compact-a7c9" would become
-    "my-conversation-before-compact-a7c9-before-compact-k2p5"
+    "my-conversation-compacted-20251028-120000" would become
+    "my-conversation-compacted-20251028-120000-compacted-20251029-130000"
     instead of
-    "my-conversation-before-compact-k2p5"
+    "my-conversation-compacted-20251029-140000"
     """
     import re
 
     # Test with a backup that has a valid hex suffix (only 0-9a-f)
-    name = _get_backup_name("my-conversation-before-compact-a7c9")
+    name = _get_compacted_name("my-conversation-compacted-20251028-120000")
     # Should strip the old suffix and add a new one
-    assert re.match(r"^my-conversation-before-compact-[0-9a-f]{4}$", name)
-    # Should NOT contain the old hex suffix
-    assert "a7c9" not in name
+    assert re.match(r"^my-conversation-compacted-\d{8}-\d{6}$", name)
+    # Should NOT contain the old timestamp
+    assert "20251028-120000" not in name
 
 
-def test_get_backup_name_empty_string():
-    """Test backup name generation with empty string raises ValueError."""
+def test_get_compacted_name_empty_string():
+    """Test compacted name generation with empty string raises ValueError."""
     with pytest.raises(ValueError, match="conversation name cannot be empty"):
-        _get_backup_name("")
+        _get_compacted_name("")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The `_get_compacted_name()` function was changed from hex-suffix naming (`-before-compact-XXXX`) to timestamp-based naming (`-compacted-YYYYMMDD-HHMMSS`) in #693, but the tests in `test_auto_compact.py` weren't updated to match.

This caused 6 test failures in PR #776 (constrained decoding).

## Solution

Updated all tests to match the new timestamp-based naming convention:

- ✅ Updated all regex patterns: `-before-compact-[0-9a-f]{4}` → `-compacted-\d{8}-\d{6}`
- ✅ Updated test docstrings and comments
- ✅ Added `time.sleep(1.1)` in uniqueness test to ensure different timestamps
- ✅ Fixed all references to old naming convention

## Testing

All 14 tests now pass:
```
============================== 14 passed in 3.18s ==============================
```

## Related

- Fixes test failures in #776
- Related to #693 (autocompact name mutation fix)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `test_auto_compact.py` to match new timestamp-based naming convention for `_get_compacted_name` function.
> 
>   - **Behavior**:
>     - Updated regex patterns in `test_auto_compact.py` from `-before-compact-[0-9a-f]{4}` to `-compacted-\d{8}-\d{6}`.
>     - Added `time.sleep(1.1)` in uniqueness test to ensure different timestamps.
>     - Fixed all references to old naming convention.
>   - **Tests**:
>     - Renamed test functions to reflect `_get_compacted_name` instead of `_get_backup_name`.
>     - Updated test docstrings and comments to match new naming convention.
>   - **Misc**:
>     - All 14 tests now pass, fixing failures in #776.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 090049e8b8af849f8d35a02ee5b789495c8e1b21. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->