### PR TITLE
fix: fix session start hook msgs not being persisted

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -94,7 +94,7 @@ def chat(
     ):
         # Process any messages from session start hooks
         for hook_msg in session_start_msgs:
-            console.log(f"[Session start hook] {hook_msg.content[:100]}...")
+            initial_msgs = initial_msgs + [hook_msg]
 
     default_model = get_default_model()
     assert default_model is not None, "No model loaded and no model specified"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes issue in `chat()` in `chat.py` to ensure session start hook messages are added to `initial_msgs`.
> 
>   - **Behavior**:
>     - Fixes issue in `chat()` in `chat.py` where session start hook messages were not being added to `initial_msgs`, ensuring they are persisted and processed correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 8021621710975bc04865b4e0a169afaadef9c1e3. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->