### PR TITLE
fix(shell): handle bashlex parsing errors for bash builtins like 'time'

### DIFF
--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -247,6 +247,32 @@ EOF"""
     assert '<<"EOF"' in commands[0]
 
 
+def test_split_commands_bash_reserved_words():
+    """Test that split_commands handles bash reserved words that bashlex can't parse.
+
+    bashlex cannot parse bash reserved words like 'time' and will raise an exception.
+    In these cases, split_commands should gracefully fall back to treating the
+    script as a single command.
+    """
+    # Test 'time' reserved word
+    script_time = "time ls -la"
+    commands = split_commands(script_time)
+    assert len(commands) == 1
+    assert commands[0] == script_time
+
+    # Test 'time' with more complex command
+    script_time_pipeline = "time ls -la | grep test"
+    commands = split_commands(script_time_pipeline)
+    assert len(commands) == 1
+    assert commands[0] == script_time_pipeline
+
+    # Test 'time' with redirection
+    script_time_redirect = "time echo 'test' > output.txt"
+    commands = split_commands(script_time_redirect)
+    assert len(commands) == 1
+    assert commands[0] == script_time_redirect
+
+
 def test_function(shell):
     script = """
 function hello() {


### PR DESCRIPTION
## Summary

Fixes #798 - Shell tool failing on bash reserved words like `time` command.

## Problem

The shell tool's `split_commands()` function uses bashlex to parse commands. However, bashlex doesn't support bash reserved words like `time`, causing errors:

```
Error during execution: Shell error: type = {time command}, token = {time}
```

## Solution

Added error handling to `split_commands()` to gracefully fall back when bashlex can't parse:
- Wraps `bashlex.parse()` in try-except block
- Falls back to treating script as single command if parsing fails
- Logs warning about fallback

This follows the same pattern used for shlex parsing elsewhere in the file (line 300).

## Testing

The fix allows commands like:
- `time ls`
- `time python -c "print(42)"`

While preserving existing multi-command splitting for normal commands.

## Changes

- Modified `gptme/tools/shell.py` - Added error handling to `split_commands()`
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes bash reserved word parsing errors in `split_commands()` by treating unparseable scripts as single commands and adds tests for `time` command handling.
> 
>   - **Behavior**:
>     - `split_commands()` in `shell.py` now handles bash reserved words like `time` by treating the script as a single command if `bashlex` parsing fails.
>     - Logs a warning when falling back to single command parsing.
>   - **Testing**:
>     - Added `test_split_commands_bash_reserved_words()` in `test_tools_shell.py` to verify handling of `time` command and similar cases.
>     - Ensures commands like `time ls` and `time echo 'test' > output.txt` are processed correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 90bcc183d88386944e112a662134ca276579f3ec. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->