### PR TITLE
fix: detect git version from pip's direct_url.json for pipx installs

### DIFF
--- a/gptme/__version__.py
+++ b/gptme/__version__.py
@@ -43,17 +43,46 @@ def get_git_version(package_dir):
 
 try:
     __version__ = importlib.metadata.version("gptme")
-    is_editable = isinstance(
-        importlib.metadata.distribution("gptme"), importlib.metadata.PathDistribution
-    )
-    if is_editable:
-        # Get the directory containing the package
+
+    # Try multiple methods to get git version info
+    git_hash = None
+
+    # Method 1: Check direct_url.json (for pip installs from git)
+    try:
+        dist = importlib.metadata.distribution("gptme")
+        if hasattr(dist, "read_text"):
+            direct_url_json = dist.read_text("direct_url.json")
+            if direct_url_json:
+                import json
+
+                direct_url_data = json.loads(direct_url_json)
+                if "vcs_info" in direct_url_data:
+                    git_hash = direct_url_data["vcs_info"].get("commit_id", "")[:8]
+    except Exception:
+        pass
+
+    # Method 2: Try git command (for editable installs)
+    if not git_hash:
+        is_editable = isinstance(
+            importlib.metadata.distribution("gptme"),
+            importlib.metadata.PathDistribution,
+        )
+        if is_editable:
+            package_dir = os.path.dirname(os.path.abspath(__file__))
+            git_version = get_git_version(package_dir)
+            if git_version:
+                __version__ = git_version
+            else:
+                __version__ += "+unknown"
+
+    # Apply git hash if found
+    if git_hash:
+        __version__ = f"{__version__}+{git_hash}"
+        # Add .dirty suffix if in development
         package_dir = os.path.dirname(os.path.abspath(__file__))
-        git_version = get_git_version(package_dir)
-        if git_version:
-            __version__ = git_version
-        else:
-            __version__ += "+unknown"
+        if get_git_version(package_dir) and ".dirty" in get_git_version(package_dir):
+            __version__ += ".dirty"
+
 except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0 (unknown)"
 


### PR DESCRIPTION
When installing via 'pipx install git+https://...', pip stores the git commit hash in a direct_url.json file within the package metadata. This commit adds support for reading that file to display the correct version string (e.g., '0.30.0+abc1234') instead of just the base version.

This fixes the issue where pipx installs from git would show version as '0.30.0+unknown' because the .git directory is not included in the installed package.

The solution:
1. First tries to read commit hash from direct_url.json (for pip/pipx installs from git)
2. Falls back to git command for editable installs
3. Only appends '+unknown' for editable installs without git info

Fixes issue where gptme --version showed '+unknown' for pipx git installs.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves version detection for pipx git installs by reading commit hash from `direct_url.json` in `gptme/__version__.py`.
> 
>   - **Behavior**:
>     - Adds logic to read git commit hash from `direct_url.json` for pipx installs in `gptme/__version__.py`.
>     - Falls back to using git command for editable installs if `direct_url.json` is not available.
>     - Appends `+unknown` only for editable installs without git info.
>   - **Versioning**:
>     - Updates `__version__` to include commit hash if found, and adds `.dirty` suffix if applicable.
>   - **Error Handling**:
>     - Catches exceptions when reading `direct_url.json` and defaults to existing behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for faf6c024fd2cfd4e9fe96a81f0d5eb9b900b5b19. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->