### PR TITLE
fix: prevent file content inclusion in command arguments

### DIFF
--- a/gptme/commands.py
+++ b/gptme/commands.py
@@ -555,12 +555,13 @@ def cmd_plugin(ctx: CommandContext) -> None:
 
 def execute_cmd(msg: Message, log: LogManager, confirm: ConfirmFunc) -> bool:
     """Executes any user-command, returns True if command was executed."""
+    from .util.content import is_message_command  # fmt: skip
+
     assert msg.role == "user"
 
     # if message starts with / treat as command
-    # when command has been run,
     # absolute paths dont trigger false positives by checking for single /
-    if msg.content.startswith("/") and msg.content.split(" ")[0].count("/") == 1:
+    if is_message_command(msg.content):
         for resp in handle_cmd(msg.content, log, confirm):
             log.append(resp)
         return True

--- a/gptme/util/content.py
+++ b/gptme/util/content.py
@@ -1,3 +1,24 @@
+def is_message_command(content: str) -> bool:
+    """
+    Check if message content is a command (starts with / and first word has exactly one slash).
+
+    Examples:
+        /shell, /log, /python - these are commands (returns True)
+        /path/to/file.md - this is a file path (returns False)
+
+    Args:
+        content: Message content to check
+
+    Returns:
+        True if content is a command, False otherwise
+    """
+    if not content or not content.startswith("/"):
+        return False
+
+    first_word = content.split()[0] if content.split() else ""
+    return first_word.count("/") == 1
+
+
 def extract_content_summary(content: str, max_words: int = 100) -> str:
     """
     Extract a summary from message content.

--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -297,12 +297,12 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
     if msg.role != "user":
         return msg
 
-    # circular import
-    from ..commands import get_user_commands  # fmt: skip
+    # Skip path processing for commands (single slash in first word)
+    # Examples: /shell, /log, /python - these are commands
+    # But /path/to/file.md (multiple slashes) is a file path, not a command
+    from .content import is_message_command  # fmt: skip
 
-    # Skip path processing for user commands
-    # (as commands might take paths as arguments, which we don't want to expand as part of the command)
-    if any(msg.content.startswith(command) for command in get_user_commands()):
+    if is_message_command(msg.content):
         return msg
 
     append_msg = ""

--- a/tests/test_message_command.py
+++ b/tests/test_message_command.py
@@ -1,0 +1,60 @@
+from gptme.util.content import is_message_command
+
+
+def test_is_message_command():
+    """Test the is_message_command helper function."""
+
+    # Commands (single slash in first word)
+    assert is_message_command("/shell echo hello")
+    assert is_message_command("/log")
+    assert is_message_command("/python print('hello')")
+    assert is_message_command("/help")
+    assert is_message_command("/exit")
+    assert is_message_command("/shell main.py")  # Original issue case
+
+    # File paths (multiple slashes)
+    assert not is_message_command("/path/to/file.md")
+    assert not is_message_command("/home/user/documents/file.txt")
+    assert not is_message_command("/usr/bin/python")
+
+    # Not commands
+    assert not is_message_command("hello world")
+    assert not is_message_command("regular message")
+    assert not is_message_command("")
+
+    # Edge cases
+    assert not is_message_command("shell echo hello")  # No leading slash
+    assert is_message_command("/")  # Just a slash
+    assert is_message_command("/a")  # Single character command
+
+
+def test_is_message_command_integration():
+    """Test that the command detection is properly integrated."""
+    import tempfile
+    from pathlib import Path
+
+    from gptme.message import Message
+    from gptme.util.context import include_paths
+
+    # Create a temp file to test with
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write("print('Hello, World!')\n")
+        temp_file = Path(f.name)
+
+    try:
+        # Test that /shell command doesn't trigger file reading
+        msg = Message("user", f"/shell {temp_file.name}")
+        result = include_paths(msg)
+        # The message should be unchanged (not expanded with file contents)
+        assert result.content == msg.content
+        assert "Hello, World!" not in result.content
+
+        # Test that a file path without /command does trigger file reading
+        msg = Message("user", str(temp_file))
+        result = include_paths(msg)
+        # The message should be expanded with file contents
+        assert "Hello, World!" in result.content
+
+    finally:
+        # Clean up
+        temp_file.unlink()


### PR DESCRIPTION
Fixes an issue where commands like `/shell main.py` were incorrectly triggering file content inclusion because the path processing logic only checked against registered commands, not tool commands.

## Changes

- Added `is_message_command()` helper function to `gptme/util/content.py`
  - Detects commands (single `/` in first word) vs file paths (multiple slashes)
  - Examples: `/shell`, `/log`, `/python` are commands
  - But `/path/to/file.md` is a file path, not a command
  
- Updated `gptme/util/context.py` to use the helper for skipping path processing
- Updated `gptme/commands.py` to use the helper for command detection
- Added comprehensive tests in `tests/test_message_command.py`

## Testing

- Unit tests verify command detection logic
- Integration tests confirm file content is not included for commands
- All tests pass

## Example

Before: `/shell main.py` would read and include contents of main.py in the prompt

After: `/shell main.py` correctly passes "main.py" as an argument without reading the file
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes file content inclusion in command arguments by distinguishing commands from file paths using a new helper function.
> 
>   - **Behavior**:
>     - Introduces `is_message_command()` in `gptme/util/content.py` to differentiate commands from file paths.
>     - Updates `execute_cmd()` in `gptme/commands.py` and `include_paths()` in `gptme/util/context.py` to use `is_message_command()` for command detection.
>   - **Testing**:
>     - Adds unit tests in `tests/test_message_command.py` to verify command detection logic.
>     - Integration tests ensure file content is not included for commands.
>   - **Example**:
>     - Before: `/shell main.py` included file contents.
>     - After: `/shell main.py` passes "main.py" as an argument without reading the file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for e7094c9c3a415ae20dc0cd487201cf085ce99b5a. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->