### PR TITLE
fix(config): remove assertions requiring prompt/env in user config

### DIFF
--- a/gptme/config.py
+++ b/gptme/config.py
@@ -294,8 +294,7 @@ default_config = UserConfig(
 def load_user_config(path: str | None = None) -> UserConfig:
     """Load the user configuration from the config file."""
     config = _load_config_doc(path).unwrap()
-    assert "prompt" in config, "prompt key missing in config"
-    assert "env" in config, "env key missing in config"
+    # Note: prompt and env are optional - defaults are used if missing
 
     prompt = UserPromptConfig(**config.pop("prompt", {}))
     env = config.pop("env", {})


### PR DESCRIPTION
## Summary
Removes assertions in `load_user_config()` that required `prompt` and `env` keys in user config.

## Problem
The assertions caused test collection to fail in CI environments where no user config file exists:

```
AssertionError: prompt key missing in config
```

This affected ErikBjare/bob CI tests that import from gptme.

## Solution
Remove the assertions since the code already handles missing sections with defaults via `.pop(key, {})`.

## Testing
- All 18 config tests pass
- Doesn't break existing functionality (defaults are used if missing)

Fixes #908
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unnecessary assertions for `prompt` and `env` in `load_user_config()` to prevent CI test failures.
> 
>   - **Behavior**:
>     - Remove assertions for `prompt` and `env` keys in `load_user_config()` in `config.py`.
>     - Defaults are used if `prompt` or `env` are missing, preventing CI test failures.
>   - **Testing**:
>     - All 18 config tests pass, ensuring no break in existing functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for a208be22a2d2d8e8553047e1abb4cffdd1dd7e0d. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

Fixes #908