### PR TITLE
fix(eval): add defensive check for eval_result in task_success_metric

### DIFF
--- a/gptme/eval/dspy/metrics.py
+++ b/gptme/eval/dspy/metrics.py
@@ -234,6 +234,9 @@ def create_task_success_metric(
 
         Returns a score between 0 and 1 indicating success rate.
         """
+        if not hasattr(pred, "eval_result") or not pred.eval_result:
+            return 0.0
+
         result: EvalResult = pred.eval_result  # type: ignore
 
         # Calculate success rate based on passed expectations


### PR DESCRIPTION
Adds defensive check to prevent AttributeError when eval_result is not set on Prediction objects.

## Problem

`task_success_metric` directly accesses `pred.eval_result` without checking if it exists, causing:
```
AttributeError: 'Prediction' object has no attribute 'eval_result'
```

This happens when `GptmeModule.forward()` fails early (e.g., missing API keys) and returns a Prediction without `eval_result` set.

## Solution

Add the same defensive check that `trajectory_feedback_metric` already has:
```python
if not hasattr(pred, "eval_result") or not pred.eval_result:
    return 0.0
```

## Testing

Encountered this during GEPA Test 2 execution when API keys were not properly passed to the tmux session.

Co-authored-by: Bob <bob@superuserlabs.org>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add defensive check in `task_success_metric` and introduce task management with `Task` and `TaskLoader` classes.
> 
>   - **Behavior**:
>     - Add defensive check in `task_success_metric` in `metrics.py` to prevent `AttributeError` when `eval_result` is missing on `Prediction` objects.
>     - Returns `0.0` if `eval_result` is not set, similar to `trajectory_feedback_metric`.
>   - **Task Management**:
>     - Introduce `Task` and `TaskLoader` classes in `loader.py` for task management and loading.
>     - `TaskLoader` can load tasks from markdown files, filter by state, priority, and tags, and select actionable tasks.
>   - **Testing**:
>     - Add tests in `test_task_loader.py` for `Task` and `TaskLoader` functionalities, including loading tasks, filtering, and selecting tasks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for c5861750a808d103c2a7c7dbec84a868194d1855. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->