### PR TITLE
fix(server): add GPTME_DISABLE_AUTH env var for k8s deployments

### DIFF
--- a/gptme/server/auth.py
+++ b/gptme/server/auth.py
@@ -178,6 +178,23 @@ def init_auth(host: str = "127.0.0.1", display: bool = True) -> str | None:
     """
     global _auth_enabled
 
+    # Check if auth is explicitly disabled via environment variable
+    if os.environ.get("GPTME_DISABLE_AUTH", "").lower() in ("true", "1", "yes"):
+        _auth_enabled = False
+        if display:
+            logger.info("=" * 60)
+            logger.info("gptme-server (Auth Disabled)")
+            logger.info("=" * 60)
+            logger.info(f"Binding to: {host}")
+            logger.info("Authentication: DISABLED (via GPTME_DISABLE_AUTH)")
+            logger.info("")
+            logger.info("⚠️  WARNING: Server is accessible without authentication!")
+            logger.info(
+                "Only use this in environments with external auth (e.g., k8s ingress)"
+            )
+            logger.info("=" * 60)
+        return None
+
     # Disable auth for local-only binding
     if is_local_host(host):
         _auth_enabled = False

--- a/scripts/Dockerfile.server
+++ b/scripts/Dockerfile.server
@@ -20,6 +20,10 @@ WORKDIR /workspace
 # Expose the server port
 EXPOSE 5700
 
+# Note: Server binds to 0.0.0.0 which enables authentication by default.
+# Set GPTME_DISABLE_AUTH=true to disable auth in environments with external auth (e.g., k8s ingress).
+# Set GPTME_SERVER_TOKEN=xxx to configure a specific auth token.
+
 # Add healthcheck
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:5700/ || exit 1


### PR DESCRIPTION
Fixes issue where k8s instances failed with 401 errors after enabling authentication for network binding.

## Problem
- Docker server binds to `0.0.0.0` which triggers auth
- K8s instances have no `GPTME_SERVER_TOKEN` configured
- All requests fail with 401 Unauthorized
- K8s deployments already have ingress/auth layers

## Solution
Added `GPTME_DISABLE_AUTH` environment variable to allow disabling built-in auth in environments with external authentication.

## Changes
- Added `GPTME_DISABLE_AUTH` check in `init_auth()`
- Documented in `Dockerfile.server`
- Added test coverage for disabled auth mode
- Updated k8s startup script (separate PR needed in gptme-infra)

## Testing
- All existing auth tests pass
- New test verifies auth can be disabled via env var
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `GPTME_DISABLE_AUTH` env var to disable auth in `gptme/server/auth.py`, documented in `Dockerfile.server`, with new test in `test_server_auth.py`.
> 
>   - **Behavior**:
>     - Adds `GPTME_DISABLE_AUTH` environment variable to disable authentication in `init_auth()` in `gptme/server/auth.py`.
>     - Logs a warning when auth is disabled, advising use only in environments with external auth.
>   - **Documentation**:
>     - Documents `GPTME_DISABLE_AUTH` usage in `scripts/Dockerfile.server`.
>   - **Testing**:
>     - Adds `test_auth_disabled_via_env()` in `tests/test_server_auth.py` to verify auth can be disabled via the environment variable.
>     - All existing auth tests pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 3eefe2b34259b74209f6a7648cd559c71a50641c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->