### PR TITLE
feat(plugins): implement Phase 3 command integration

### DIFF
--- a/gptme/commands.py
+++ b/gptme/commands.py
@@ -538,3 +538,18 @@ def get_user_commands() -> list[str]:
     """Returns a list of all user commands, including tool-registered commands"""
     # Get all registered commands (includes built-in + tool-registered)
     return [f"/{cmd}" for cmd in _command_registry.keys()]
+
+
+def init_commands() -> None:
+    """Initialize plugin commands."""
+    from pathlib import Path
+
+    from .config import get_config
+    from .plugins import register_plugin_commands
+
+    config = get_config()
+    if config.project and config.project.plugins and config.project.plugins.paths:
+        register_plugin_commands(
+            plugin_paths=[Path(p) for p in config.project.plugins.paths],
+            enabled_plugins=config.project.plugins.enabled or None,
+        )

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -5,6 +5,7 @@ from typing import cast
 from dotenv import load_dotenv
 from rich.logging import RichHandler
 
+from .commands import init_commands
 from .config import get_config
 from .hooks import init_hooks
 from .llm import guess_provider_from_config, init_llm
@@ -38,6 +39,7 @@ def init(
     init_model(model, interactive)
     init_tools(tool_allowlist)
     init_hooks()
+    init_commands()
 
     set_tool_format(tool_format)
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -3,8 +3,14 @@
 import tempfile
 from pathlib import Path
 
+from gptme.commands import _command_registry, unregister_command
 from gptme.config import PluginsConfig
-from gptme.plugins import Plugin, discover_plugins, get_plugin_tool_modules
+from gptme.plugins import (
+    Plugin,
+    discover_plugins,
+    get_plugin_tool_modules,
+    register_plugin_commands,
+)
 
 
 def test_plugin_dataclass():
@@ -108,6 +114,78 @@ def test_get_plugin_tool_modules():
         assert len(tool_modules) == 2
         assert "plugin1.tools" in tool_modules
         assert "plugin2.tools" in tool_modules
+
+
+def test_discover_plugins_with_commands_package():
+    """Test plugin discovery with commands as a package."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        plugin_dir = Path(tmpdir) / "cmd_plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "__init__.py").write_text("# Plugin init")
+
+        # Create commands directory with __init__.py
+        commands_dir = plugin_dir / "commands"
+        commands_dir.mkdir()
+        (commands_dir / "__init__.py").write_text("# Commands init")
+
+        plugins = discover_plugins([Path(tmpdir)])
+
+        assert len(plugins) == 1
+        assert plugins[0].name == "cmd_plugin"
+        assert "cmd_plugin.commands" in plugins[0].command_modules
+
+
+def test_discover_plugins_with_command_modules():
+    """Test plugin discovery with individual command modules."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        plugin_dir = Path(tmpdir) / "cmd_plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "__init__.py").write_text("# Plugin init")
+
+        # Create commands directory without __init__.py (individual modules)
+        commands_dir = plugin_dir / "commands"
+        commands_dir.mkdir()
+        (commands_dir / "weather.py").write_text("# Weather command")
+        (commands_dir / "joke.py").write_text("# Joke command")
+
+        plugins = discover_plugins([Path(tmpdir)])
+
+        assert len(plugins) == 1
+        assert "cmd_plugin.commands.weather" in plugins[0].command_modules
+        assert "cmd_plugin.commands.joke" in plugins[0].command_modules
+
+
+def test_register_plugin_commands():
+    """Test registering commands from plugins."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        plugin_dir = Path(tmpdir) / "test_cmd_plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "__init__.py").write_text("# Plugin init")
+
+        # Create commands module with register function
+        commands_dir = plugin_dir / "commands"
+        commands_dir.mkdir()
+        (commands_dir / "test_cmd.py").write_text(
+            """
+from gptme.commands import register_command, CommandContext
+from gptme.message import Message
+
+def register():
+    def test_handler(ctx: CommandContext):
+        yield Message("system", "Test command executed")
+
+    register_command("testcmd", test_handler)
+"""
+        )
+
+        # Register commands
+        register_plugin_commands([Path(tmpdir)])
+
+        # Verify command was registered
+        assert "testcmd" in _command_registry
+
+        # Clean up
+        unregister_command("testcmd")
 
 
 def test_get_plugin_tool_modules_with_allowlist():


### PR DESCRIPTION
Implements command plugin support, completing the plugin system as outlined in Issue #842.

## Changes
- Added command_modules field to Plugin dataclass
- Implemented command discovery in _load_plugin (follows tools/hooks pattern)
- Created register_plugin_commands() function for command registration
- Added init_commands() in commands.py called during startup
- Integrated into init.py initialization sequence
- Added comprehensive tests for command plugin discovery and registration
- Updated documentation with command plugin examples and usage

## How It Works
Plugin commands work like built-in commands:
- Commands are discovered from plugins/*/commands/ directories
- Command modules must have a register() function
- Commands use register_command() to register handlers
- Commands can be invoked with / prefix (e.g., /weather, /joke)

## Example Plugin Structure
```
my_plugin/
├── __init__.py
└── commands/
    ├── __init__.py  # Optional: if present, treated as package
    └── weather.py   # Individual command module with register()
```

## Tests
All 16 plugin tests pass, including 3 new command-specific tests.

Closes #842 Phase 3
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Implements command integration for plugins, adding command discovery, registration, and tests, completing the plugin system.
> 
>   - **Behavior**:
>     - Adds `command_modules` field to `Plugin` dataclass in `gptme/plugins/__init__.py`.
>     - Implements command discovery in `_load_plugin()` in `gptme/plugins/__init__.py`.
>     - Adds `register_plugin_commands()` in `gptme/plugins/__init__.py` for command registration.
>     - Adds `init_commands()` in `gptme/commands.py` and integrates it into `init()` in `gptme/init.py`.
>   - **Command Handling**:
>     - Commands are discovered from `plugins/*/commands/` directories.
>     - Command modules must have a `register()` function.
>     - Commands use `register_command()` to register handlers.
>     - Commands can be invoked with `/` prefix (e.g., `/weather`).
>   - **Tests**:
>     - Adds tests for command plugin discovery and registration in `tests/test_plugins.py`.
>   - **Documentation**:
>     - Updates `docs/plugins.md` with command plugin examples and usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 5afd7cd4d5f58c565c2e1e44da6373113633af24. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->