### PR TITLE
fix(telemetry): filter NotGiven attribute warnings from OTEL instrumentation

### DIFF
--- a/gptme/util/_telemetry.py
+++ b/gptme/util/_telemetry.py
@@ -50,8 +50,6 @@ class NotGivenAttributeFilter(logging.Filter):
     libraries capture API parameters including those set to NOT_GIVEN sentinel values.
     OTEL's attribute validation warns about these since NotGiven is not a valid
     attribute type. The data is still exported correctly, so we suppress the warning.
-
-    See: https://github.com/gptme/gptme/issues/XXX for upstream tracking.
     """
 
     def filter(self, record: logging.LogRecord) -> bool:


### PR DESCRIPTION
## Problem

When using telemetry with Claude models that have extended thinking enabled, the OpenTelemetry instrumentation libraries emit warnings like:

```
Invalid type NotGiven for attribute 'gen_ai.request.top_p' value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
```

This happens because:
1. `top_p` is intentionally set to `NOT_GIVEN` for reasoning models to avoid conflicts
2. The `opentelemetry-instrumentation-anthropic` / `opentelemetry-instrumentation-openai` libraries capture these sentinel values as attributes
3. OTEL's attribute validation warns because `NotGiven` is not a valid attribute type

## Solution

Add a `NotGivenAttributeFilter` logging filter that suppresses these specific warnings. The data is still exported correctly (just without the unset attribute), so this is purely cosmetic noise reduction.

## Changes

- Add `NotGivenAttributeFilter` class to filter `NotGiven` type warnings
- Apply the filter to `opentelemetry.attributes` logger
- Refactor existing filter application for clarity

## Testing

Verified the filter works correctly:
```python
# NotGiven warning is filtered
test_logger.warning('Invalid type NotGiven for attribute gen_ai.request.top_p value')
# Normal warnings pass through
test_logger.warning('Normal warning message')
assert len(handler.records) == 1  # Only normal warning captured
```

## Related

- Observed in Alice's autonomous runs with Claude Sonnet
- Similar pattern to existing `TelemetryConnectionErrorFilter`
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `NotGivenAttributeFilter` to suppress specific OpenTelemetry warnings about `NotGiven` attributes in `_telemetry.py`.
> 
>   - **Behavior**:
>     - Adds `NotGivenAttributeFilter` class in `_telemetry.py` to suppress warnings about `NotGiven` type in telemetry attributes.
>     - Applies `NotGivenAttributeFilter` to `opentelemetry.attributes` logger to filter out specific warnings.
>   - **Refactoring**:
>     - Refactors filter application logic in `init_telemetry()` for clarity.
>   - **Testing**:
>     - Verified that `NotGiven` warnings are filtered while normal warnings pass through.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 771c5e8c470b9b04a64f9c119a8798f489859083. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->