### PR TITLE
fix(llm): add empty content field for DeepSeek assistant messages with tool_calls

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -581,9 +581,14 @@ def _transform_msgs_for_special_provider(
         result = []
         for msg in messages_dicts:
             content = msg.get("content")
-            # Skip messages without content (e.g., tool call messages)
+            # Handle messages without content (e.g., tool call messages)
             if content is None:
-                result.append(msg)
+                # DeepSeek requires reasoning_content for assistant messages with tool_calls
+                # Since we don't store reasoning_content in Message objects, add empty reasoning_content field
+                if model.provider == "deepseek" and msg.get("role") == "assistant" and msg.get("tool_calls"):
+                    result.append({**msg, "reasoning_content": ""})
+                else:
+                    result.append(msg)
                 continue
             # Handle list content (multi-modal messages)
             if isinstance(content, list):


### PR DESCRIPTION
## Problem

DeepSeek's API requires assistant messages with tool_calls to have either a `content` field or a `reasoning_content` field. The previous fix (#896) allowed messages without content to pass through unchanged, but this caused an error for DeepSeek when assistant messages had tool_calls.

## Error Message

```
Error code: 400 - {'error': {'message': 'Missing `reasoning_content` field in the assistant message at message index 2. For more information, please refer to https://api-docs.deepseek.com/guides/thinking_with_tools', 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_request_error'}}
```

## Solution

Since we don't currently store `reasoning_content` in Message objects, this fix adds an empty `content` field for DeepSeek assistant messages that have tool_calls but no content.

## Testing

- Added two new test cases:
  - `test_transform_msgs_for_deepseek_tool_calls`: Verifies empty content field is added
  - `test_transform_msgs_for_deepseek_tool_results`: Verifies tool messages pass through unchanged
- All existing transform tests still pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix DeepSeek assistant messages with tool_calls by adding empty content field if missing.
> 
>   - **Behavior**:
>     - Modify `_transform_msgs_for_special_provider` in `llm_openai.py` to add an empty `content` field for DeepSeek assistant messages with `tool_calls` if `content` is missing.
>   - **Testing**:
>     - Add `test_transform_msgs_for_deepseek_tool_calls` in `test_llm_openai.py` to verify empty `content` field is added for DeepSeek assistant messages with `tool_calls`.
>     - Add `test_transform_msgs_for_deepseek_tool_results` in `test_llm_openai.py` to ensure tool result messages pass through unchanged.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 81f5a5f6daf5a755e9a0ed4b9f7d741ae42eb78b. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->