### PR TITLE
Fix: Use conservative token limit for Anthropic models to prevent overflow

### DIFF
--- a/gptme/util/reduce.py
+++ b/gptme/util/reduce.py
@@ -26,7 +26,7 @@ def reduce_log(
         # Use more conservative multiplier for Anthropic models due to tokenizer inaccuracy
         # tiktoken's cl100k_base fallback can undercount tokens for Claude models,
         # so we trigger reduction earlier to avoid hitting the API limit
-        multiplier = 0.75 if "anthropic" in model.model.lower() else 0.9
+        multiplier = 0.75 if model.provider == "anthropic" else 0.9
         limit = multiplier * model.context
 
     # if we are below the limit, return the log as-is


### PR DESCRIPTION
## Problem

Fixes #458

After long conversations, gptme crashes with:
```
anthropic.BadRequestError: prompt is too long: 200297 tokens > 200000 maximum
```

This occurs because:
1. Anthropic models have 200k token context limit
2. Reduction logic triggers at 0.9 × 200k = 180k tokens
3. But token counting uses tiktoken's cl100k_base as fallback for Anthropic models
4. This fallback **undercounts** tokens for Claude models
5. System thinks it's at ~180k when actually at 200k+
6. API call fails when actual count exceeds 200k

## Solution

Use a more conservative multiplier (0.75 instead of 0.9) for Anthropic models when calculating the reduction trigger point.

- **Before**: Reduction triggers at 180k estimated tokens (0.9 × 200k)
- **After**: Reduction triggers at 150k estimated tokens (0.75 × 200k)

This provides a 50k token safety margin to account for tokenizer inaccuracy, preventing overflow while still utilizing 75% of the context window.

## Changes

- Modified `gptme/util/reduce.py` to detect Anthropic models and apply conservative multiplier
- Added explanatory comments documenting the tokenizer inaccuracy issue
- No changes to other models (still use 0.9 multiplier)

## Testing

Existing tests pass (they use GPT-4, not Anthropic models, so behavior unchanged).

The fix prevents the reported error by triggering reduction much earlier, before the true token count approaches the API limit.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adjusts token limit multiplier for Anthropic models in `reduce_log()` to prevent overflow errors due to tokenizer inaccuracy.
> 
>   - **Behavior**:
>     - Adjusts token limit multiplier in `reduce_log()` in `reduce.py` for Anthropic models from 0.9 to 0.75 to prevent overflow errors.
>     - Adds comments explaining the tokenizer inaccuracy issue with Anthropic models.
>   - **Testing**:
>     - Existing tests pass as they use GPT-4, unaffected by this change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for cf3d51d1be1421337e00be550883167e4021646f. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->