### PR TITLE
fix(tests): explicitly disable chat history in server v2 test

### DIFF
--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -100,6 +100,8 @@ def test_v2_create_conversation_default_system_prompt(
     """Test creating a V2 conversation with a default system prompt."""
     # Use tmp_path as workspace to avoid workspace context message
     monkeypatch.chdir(tmp_path)
+    # Explicitly disable chat history for this test
+    monkeypatch.setenv("GPTME_CHAT_HISTORY", "false")
 
     convname = f"test-server-v2-{random.randint(0, 1000000)}"
     response = client.put(


### PR DESCRIPTION
The `test_v2_create_conversation_default_system_prompt` was failing because it expected exactly 2 messages (system + user) but was getting 3 due to chat history context being added.

While `conftest.py` globally sets `GPTME_CHAT_HISTORY=false`, the server test environment needs explicit environment variable setting via monkeypatch to ensure the config is correctly applied during test execution.

## Root Cause
The test creates a Flask test client that may have different environment variable inheritance, causing the global conftest setting to not be properly applied during conversation initialization.

## Solution
Added `monkeypatch.setenv("GPTME_CHAT_HISTORY", "false")` directly in the test to ensure the environment variable is set correctly for the test execution context.

Fixes CI failure on master branch (commit 4acc3748).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Explicitly disable chat history in `test_v2_create_conversation_default_system_prompt` to ensure correct message count by setting `GPTME_CHAT_HISTORY` to `false`.
> 
>   - **Behavior**:
>     - In `test_v2_create_conversation_default_system_prompt` in `test_server_v2.py`, explicitly set `GPTME_CHAT_HISTORY` to `false` using `monkeypatch.setenv()` to ensure only 2 messages (system + user) are present.
>   - **Root Cause**:
>     - Flask test client environment variable inheritance issue caused global `conftest.py` setting to be ignored.
>   - **Solution**:
>     - Added `monkeypatch.setenv("GPTME_CHAT_HISTORY", "false")` to ensure correct environment variable setting during test execution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 684ef94e38bff359e84c63ef4be7b052b36ed2bc. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->