### PR TITLE
feat: support OPENROUTER_API_KEY for perplexity

### DIFF
--- a/docs/lessons/tools/browser.md
+++ b/docs/lessons/tools/browser.md
@@ -48,6 +48,12 @@ read_url("https://gptme.org/docs/getting-started.html")
 search("latest developments in LLM agents", "perplexity")
 ```
 
+**Note**: Perplexity search requires either:
+- `PERPLEXITY_API_KEY` - Direct access to Perplexity API
+- `OPENROUTER_API_KEY` - Uses Perplexity via OpenRouter (model: `perplexity/sonar-pro`)
+
+If both keys are available, PERPLEXITY_API_KEY takes precedence.
+
 ### Taking Screenshots
 ```python
 # Screenshot and view

--- a/gptme/tools/_browser_perplexity.py
+++ b/gptme/tools/_browser_perplexity.py
@@ -35,27 +35,49 @@ def search_perplexity(query: str) -> str:
                 "Error: OpenAI package not installed. Install with: pip install openai"
             )
 
-        # Get API key
+        # Get API key - try Perplexity first, then OpenRouter
         api_key = os.getenv("PERPLEXITY_API_KEY")
+        use_openrouter = False
+
         if not api_key:
             # Try config file
             config_path = Path.home() / ".config" / "gptme" / "config.toml"
+            config_env = {}
             if config_path.exists():
                 with open(config_path) as f:
                     config = tomlkit.load(f)
-                    api_key = config.get("env", {}).get("PERPLEXITY_API_KEY")
+                    config_env = config.get("env", {})
+
+            # Try Perplexity key from config
+            api_key = config_env.get("PERPLEXITY_API_KEY")
+
+            if not api_key:
+                # Try OpenRouter as fallback
+                api_key = os.getenv("OPENROUTER_API_KEY") or config_env.get(
+                    "OPENROUTER_API_KEY"
+                )
+                if api_key:
+                    use_openrouter = True
 
         if not api_key:
-            return "Error: Perplexity API key not found. Set PERPLEXITY_API_KEY environment variable or add it to ~/.config/gptme/config.toml"
+            return "Error: No API key found. Set PERPLEXITY_API_KEY or OPENROUTER_API_KEY environment variable or add it to ~/.config/gptme/config.toml"
 
         # Create client and search
-        client = OpenAI(
-            api_key=api_key,
-            base_url="https://api.perplexity.ai",
-        )
+        if use_openrouter:
+            client = OpenAI(
+                api_key=api_key,
+                base_url="https://openrouter.ai/api/v1",
+            )
+            model = "perplexity/sonar-pro"
+        else:
+            client = OpenAI(
+                api_key=api_key,
+                base_url="https://api.perplexity.ai",
+            )
+            model = "sonar-pro"
 
         response = client.chat.completions.create(
-            model="sonar-pro",
+            model=model,
             messages=[
                 {
                     "role": "system",
@@ -79,8 +101,13 @@ def search_perplexity(query: str) -> str:
 
 
 def has_perplexity_key() -> bool:
-    """Check if Perplexity API key is available."""
+    """Check if Perplexity or OpenRouter API key is available."""
+    # Check for Perplexity key
     if os.getenv("PERPLEXITY_API_KEY"):
+        return True
+
+    # Check for OpenRouter key (can be used for Perplexity search)
+    if os.getenv("OPENROUTER_API_KEY"):
         return True
 
     # Try config file
@@ -89,7 +116,11 @@ def has_perplexity_key() -> bool:
         try:
             with open(config_path) as f:
                 config = tomlkit.load(f)
-                return bool(config.get("env", {}).get("PERPLEXITY_API_KEY"))
+                env_config = config.get("env", {})
+                return bool(
+                    env_config.get("PERPLEXITY_API_KEY")
+                    or env_config.get("OPENROUTER_API_KEY")
+                )
         except Exception:
             pass
 

--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -167,7 +167,7 @@ def search(query: str, engine: EngineType = "google") -> str:
         if has_perplexity:
             return search_perplexity(query)  # type: ignore
         else:
-            return "Error: Perplexity search not available. Set PERPLEXITY_API_KEY environment variable or add it to ~/.config/gptme/config.toml"
+            return "Error: Perplexity search not available. Set PERPLEXITY_API_KEY or OPENROUTER_API_KEY environment variable or add it to ~/.config/gptme/config.toml"
     elif browser == "playwright":
         return search_playwright(query, engine)
     elif browser == "lynx":

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -46,3 +46,33 @@ def test_read_url_arxiv_pdf():
     # TODO: test that we can read it
     # url = "https://arxiv.org/pdf/2410.12361v2"
     pass
+
+
+@pytest.mark.slow
+def test_search_perplexity(monkeypatch):
+    """Test Perplexity search with both API types."""
+    import os
+
+    # Skip if no API keys available
+    has_perplexity = os.getenv("PERPLEXITY_API_KEY") is not None
+    has_openrouter = os.getenv("OPENROUTER_API_KEY") is not None
+
+    if not (has_perplexity or has_openrouter):
+        pytest.skip("No PERPLEXITY_API_KEY or OPENROUTER_API_KEY available")
+
+    # Test the search works
+    results = search("what is gptme", "perplexity")
+    assert results, "Should get results from Perplexity"
+    assert (
+        "error" not in results.lower() or "Error" not in results
+    ), f"Got error: {results}"
+
+    # If we have OpenRouter key, test that it works too
+    if has_openrouter and not has_perplexity:
+        # Clear Perplexity key to force OpenRouter usage
+        monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+        results2 = search("what is gptme", "perplexity")
+        assert results2, "Should get results from OpenRouter"
+        assert (
+            "error" not in results2.lower() or "Error" not in results2
+        ), f"Got error: {results2}"


### PR DESCRIPTION
Support OpenRouter keys for Perplexity as suggested in https://github.com/gptme/gptme/issues/492#issuecomment-3474519476

Should help us get a search tool working in gptme.ai
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for `OPENROUTER_API_KEY` as a fallback for Perplexity searches and updates related documentation and tests.
> 
>   - **Behavior**:
>     - `search_perplexity()` in `_browser_perplexity.py` now supports `OPENROUTER_API_KEY` as a fallback if `PERPLEXITY_API_KEY` is not set.
>     - Updates error messages in `search_perplexity()` and `search()` in `browser.py` to reflect new API key options.
>   - **Documentation**:
>     - Updates `browser.md` to include `OPENROUTER_API_KEY` as an option for Perplexity search.
>   - **Tests**:
>     - Adds `test_search_perplexity()` in `test_browser.py` to test Perplexity search with both API keys.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 9ba042e67dbb8edb7786eb377f9220dbeed89bb6. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->