### PR TITLE
fix(gepa): Phase 3.3 - Fix DSPy auto parameter conflict in MIPROv2

### DIFF
--- a/gptme/eval/dspy/prompt_optimizer.py
+++ b/gptme/eval/dspy/prompt_optimizer.py
@@ -394,7 +394,6 @@ class PromptOptimizer:
             metric = create_composite_metric(eval_specs=eval_specs)
             return MIPROv2(
                 metric=metric,
-                auto="medium",
                 max_bootstrapped_demos=self.max_demos,
                 max_labeled_demos=self.max_demos * 2,
                 num_candidates=self.num_trials,


### PR DESCRIPTION
## Problem

Test 3 (26-task validation) failed with DSPy configuration error:
```
Error: 'If auto is not None, num_candidates and num_trials cannot be set...'
```

Affected: miprov2_light and miprov2_medium optimizer configs

## Root Cause

MIPROv2 initialization was setting BOTH:
- `auto='medium'` (hardcoded line 397)
- `num_candidates=self.num_trials` (line 400)

DSPy docs state these parameters are mutually exclusive.

## Fix

Removed hardcoded `auto='medium'` line, keeping `num_candidates` to respect experiment-specific num_trials values:
- miprov2_light: num_trials=5
- miprov2_medium: num_trials=10

## Impact

- ✅ Fixes configuration errors blocking Phase 3.3
- ✅ MIPROv2 configs now respect experiment-defined num_trials
- ✅ Consistent with GEPA approach (manual parameter control)

## Testing

Needs validation in Phase 3.3 full 26-task run:
- Configure: train_size=18, val_size=8, comparison_examples=26
- Run: full GEPA optimization with all optimizers
- Verify: miprov2_light and miprov2_medium complete without errors

## Related

- Session 1084: Test 3 analysis that identified issue
- Issue: GEPA Phase 3.3 validation
- Task: implement-gepa-optimization.md Phase 3.3
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes DSPy configuration error in `prompt_optimizer.py` by removing `auto='medium'` from MIPROv2 initialization to resolve parameter conflict.
> 
>   - **Behavior**:
>     - Fixes DSPy configuration error in `prompt_optimizer.py` by removing `auto='medium'` from MIPROv2 initialization.
>     - Ensures `num_candidates` is set to `self.num_trials` for experiment-specific values.
>   - **Impact**:
>     - Resolves configuration errors blocking Phase 3.3.
>     - MIPROv2 configs now respect experiment-defined `num_trials` values.
>     - Aligns with GEPA's manual parameter control approach.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 31e3456682cd73a85eda163df0f23c3604da7e84. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->