### PR TITLE
fix(models): support local providers in get_summary_model

### DIFF
--- a/gptme/util/auto_naming.py
+++ b/gptme/util/auto_naming.py
@@ -89,13 +89,16 @@ def _generate_llm_name(
         from ..llm import _chat_complete
         from ..llm.models import get_model, get_summary_model
 
-        # Try to use cheaper summary model
+        # Try to use cheaper summary model (if available for provider)
         naming_model = model
         try:
             current_model = get_model(model)
             if current_model.provider != "unknown":
                 summary_model_name = get_summary_model(current_model.provider)
-                naming_model = f"{current_model.provider}/{summary_model_name}"
+                # Only switch models if a summary model is defined for this provider
+                if summary_model_name is not None:
+                    naming_model = f"{current_model.provider}/{summary_model_name}"
+                # For local/unknown providers, keep using the original model
         except Exception:
             logger.exception("exception during auto-name")
 


### PR DESCRIPTION
## Summary
Fix ValueError when using local providers (like Ollama) during auto-naming.

## Problem
When using a local model (e.g., `local/gpt-oss:latest`), the `get_summary_model()` function would raise a ValueError because there was no case for the "local" provider:

```
ValueError: Provider local did not have a summary model
```

This caused noisy error logs during auto-naming, even though auto-naming continued to work (due to exception handling).

## Solution
- Modified `get_summary_model()` to return `None` for "local" and unknown providers instead of raising ValueError
- Updated callers (`auto_naming.py` and `get_default_model_summary()`) to handle `None` by using the same model (no model substitution)
- For local providers, there's no cost benefit to using a "cheaper" summary model, so using the same model is correct behavior

## Testing
- All `test_auto_naming.py` tests pass
- Verified fix with local provider returns `None` correctly

Fixes #949
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `get_summary_model()` now returns `None` for local and unknown providers, updating model selection logic in `models.py` and `auto_naming.py`.
> 
>   - **Behavior**:
>     - `get_summary_model()` in `models.py` now returns `None` for "local" and unknown providers instead of raising `ValueError`.
>     - `get_default_model_summary()` in `models.py` updated to handle `None` by using the default model.
>     - `_generate_llm_name()` in `auto_naming.py` updated to use the original model if `get_summary_model()` returns `None`.
>   - **Testing**:
>     - All tests in `test_auto_naming.py` pass.
>     - Verified that local provider returns `None` correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 05fa7f40c5b9acb408283c6903016394773266af. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->