### PR TITLE
fix(llm): handle mixed content types in Groq/DeepSeek transformation

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -578,19 +578,26 @@ def _transform_msgs_for_special_provider(
 ):
     # groq and deepseek needs message.content to be a string
     if model.provider == "groq" or model.provider == "deepseek":
-        return [
-            {
-                **msg,
-                "content": "\n\n".join(
+        result = []
+        for msg in messages_dicts:
+            content = msg.get("content")
+            # Skip messages without content (e.g., tool call messages)
+            if content is None:
+                result.append(msg)
+                continue
+            # Handle list content (multi-modal messages)
+            if isinstance(content, list):
+                text_parts = [
                     part["text"]
-                    for part in msg["content"]
+                    for part in content
                     if isinstance(part, dict) and part.get("type") == "text"
-                )
-                if isinstance(msg["content"], list)
-                else msg["content"],
-            }
-            for msg in messages_dicts
-        ]
+                ]
+                # Use placeholder if all parts are non-text (e.g., images only)
+                transformed = "\n\n".join(text_parts) if text_parts else "[non-text content]"
+                result.append({**msg, "content": transformed})
+            else:
+                result.append(msg)
+        return result
 
     return messages_dicts
 


### PR DESCRIPTION
## Summary

Fixes #375 - Groq API error when content contains mixed types.

## Problem

The `_transform_msgs_for_special_provider` function was failing when message content contained non-text parts (like images). The function assumed all content parts have a 'text' key:

```python
content: "\n\n".join(part["text"] for part in msg["content"])
```

This would cause a KeyError when image_url or other content types were present, resulting in the error:
```
'messages.0.content' : value must be a string
```

## Solution

Filter to only include text-type content parts when joining content:

```python
content: "\n\n".join(
    part["text"]
    for part in msg["content"]
    if isinstance(part, dict) and part.get("type") == "text"
)
```

## Testing

- Added new test `test_transform_msgs_for_groq` covering:
  - List content with only text parts
  - String content (passthrough)
  - Mixed content with text and images (images filtered out)
- All existing tests pass