### PR TITLE
fix(lessons): handle empty globs/triggers in Cursor rules

### DIFF
--- a/gptme/lessons/parser.py
+++ b/gptme/lessons/parser.py
@@ -180,7 +180,8 @@ def _translate_cursor_metadata(frontmatter: dict) -> LessonMetadata:
     description = frontmatter.get("description")
 
     # Translate globs to keywords
-    globs = frontmatter.get("globs", [])
+    # Note: YAML parses empty values (e.g., "globs:") as None, not missing
+    globs = frontmatter.get("globs") or []
     keywords = []
     for glob in globs:
         keywords.extend(_glob_to_keywords(glob))
@@ -196,7 +197,8 @@ def _translate_cursor_metadata(frontmatter: dict) -> LessonMetadata:
     status = "active"  # Default status
 
     # Extract other Cursor-specific fields
-    triggers = frontmatter.get("triggers", [])
+    # Note: YAML parses empty values as None, not missing
+    triggers = frontmatter.get("triggers") or []
     version = frontmatter.get("version")
 
     return LessonMetadata(


### PR DESCRIPTION
YAML parses empty values (e.g., "globs:") as None, not as missing keys. Use `or []` pattern to handle both missing and None values.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix handling of empty YAML keys in `parser.py` by using `or []` pattern for `globs` and `triggers`.
> 
>   - **Behavior**:
>     - Use `or []` pattern in `_translate_cursor_metadata()` to handle `None` values for `globs` and `triggers` in `parser.py`.
>     - Ensures empty YAML keys are treated as empty lists, not `None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 23b14a2325d45febcb512c677de6558be8832158. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->