### PR TITLE
feat(lessons): auto-discover lessons from plugins

### DIFF
--- a/gptme/lessons/index.py
+++ b/gptme/lessons/index.py
@@ -165,12 +165,25 @@ class LessonIndex:
             plugins = discover_plugins(plugin_paths)
             for plugin in plugins:
                 # Check for lessons/ directory in plugin
+                # For flat layout: lessons/ is directly in plugin.path
+                # For src/ layout: plugin.path is src/module/, so lessons/ is at project root
                 plugin_lessons_dir = plugin.path / "lessons"
-                if plugin_lessons_dir.exists():
+                if plugin_lessons_dir.is_dir():
                     dirs.append(plugin_lessons_dir)
                     logger.debug(
                         f"Found plugin lessons: {plugin.name} -> {plugin_lessons_dir}"
                     )
+                else:
+                    # Check for src/ layout: walk up to find project root
+                    # plugin.path might be /project/src/module/, lessons at /project/lessons/
+                    project_root = plugin.path.parent.parent
+                    if (project_root / "pyproject.toml").exists():
+                        project_lessons_dir = project_root / "lessons"
+                        if project_lessons_dir.is_dir():
+                            dirs.append(project_lessons_dir)
+                            logger.debug(
+                                f"Found plugin lessons (src layout): {plugin.name} -> {project_lessons_dir}"
+                            )
 
         return dirs
 


### PR DESCRIPTION
When plugins are configured via `[plugins].paths`, automatically search each plugin's `lessons/` directory for lesson files.

## What this enables

Plugins can now ship with their own lessons that get included automatically when the plugin is loaded. For example, the warp-grep plugin can include a `lessons/` directory with usage guidance:

```
plugins/warp-grep/
├── src/gptme_warp_grep/tools/warp_grep.py
└── lessons/
    └── tools/
        └── warp-grep-usage.md   # Auto-discovered!
```

## How it works

The `LessonIndex._default_dirs()` function now:
1. Gets configured plugin paths from `[plugins].paths`
2. Uses `discover_plugins()` to find all plugins
3. Checks each plugin for a `lessons/` directory
4. Adds found directories to the lesson search path

## Testing

Will test by:
1. Adding `lessons/` directory to warp-grep plugin
2. Verifying lesson appears in `/lesson list`
3. Verifying keyword matching works
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> `LessonIndex._default_dirs()` now auto-discovers lesson directories from plugins configured in `[plugins].paths`, supporting both flat and `src/` layouts.
> 
>   - **Behavior**:
>     - `LessonIndex._default_dirs()` now auto-discovers `lessons/` directories from plugins configured in `[plugins].paths`.
>     - Supports both flat and `src/` layout plugin structures.
>   - **Testing**:
>     - Add `lessons/` to warp-grep plugin and verify appearance in `/lesson list`.
>     - Verify keyword matching functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 80741b5876ade9bc7642f1d40b91c406621d7a12. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->