### PR TITLE
fix(telemetry): remove noisy codeblock tracing

### DIFF
--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -50,12 +50,14 @@ class Codeblock:
         return "." in self.lang or "/" in self.lang
 
     @classmethod
-    @trace_function(
-        name="codeblock.iter_from_markdown", attributes={"component": "parser"}
-    )
     def iter_from_markdown(
         cls, markdown: str, streaming: bool = False
     ) -> list["Codeblock"]:
+        """Extract codeblocks from markdown.
+
+        Note: Tracing removed from this function as it's called hundreds of times
+        per conversation, creating ~97% of all trace spans (see Issue #199).
+        """
         return list(_extract_codeblocks(markdown, streaming=streaming))
 
 
@@ -66,12 +68,14 @@ re_triple_tick_start = re.compile(r"^```.*\n")
 re_triple_tick_end = re.compile(r"^```$")
 
 
-@trace_function(name="codeblock.extract_codeblocks", attributes={"component": "parser"})
 def _extract_codeblocks(
     markdown: str, streaming: bool = False
 ) -> Generator[Codeblock, None, None]:
     """
     Extracts code blocks from a markdown string using context-aware pattern matching.
+
+    Note: Tracing removed from this function as it's called hundreds of times
+    per conversation, creating ~97% of all trace spans (see Issue #199).
 
     Args:
         markdown: The markdown string to extract code blocks from


### PR DESCRIPTION
## Summary
Remove @trace_function decorators from iter_from_markdown() and _extract_codeblocks() as these functions are called hundreds of times per conversation, creating ~97% of all trace spans.

## Analysis
Queried Jaeger at http://jaeger.hassel.bjareho.lt:16686 and found:

- Single trace: **1522 spans**
- `codeblock.extract_codeblocks`: **737 calls** (~5µs each)
- `codeblock.iter_from_markdown`: **737 calls**
- Together: **97% of all spans**

![Span distribution](https://user-images.githubusercontent.com/...) 

```
Operation counts (sorted by frequency):
    737 - codeblock.extract_codeblocks
    737 - codeblock.iter_from_markdown
      7 - llm.stream
      7 - chat.step
      6 - tools.execute_msg
      6 - llm.reply_stream
      6 - anthropic.chat
      6 - llm.reply
      3 - tool.save.confirm
      3 - tool.shell
      3 - tool.save
      1 - tool.shell.confirm
```

## Changes
- Removed `@trace_function` from `Codeblock.iter_from_markdown()`
- Removed `@trace_function` from `_extract_codeblocks()`
- Added docstring notes explaining why tracing was removed

## Result
After this change, traces will show only the meaningful high-level operations (chat.step, llm.reply, tool.*), making it much easier to analyze performance and understand the conversation flow.

Closes ErikBjare/bob#199
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `@trace_function` from `iter_from_markdown()` and `_extract_codeblocks()` in `gptme/codeblock.py` to reduce trace span noise.
> 
>   - **Behavior**:
>     - Removed `@trace_function` from `Codeblock.iter_from_markdown()` and `_extract_codeblocks()` to reduce trace spans.
>     - Added docstring notes in both functions explaining the removal of tracing due to high span generation.
>   - **Analysis**:
>     - `iter_from_markdown()` and `_extract_codeblocks()` were responsible for 97% of trace spans, with 737 calls each per conversation.
>   - **Result**:
>     - Traces now focus on high-level operations, improving performance analysis and conversation flow understanding.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 102c3e4a961a62c408430141e879df948ac6ec39. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->