### PR TITLE
feat(hooks): improve typing for hook registration and triggering

### DIFF
--- a/gptme/tools/precommit.py
+++ b/gptme/tools/precommit.py
@@ -43,7 +43,7 @@ from ..util.context import md_codeblock
 from .base import ToolSpec
 
 if TYPE_CHECKING:
-    from ..logmanager import LogManager
+    from ..logmanager import Log, LogManager
 
 logger = logging.getLogger(__name__)
 
@@ -188,10 +188,11 @@ def handle_precommit_command(ctx: CommandContext) -> Generator[Message, None, No
 
 
 def run_precommit_on_file(
+    log: "Log | None",
+    workspace: Path | None,
     path: Path,
     content: str,
     created: bool = False,
-    **kwargs,
 ) -> Generator[Message, None, None]:
     """Hook function that runs pre-commit on saved files.
 


### PR DESCRIPTION
Fixes #766

Improves type safety for the hook system by ensuring Protocol definitions match actual trigger calls and adding type-safe registration via overload declarations.

See commit message for detailed changes.

All pre-commit hooks pass including mypy.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance type safety for hook registration and triggering in `gptme/hooks.py` by adding type-safe overloads and updating protocol definitions.
> 
>   - **Type Safety Enhancements**:
>     - Add type-safe overloads for `register_hook()` in `gptme/hooks.py` to ensure hooks match expected protocol signatures.
>     - Introduce `FilePreSaveHook` and update `FilePostSaveHook` to include `log` and `workspace` parameters.
>   - **Protocol Definitions**:
>     - Add `FilePreSaveHook` protocol in `gptme/hooks.py` for pre-save file operations.
>     - Update `FilePostSaveHook` protocol to include additional parameters for type safety.
>   - **Miscellaneous**:
>     - Minor type import change in `gptme/tools/precommit.py` (`Log` added to TYPE_CHECKING imports).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for c4463e4a7d47f51b75c402016d614c70006d3496. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->