### PR TITLE
docs: add optional system dependencies section

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -26,36 +26,10 @@ If ``uv`` is not installed, you can install it using pip, pipx, or your system p
 
    Windows is not directly supported, but you can run gptme using WSL or Docker.
 
-Optional System Dependencies
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. tip::
 
-Some gptme features require additional non-Python dependencies. These are optional and only needed for specific tools:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 20 40 40
-
-   * - Dependency
-     - Purpose
-     - Installation
-   * - ``playwright``
-     - Browser automation for the browser tool
-     - ``pipx inject gptme playwright && playwright install``
-   * - ``lynx``
-     - Text-based web browser (alternative to playwright)
-     - ``apt install lynx`` (Debian/Ubuntu) or ``brew install lynx`` (macOS)
-   * - ``tmux``
-     - Terminal multiplexer for long-running commands
-     - ``apt install tmux`` (Debian/Ubuntu) or ``brew install tmux`` (macOS)
-   * - ``gh``
-     - GitHub CLI for the gh tool
-     - See `GitHub CLI installation <https://cli.github.com/>`_
-   * - ``wl-clipboard``
-     - Wayland clipboard support
-     - ``apt install wl-clipboard`` (Debian/Ubuntu)
-   * - ``pdftotext``
-     - PDF text extraction
-     - ``apt install poppler-utils`` (Debian/Ubuntu) or ``brew install poppler`` (macOS)
+   Some gptme tools require additional system dependencies (playwright, tmux, gh, etc.).
+   See :doc:`system-dependencies` for details.
 
 Usage
 -----

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ See the `README <https://github.com/gptme/gptme/blob/master/README.md>`_ file fo
    :caption: User Guide
 
    getting-started
+   system-dependencies
    usage
    concepts
    examples

--- a/docs/system-dependencies.rst
+++ b/docs/system-dependencies.rst
@@ -1,0 +1,66 @@
+System Dependencies
+===================
+
+Some gptme features require additional non-Python dependencies. These are optional and only needed for specific tools.
+
+Optional Dependencies
+---------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40 40
+
+   * - Dependency
+     - Purpose
+     - Installation
+   * - ``playwright``
+     - Browser automation for the browser tool
+     - ``pipx inject gptme playwright && playwright install``
+   * - ``lynx``
+     - Text-based web browser (alternative to playwright)
+     - ``apt install lynx`` (Debian/Ubuntu) or ``brew install lynx`` (macOS)
+   * - ``tmux``
+     - Terminal multiplexer for long-running commands
+     - ``apt install tmux`` (Debian/Ubuntu) or ``brew install tmux`` (macOS)
+   * - ``gh``
+     - GitHub CLI for the gh tool
+     - See `GitHub CLI installation <https://cli.github.com/>`_
+   * - ``wl-clipboard``
+     - Wayland clipboard support
+     - ``apt install wl-clipboard`` (Debian/Ubuntu)
+   * - ``pdftotext``
+     - PDF text extraction
+     - ``apt install poppler-utils`` (Debian/Ubuntu) or ``brew install poppler`` (macOS)
+
+Details
+-------
+
+playwright
+~~~~~~~~~~
+
+The ``playwright`` library enables browser automation capabilities. After installing with ``pipx inject gptme playwright``, run ``playwright install`` to download the required browser binaries.
+
+lynx
+~~~~
+
+An alternative to playwright for web browsing. Uses less resources and works in text mode, but has limited JavaScript support.
+
+tmux
+~~~~
+
+Required for the tmux tool which enables running long-running or interactive commands in persistent terminal sessions.
+
+gh (GitHub CLI)
+~~~~~~~~~~~~~~~
+
+The GitHub CLI is needed for the gh tool to interact with GitHub repositories, issues, and pull requests. Installation instructions vary by platform - see the `official documentation <https://cli.github.com/>`_.
+
+wl-clipboard
+~~~~~~~~~~~~
+
+Needed for clipboard operations on Wayland-based Linux systems. Not required on X11 systems or other platforms.
+
+pdftotext
+~~~~~~~~~
+
+Part of the poppler utilities, used for extracting text from PDF files. Install the ``poppler-utils`` package on Debian/Ubuntu or ``poppler`` on macOS.


### PR DESCRIPTION
## Summary

Fixes #246 - Documents all non-python dependencies that users should know about when installing gptme.

## Changes

Added a new "Optional System Dependencies" section to the Getting Started guide that documents:

| Dependency | Purpose | Installation |
|------------|---------|--------------|
| playwright | Browser automation for the browser tool | pipx inject + playwright install |
| lynx | Text-based web browser (alternative to playwright) | apt/brew |
| tmux | Terminal multiplexer for long-running commands | apt/brew |
| gh | GitHub CLI for the gh tool | See GitHub CLI docs |
| wl-clipboard | Wayland clipboard support | apt |
| pdftotext | PDF text extraction | poppler-utils |

These are presented in a clear table format with installation instructions for both Debian/Ubuntu and macOS where applicable.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds documentation for optional system dependencies required by gptme tools, including installation instructions and updates to the getting started guide and index.
> 
>   - **Documentation**:
>     - Adds `system-dependencies.rst` to document optional non-Python dependencies for gptme tools.
>     - Lists dependencies like `playwright`, `lynx`, `tmux`, `gh`, `wl-clipboard`, and `pdftotext` with installation instructions.
>   - **Getting Started Guide**:
>     - Adds a tip in `getting-started.rst` to refer users to the new system dependencies documentation.
>   - **Index Update**:
>     - Updates `index.rst` to include the new `system-dependencies` section in the user guide.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for e5f0230f507f123e003b632f53692b82d6109712. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->