### PR TITLE
fix(codeblock): handle nested codeblocks with same language tag

### DIFF
--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -233,8 +233,21 @@ def _extract_codeblocks(
                                 # This closes a nested block, add to content
                                 content_lines.append(line)
                     else:
-                        # This starts a nested block (has language or content after ```)
-                        nesting_depth += 1
+                        # Line has content after ``` - check if it looks like a valid language tag
+                        # to determine if it opens a nested block or is just content
+                        potential_lang = line[3:].strip()
+                        # Valid language tags start with alphanumeric, underscore, slash, or dot
+                        # They should NOT start with quotes or other special characters
+                        # Examples of valid: python, js, save path/to/file.py, .env
+                        # Examples of invalid: ''', "", ===
+                        is_valid_lang = bool(potential_lang) and (
+                            potential_lang[0].isalnum()
+                            or potential_lang[0] in "_/.~"
+                        )
+                        if is_valid_lang:
+                            # This starts a nested block (has valid language tag)
+                            nesting_depth += 1
+                        # Either way, add to content (nested blocks appear as content)
                         content_lines.append(line)
                 else:
                     content_lines.append(line)

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -716,9 +716,6 @@ print("incomplete")
     assert 'print("incomplete")' in blocks[0].content
 
 
-@pytest.mark.xfail(
-    reason="Parser returns 0 blocks when nested blocks have same language tag"
-)
 def test_nested_with_same_language_tag():
     """
     Nested blocks with the same language tag as outer block.


### PR DESCRIPTION
## Summary

Fixes the codeblock parser incorrectly handling nested codeblocks when the nested block has the same language tag as the outer block (Issue #111).

## Problem

gptme couldn't write codeblocks containing other codeblocks due to early stopping. The parser treated `'''` after ``````` as a valid language tag, incorrectly incrementing nesting depth.

## Solution

Added validation that content after ``````` must start with a valid language tag character (alphanumeric, underscore, forward slash, dot, or tilde).

## Testing

- All 36 existing codeblock tests pass  
- Previously XFAIL test now passes (marker removed)
- Lint and type check clean

Fixes #111
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes handling of nested codeblocks with the same language tag by validating language tag characters in `gptme/codeblock.py`.
> 
>   - **Behavior**:
>     - Fixes handling of nested codeblocks with the same language tag in `gptme/codeblock.py` by adding validation for valid language tag characters after opening.
>     - Ensures content after ``````` must start with alphanumeric, underscore, forward slash, dot, or tilde.
>   - **Testing**:
>     - All 36 existing codeblock tests pass.
>     - `test_nested_with_same_language_tag` in `tests/test_codeblock.py` now passes, XFAIL marker removed.
>     - Lint and type check are clean.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 4006bfba470e24365d13ce4578aa69484951fd58. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->