### PR TITLE
fix: read [prompt] section in project config

### DIFF
--- a/gptme/config.py
+++ b/gptme/config.py
@@ -183,14 +183,20 @@ class ProjectConfig:
     def from_dict(cls, config_data: dict, workspace: Path | None = None) -> Self:
         """Create a ProjectConfig instance from a dictionary. Warns about unknown keys."""
         # Support new "prompt" section or old-style base_prompt + files + context_cmd
+        # Support new "prompt" section or old-style base_prompt + files + context_cmd
         prompt_data = config_data.pop("prompt", None)
-        if not isinstance(prompt_data, dict):
-            prompt_data = config_data
-
-        prompt = prompt_data.pop("prompt", None)
-        base_prompt = prompt_data.pop("base_prompt", None)
-        files = prompt_data.pop("files", None)
-        context_cmd = prompt_data.pop("context_cmd", None)
+        if isinstance(prompt_data, dict):
+            # New format: [prompt] section with nested values
+            prompt = prompt_data.pop("prompt", None)
+            base_prompt = prompt_data.pop("base_prompt", None)
+            files = prompt_data.pop("files", None)
+            context_cmd = prompt_data.pop("context_cmd", None)
+        else:
+            # Old format: flat structure, prompt_data contains the prompt string
+            prompt = prompt_data
+            base_prompt = config_data.pop("base_prompt", None)
+            files = config_data.pop("files", None)
+            context_cmd = config_data.pop("context_cmd", None)
 
         rag = RagConfig(**config_data.pop("rag", {}))
         agent = (


### PR DESCRIPTION
Fixes issue @Miyou found in @TimeToBuildBob's gptme.toml
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> `from_dict` in `ProjectConfig` now supports a new 'prompt' section, maintaining backward compatibility with old configuration styles.
> 
>   - **Behavior**:
>     - `from_dict` in `ProjectConfig` now supports a new 'prompt' section in the configuration.
>     - Handles both new 'prompt' section and old-style `base_prompt`, `files`, `context_cmd` for backward compatibility.
>   - **Misc**:
>     - Adds `base_prompt` to the `ProjectConfig` constructor.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 5a98910716aa9a85c071dada43e3a876f1f3a9d9. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->