### PR TITLE
fix(dspy): register metadata for complexity test tasks

### DIFF
--- a/gptme/eval/dspy/tasks.py
+++ b/gptme/eval/dspy/tasks.py
@@ -1132,7 +1132,7 @@ if __name__ == "__main__":
     elapsed = time.time() - start
     print(f"Processed {count} records in {elapsed:.2f}s")
 """
-    
+
     spec, metadata = (
         TaskBuilder()
         .with_name("optimize-data-pipeline")

--- a/tests/test_dspy_hybrid.py
+++ b/tests/test_dspy_hybrid.py
@@ -1,5 +1,16 @@
 """Tests for hybrid optimizer implementation (Phase 4.1)."""
 
+import pytest
+
+# Check if DSPy is available and handle import errors gracefully
+try:
+    from gptme.eval.dspy import _has_dspy  # fmt: skip
+
+    if not _has_dspy():
+        pytest.skip("DSPy not available", allow_module_level=True)
+except (ImportError, ModuleNotFoundError):
+    pytest.skip("DSPy module not available", allow_module_level=True)
+
 import dspy
 
 from gptme.eval.dspy.hybrid_optimizer import (


### PR DESCRIPTION
Fixes #866

## Problem

The `create_medium_complexity_task()` and `create_complex_task()` functions were returning raw `EvalSpec` dicts without registering their metadata in the `_task_metadata` registry. This caused `test_task_structure` to fail because `get_task_metadata()` returned empty dicts `{}` for these tasks.

## Root Cause

When the test called:
```python
metadata = get_task_metadata(task["name"])
assert "focus_areas" in metadata  # Failed here
```

The function returned `{}` because these two tasks were never registered in the `_task_metadata` global registry.

## Solution

Convert both functions to use the `TaskBuilder` pattern consistently with the rest of the codebase:

1. Use `TaskBuilder()` instead of raw dict literals
2. Call `.build_with_metadata()` instead of returning raw `EvalSpec`
3. Register metadata in `_task_metadata` before returning the spec
4. Add appropriate `focus_areas` to metadata:
   - Medium task: `["system_design", "testing", "complexity_medium"]`
   - Complex task: `["performance_optimization", "profiling", "complexity_high"]`

## Testing

This fix should allow `test_task_structure` to pass, which was previously failing with:
AssertionError: assert 'focus_areas' in {}

## Impact

- Unblocks PRs #861, #863, and potentially others that were failing this test
- Ensures consistency across all task creation functions
- Makes the focus area filtering system work correctly for all tasks

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes metadata registration for complexity test tasks using `TaskBuilder` to ensure consistent task creation and unblock related PRs.
> 
>   - **Behavior**:
>     - Fixes metadata registration for `create_medium_complexity_task()` and `create_complex_task()` in `tasks.py`.
>     - Uses `TaskBuilder` and `build_with_metadata()` to ensure metadata is registered in `_task_metadata`.
>     - Adds `focus_areas` to metadata for both tasks.
>   - **Testing**:
>     - Resolves `test_task_structure` failure by ensuring `get_task_metadata()` returns correct metadata.
>   - **Impact**:
>     - Unblocks PRs #861, #863 by fixing test failures.
>     - Ensures consistent task creation and metadata registration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for a6ab7669a9ebcda426ec38ee8b0ec46c7f0fc94f. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->