### PR TITLE
fix(setup): use PROVIDERS instead of get_args(Provider)

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -437,7 +437,7 @@ def list_available_providers() -> list[tuple[Provider, str]]:
         ("groq", "GROQ_API_KEY"),
         ("xai", "XAI_API_KEY"),
         ("deepseek", "DEEPSEEK_API_KEY"),
-        ("openai-azure", "AZURE_OPENAI_API_KEY"),
+        ("azure", "AZURE_OPENAI_API_KEY"),
     ]
 
     for provider, env_var in provider_checks:

--- a/gptme/setup.py
+++ b/gptme/setup.py
@@ -238,7 +238,7 @@ def _show_user_config_status():
     for provider in all_providers:
         # Generate display name
         display_name = provider.replace("-", " ").title()
-        if provider == "openai-azure":
+        if provider == "azure":
             display_name = "Azure OpenAI"
         elif provider == "xai":
             display_name = "XAI"


### PR DESCRIPTION
## Problem

`/setup` command fails with a fatal error `replace` on Python 3.13 (Issue #957).

## Root Cause

`get_args(Provider)` where `Provider = BuiltinProvider | CustomProvider` returns the union member **types** `(BuiltinProvider, CustomProvider)`, not the actual string values.

When the code tries to iterate and call `.replace()` on these types, it fails.

## Fix

Use the existing `PROVIDERS` constant which correctly contains the list of built-in provider strings from `get_args(BuiltinProvider)`.

## Testing

- Import succeeds: `from gptme.setup import _show_user_config_status`
- All pre-commit checks pass (ruff, mypy)

Fixes #957
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes fatal error in `/setup` command on Python 3.13 by using `PROVIDERS` instead of `get_args(Provider)` and corrects provider name in `list_available_providers()`.
> 
>   - **Behavior**:
>     - Fixes fatal error in `/setup` command on Python 3.13 by replacing `get_args(Provider)` with `PROVIDERS` in `_show_user_config_status()` in `setup.py`.
>     - Corrects provider name from `openai-azure` to `azure` in `list_available_providers()` in `__init__.py`.
>   - **Imports**:
>     - Removes unused `get_args` import from `setup.py`.
>   - **Testing**:
>     - Import of `_show_user_config_status` from `setup.py` succeeds.
>     - All pre-commit checks pass (ruff, mypy).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 68d056ebce157653d42aeb5cea91480731f00b73. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->