### PR TITLE
fix(tools): preserve full type information in tool signatures

### DIFF
--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -132,28 +132,28 @@ class Parameter:
 # TODO: there must be a better way?
 def derive_type(t) -> str:
     origin = get_origin(t)
-    
+
     # Handle Literal types
     if origin == Literal:
         v = ", ".join(f'"{a}"' for a in get_args(t))
         return f"Literal[{v}]"
-    
+
     # Handle Union types (both typing.Union and types.UnionType)
     if origin == Union or origin == types.UnionType:
         v = ", ".join(derive_type(a) for a in get_args(t))
         return f"Union[{v}]"
-    
+
     # Handle other generic types (list[int], dict[str, int], etc.)
     if origin is not None:
         args = get_args(t)
         if args:
             type_args = ", ".join(derive_type(arg) for arg in args)
             return f"{origin.__name__}[{type_args}]"
-    
+
     # Special case for NoneType
     if t is type(None):
         return "None"
-    
+
     # Fallback to type name
     return t.__name__
 

--- a/tests/test_tools_python.py
+++ b/tests/test_tools_python.py
@@ -46,14 +46,13 @@ def test_callable_signature():
     assert callable_signature(h) == 'h(a: Literal["a", "b"]) -> str'
 
     # Test generic types
-    from typing import Optional
 
     def i(a: list[int]) -> str:
         return str(a)
 
     assert callable_signature(i) == "i(a: list[int]) -> str"
 
-    def j(a: Optional[list[int]]) -> str:
+    def j(a: list[int] | None) -> str:
         return str(a)
 
     assert callable_signature(j) == "j(a: Union[list[int], None]) -> str"


### PR DESCRIPTION
Fixes #349

## Problem
Tool type hints were losing information for generic types. For example:
- `Optional[list[int]]` was shown as just `Optional`
- `list[int]` was shown as just `list`

This made it harder for LLMs to understand the expected parameter types.

## Solution
Enhanced the `derive_type` function to:
1. Handle `typing.Union` (in addition to existing `types.UnionType` support)
2. Recursively process generic types with arguments (list[int], dict[str, int], etc.)
3. Special case for `NoneType` to display as 'None' instead of 'NoneType'

## Changes
- Updated imports to include `Union` and `get_args`
- Refactored `derive_type` to handle generic types recursively
- Added comprehensive test cases covering:
  - Generic types: `list[int]`, `dict[str, int]`
  - Union types: `Optional[list[int]]`, `int | str`

## Testing
All tests pass, including new test cases for the reported issue.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances `derive_type` in `base.py` to preserve full type information for generic and union types, with updated imports and new test cases.
> 
>   - **Behavior**:
>     - `derive_type` in `base.py` now handles `typing.Union` and recursively processes generic types like `list[int]`, `dict[str, int]`.
>     - Special case for `NoneType` to display as 'None'.
>   - **Imports**:
>     - Added `Union` and `get_args` to imports in `base.py`.
>   - **Testing**:
>     - Added test cases in `test_tools_python.py` for generic types (`list[int]`, `dict[str, int]`) and union types (`Optional[list[int]]`, `int | str`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 66788e846abea4497a275d4feca12a0c597ff6f8. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->