### PR TITLE
refactor: migrate TTS to hook-based architecture

### DIFF
--- a/gptme/hooks.py
+++ b/gptme/hooks.py
@@ -148,6 +148,21 @@ class GenerationPreHook(Protocol):
     ) -> Generator[Message | StopPropagation, None, None]: ...
 
 
+class GenerationPostHook(Protocol):
+    """Hook called after generating response.
+
+    Args:
+        message: The generated message
+        workspace: Workspace directory path (optional)
+    """
+
+    def __call__(
+        self,
+        message: Message,
+        **kwargs: Any,
+    ) -> Generator[Message | StopPropagation, None, None]: ...
+
+
 class FilePreSaveHook(Protocol):
     """Hook called before saving a file.
 
@@ -196,6 +211,7 @@ HookFunc = (
     | MessageProcessHook
     | LoopContinueHook
     | GenerationPreHook
+    | GenerationPostHook
     | FilePreSaveHook
     | FilePostSaveHook
 )
@@ -444,6 +460,16 @@ def register_hook(
     name: str,
     hook_type: Literal[HookType.GENERATION_PRE],
     func: GenerationPreHook,
+    priority: int = 0,
+    enabled: bool = True,
+) -> None: ...
+
+
+@overload
+def register_hook(
+    name: str,
+    hook_type: Literal[HookType.GENERATION_POST],
+    func: GenerationPostHook,
     priority: int = 0,
     enabled: bool = True,
 ) -> None: ...

--- a/tests/test_tools_tts.py
+++ b/tests/test_tools_tts.py
@@ -1,8 +1,14 @@
+from unittest.mock import MagicMock, patch
+
+from gptme.message import Message
 from gptme.tools.tts import (
     join_short_sentences,
     re_thinking,
     re_tool_use,
+    speak_on_generation,
     split_text,
+    tool,
+    wait_on_session_end,
 )
 
 
@@ -124,3 +130,80 @@ def test_clean_for_speech():
         == "Using tool"
     )
     assert re_tool_use.sub("", "```tool\ncontents\n```\nRan tool").strip() == "Ran tool"
+
+
+def test_hooks_registered():
+    """Test that TTS hooks are properly registered in the tool spec."""
+    assert "speak_on_generation" in tool.hooks
+    assert "wait_on_session_end" in tool.hooks
+
+    # Check hook types
+    assert tool.hooks["speak_on_generation"][0] == "generation_post"
+    assert tool.hooks["wait_on_session_end"][0] == "session_end"
+
+
+@patch("gptme.tools.tts.speak")
+def test_speak_on_generation_hook(mock_speak):
+    """Test that speak_on_generation hook calls speak() for assistant messages."""
+    # Test with assistant message
+    msg = Message("assistant", "Hello, world!")
+    result = list(speak_on_generation(message=msg))
+
+    # Should call speak with message content
+    mock_speak.assert_called_once_with("Hello, world!")
+    # Hook yields None from the bare yield statement
+    assert len(result) == 1
+    assert result[0] is None
+
+    # Reset mock
+    mock_speak.reset_mock()
+
+    # Test with non-assistant message (should not speak)
+    user_msg = Message("user", "Test user message")
+    result = list(speak_on_generation(message=user_msg))
+    mock_speak.assert_not_called()
+
+
+@patch("gptme.tools.tts.tts_request_queue")
+@patch("gptme.tools.tts.stop")
+@patch("gptme.tools.tts.os.environ.get")
+@patch("gptme.util.sound.wait_for_audio")
+def test_wait_on_session_end_hook(mock_wait_audio, mock_env_get, mock_stop, mock_queue):
+    """Test that wait_on_session_end hook waits for TTS when enabled."""
+    # Mock GPTME_VOICE_FINISH enabled
+    mock_env_get.return_value = "1"
+
+    # Create mock manager
+    mock_manager = MagicMock()
+
+    # Call the hook
+    result = list(wait_on_session_end(manager=mock_manager))
+
+    # Should wait for queue
+    mock_queue.join.assert_called_once()
+    # Should wait for audio
+    mock_wait_audio.assert_called_once()
+
+    # Hook yields None from the bare yield statement
+    assert len(result) == 1
+    assert result[0] is None
+
+
+@patch("gptme.tools.tts.os.environ.get")
+def test_wait_on_session_end_disabled(mock_env_get):
+    """Test that wait_on_session_end hook does nothing when disabled."""
+    # Mock GPTME_VOICE_FINISH disabled
+    mock_env_get.return_value = "0"
+
+    # Create mock manager
+    mock_manager = MagicMock()
+
+    # Call the hook
+    with patch("gptme.tools.tts.tts_request_queue") as mock_queue:
+        result = list(wait_on_session_end(manager=mock_manager))
+
+    # Should not wait for queue
+    mock_queue.join.assert_not_called()
+
+    # Should yield nothing
+    assert len(result) == 0


### PR DESCRIPTION
Refactored TTS integration from manual calls in `chat.py` to a fully automatic hook-based system.

## Changes

### Added GENERATION_POST hook support
- Created `GenerationPostHook` Protocol in `hooks.py`
- Added to `HookFunc` union and `register_hook()` overloads
- Enables type-safe hook registration for post-generation events

### Implemented TTS hooks
- `speak_on_generation`: Automatically speaks assistant messages after generation
- `wait_on_session_end`: Waits for TTS to finish before session exit (respects `GPTME_VOICE_FINISH`)
- Both hooks registered in TTS tool spec with priority 0

### Cleaned up chat.py
- Added `GENERATION_POST` hook trigger after message generation
- Removed manual `speak()` call
- Removed `_wait_for_tts_if_enabled()` function and all its calls
- Removed TTS imports: `speak`, `stop`, `tts_request_queue`, `wait_for_audio`
- **Result: Zero TTS-specific code in chat.py**

### Updated tests
- Added `test_hooks_registered()`: Verifies hooks in tool spec
- Added `test_speak_on_generation_hook()`: Tests speaking on generation
- Added `test_wait_on_session_end_hook()`: Tests waiting at session end  
- Added `test_wait_on_session_end_disabled()`: Tests disabled wait
- All 28 tests passing

## Benefits

- ✅ **Modularity**: TTS logic fully self-contained in TTS tool
- ✅ **Automatic**: No manual integration needed
- ✅ **Clean separation**: Chat logic independent of TTS
- ✅ **Extensibility**: Easy to add more TTS hooks
- ✅ **Type-safe**: Full mypy coverage
- ✅ **Backward compatible**: Public API preserved

## Testing

- All TTS tests pass (12/12)
- Chat integration tests pass (3/3)
- Hook system tests pass (13/13)
- Type checks pass with mypy
- Pre-commit hooks pass

## Stats

- 4 files changed
- 177 insertions(+), 28 deletions(-)
- Net: +149 lines
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor TTS integration to a hook-based architecture, enhancing modularity and removing direct TTS calls from `chat.py`.
> 
>   - **Behavior**:
>     - Refactor TTS integration to use hooks in `chat.py`, removing direct TTS calls.
>     - Add `GENERATION_POST` hook in `hooks.py` for post-generation events.
>     - Implement `speak_on_generation` and `wait_on_session_end` hooks in `tts.py`.
>   - **Tests**:
>     - Add tests for hook registration and functionality in `test_tools_tts.py`.
>     - Ensure all 28 tests pass, including new TTS hook tests.
>   - **Misc**:
>     - Remove TTS-specific imports and functions from `chat.py`.
>     - Update `HookFunc` union and `register_hook()` overloads in `hooks.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for dddab5de2174cf9c558b780616b2152c816434ea. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->