### PR TITLE
fix(mcp): preserve server process when conversation is interrupted (Issue #602)

### DIFF
--- a/gptme/tools/mcp_adapter.py
+++ b/gptme/tools/mcp_adapter.py
@@ -5,7 +5,7 @@ from logging import getLogger
 
 from gptme.config import Config, MCPServerConfig, get_config, set_config
 
-from ..mcp.client import MCPClient
+from ..mcp.client import MCPClient, MCPInterruptedError
 from ..mcp.registry import MCPRegistry, format_server_details, format_server_list
 from ..message import Message
 from ..util.ask_execute import execute_with_confirmation
@@ -247,6 +247,11 @@ def create_mcp_execute_function(
             # Execute the tool with retry on connection failures
             result = _call_mcp_tool_with_retry(server_name, tool_name, kwargs, config)
             yield Message("system", result)
+        except MCPInterruptedError:
+            # User interrupted the operation - don't log as error, just inform
+            yield Message(
+                "system", "MCP operation interrupted. The server is still running."
+            )
         except Exception as e:
             logger.error(f"Error executing MCP tool {tool_name}: {e}")
 


### PR DESCRIPTION
## Summary

When a user presses Ctrl+C to interrupt an assistant response during an MCP tool call, the MCP server process would get killed. This fix preserves the server so it can continue to be used for subsequent requests.

## Problem

The issue was that `KeyboardInterrupt` is a `BaseException`, not an `Exception`, so it bypassed the existing exception handling in `_run_async()`. This caused the interrupt to propagate through the asyncio stack and trigger the `stdio_client` context manager cleanup, which terminates the MCP server process.

## Solution

1. **Catch KeyboardInterrupt** in `_run_async()` before it propagates
2. **Gracefully cancel** pending asyncio tasks
3. **Raise MCPInterruptedError** (a regular `Exception`, not `BaseException`)
4. **Handle gracefully** in `mcp_adapter` to show user-friendly message

The key insight is that by converting `KeyboardInterrupt` to a regular `Exception`, we prevent the interrupt from triggering aggressive cleanup that would kill the MCP server.

## Testing

- Code passes ruff linting
- Code passes mypy type checking
- Verified `MCPInterruptedError` is correctly defined as an `Exception` subclass

## Related

Fixes #602
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix MCP server termination on user interruption by catching `KeyboardInterrupt` and raising `MCPInterruptedError`.
> 
>   - **Behavior**:
>     - Catch `KeyboardInterrupt` in `_run_async()` in `client.py` to prevent MCP server termination.
>     - Convert `KeyboardInterrupt` to `MCPInterruptedError` to handle gracefully in `mcp_adapter.py`.
>     - Inform user of interruption without logging as error.
>   - **Exceptions**:
>     - Add `MCPInterruptedError` in `client.py` as a subclass of `Exception`.
>   - **Testing**:
>     - Code passes ruff linting and mypy type checking.
>     - Verified `MCPInterruptedError` is correctly defined as an `Exception` subclass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 001b6180de68a8f8b7fcc7d5a609d4b7118717de. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->