### PR TITLE
fix: remove xfail markers from previously flaky server tests

### DIFF
--- a/tests/test_server_v2_auto_stepping.py
+++ b/tests/test_server_v2_auto_stepping.py
@@ -12,7 +12,6 @@ from gptme.tools import ToolUse
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.xfail("CI" in os.environ, reason="Flaky, esp in CI")
 @pytest.mark.timeout(30)
 def test_auto_stepping(
     init_, setup_conversation, event_listener, mock_generation, wait_for_event

--- a/tests/test_server_v2_tool_confirmation.py
+++ b/tests/test_server_v2_tool_confirmation.py
@@ -1,7 +1,6 @@
 """Tests for the tool confirmation flow in the V2 API."""
 
 import logging
-import os
 import unittest.mock
 
 import pytest
@@ -12,7 +11,6 @@ from gptme.tools import ToolUse
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.xfail("CI" in os.environ, reason="Flaky on CI (sometimes)")
 @pytest.mark.timeout(20)
 def test_tool_confirmation_flow(
     init_, setup_conversation, event_listener, mock_generation, wait_for_event


### PR DESCRIPTION
This PR removes the xfail markers from `test_auto_stepping` and `test_tool_confirmation_flow` which were previously marked as flaky.

## Background

These tests were marked as flaky in commits:
- 0d9448af: `test_tool_confirmation_flow` - "Flaky on CI (sometimes)"
- 2db3c003: `test_auto_stepping` - "Flaky, esp in CI"

## Why Remove Xfails

The thread safety fixes in #848 (ContextVar for model and hook registry) resolved the underlying issues causing the flakiness:
- Each thread/context now has independent model state
- Each thread/context has its own hook registry
- No more cross-thread interference

## Testing

Verified stability by:
- ✅ Running both tests 5 times in isolation - all passed
- ✅ Running full server v2 test suite in parallel with `-n 16` - all 20 tests passed
- ✅ Tests consistently pass without timeouts or race conditions

The tests are no longer flaky and can be run reliably in CI.

Closes the flaky test issues that required the xfail markers.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `xfail` markers from stable tests `test_auto_stepping` and `test_tool_confirmation_flow` due to resolved flakiness.
> 
>   - **Behavior**:
>     - Remove `xfail` markers from `test_auto_stepping` in `test_server_v2_auto_stepping.py` and `test_tool_confirmation_flow` in `test_server_v2_tool_confirmation.py`.
>     - Tests are no longer flaky due to thread safety improvements from #848.
>   - **Testing**:
>     - Verified by running tests 5 times in isolation and full suite in parallel with `-n 16`.
>     - All tests passed consistently without timeouts or race conditions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 596d4e69fa566f8723e653cde50ad152941d4d59. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->