### PR TITLE
chore: change default TTS server port to 8765

### DIFF
--- a/gptme/tools/tts.py
+++ b/gptme/tools/tts.py
@@ -46,7 +46,7 @@ from .base import ToolSpec
 log = logging.getLogger(__name__)
 
 host = "localhost"
-port = 8000
+port = 8765
 
 # Check for TTS-specific imports
 has_tts_imports = False
@@ -65,7 +65,7 @@ def is_available() -> bool:
         # console.log("TTS tool not available: missing dependencies")
         return False
 
-    # available if a server is running on localhost:8000
+    # available if a server is running on localhost:8765
     server_available = (
         socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex((host, port)) == 0
     )

--- a/scripts/tts_server.py
+++ b/scripts/tts_server.py
@@ -302,7 +302,7 @@ async def text_to_speech(
 
 
 @click.command()
-@click.option("--port", default=8000, help="Port to run the server on")
+@click.option("--port", default=8765, help="Port to run the server on")
 @click.option("--host", default="127.0.0.1", help="Host to run the server on")
 @click.option(
     "--backend",


### PR DESCRIPTION
Prevents common conflicts with development servers that use port 8000
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change default TTS server port to 8765 to prevent conflicts with other development servers.
> 
>   - **Behavior**:
>     - Change default TTS server port from 8000 to 8765 in `gptme/tools/tts.py` and `scripts/tts_server.py`.
>     - Update comment in `is_available()` in `gptme/tools/tts.py` to reflect new port.
>   - **Misc**:
>     - Update `@click.option` for `--port` in `scripts/tts_server.py` to default to 8765.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 6f4cddf168d5e6084a564aaf6a29028fe2af4ccd. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->