### PR TITLE
fix(eval): run gptme agent inside Docker when --use-docker is used

### DIFF
--- a/gptme/eval/main.py
+++ b/gptme/eval/main.py
@@ -98,7 +98,7 @@ def docker_reexec(argv: list[str]) -> None:
         "run",
         "--rm",
         "-v",
-        # use seperate config dir for gptme-eval (only stores API keys)
+        # use separate config dir for gptme-eval (only stores API keys)
         f"{Path.home()}/.config/gptme-eval:/home/appuser/.config/gptme",
         "-v",
         f"{git_root}/eval_results:/app/eval_results",


### PR DESCRIPTION
## Problem

Issue ErikBjare/bob#89 reported that `--use-docker` only runs verification steps in Docker, while the actual gptme agent runs on the host, causing git config pollution.

**Root Cause**: The current implementation creates `DockerExecutionEnv` in the `execute()` function AFTER the agent has already run via `act_process()`. This means:
- `agent.act()` runs directly on HOST
- `gptme_chat()` and all tools execute on HOST (causing git config pollution)
- Only verification/artifact checking happens in Docker

## Solution

This PR implements Docker re-execution at the entry point:

1. **Detection**: Check if already running inside Docker (reads `/proc/1/cgroup`)
2. **Re-execution**: If `--use-docker` and not in Docker, re-execute entire command inside container
3. **Isolation**: Mount config, results, and source code into container
4. **Transparency**: Exit with same return code, seamless to caller

### Implementation

Added two helper functions to `gptme/eval/main.py`:
- `in_docker()`: Detects Docker environment via cgroup
- `docker_reexec()`: Builds/checks image, constructs docker run command, re-executes

Modified `main()` to check and re-execute before any eval logic runs.

## Benefits

- ✅ **Complete isolation**: Entire agent execution happens in Docker
- ✅ **No git config pollution**: Host environment protected
- ✅ **Simple API**: Same `--use-docker` flag, now works correctly
- ✅ **Backward compatible**: Works without Docker when flag not set
- ✅ **Safe**: Prevents infinite recursion via Docker detection

## Testing

- [x] Syntax check passes
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [ ] Runtime test with `gptme-eval hello --model <model> --use-docker`
- [ ] Verify git config preserved on host

Fixes ErikBjare/bob#89
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure gptme agent runs inside Docker when `--use-docker` is used by modifying `main()` in `gptme/eval/main.py`.
> 
>   - **Behavior**:
>     - `main()` in `gptme/eval/main.py` modified to re-execute command inside Docker if `--use-docker` is set and not already in Docker.
>     - Adds `in_docker()` to detect Docker environment and `docker_reexec()` to handle Docker execution.
>   - **Implementation**:
>     - `docker_reexec()` builds/checks Docker image, mounts necessary directories, and re-executes command inside Docker.
>     - Ensures seamless exit with the same return code as the original command.
>   - **Benefits**:
>     - Full isolation of agent execution in Docker, preventing host git config pollution.
>     - Maintains backward compatibility when `--use-docker` is not set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 142be9ba592a108281d08de3ed7f8c81c1e2fb30. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->