### PR TITLE
fix(setup): check for wl-copy instead of wl-clipboard command

### DIFF
--- a/gptme/setup.py
+++ b/gptme/setup.py
@@ -500,11 +500,13 @@ def _check_optional_dependencies():
     ]
 
     # Only check wl-clipboard in Wayland environments
+    # Note: wl-clipboard package provides wl-copy and wl-paste executables, not wl-clipboard
     if _is_wayland_environment():
         dependencies.append(
             {
                 "name": "wl-clipboard",
                 "check_type": "command",
+                "check_command": "wl-copy",  # Actual executable name
                 "purpose": "Clipboard operations on Wayland",
                 "install": "sudo apt install wl-clipboard  # Ubuntu/Debian",
             }
@@ -518,7 +520,9 @@ def _check_optional_dependencies():
     missing_deps = []
 
     for dep in dependencies:
-        is_available = _check_dependency(dep["name"], dep["check_type"])
+        # Use check_command if provided, otherwise use name
+        check_name = dep.get("check_command", dep["name"])
+        is_available = _check_dependency(check_name, dep["check_type"])
         status = "[green]✅[/green]" if is_available else "[red]❌[/red]"
         deps_table.add_row(dep["name"], status, dep["purpose"])
 


### PR DESCRIPTION
## Summary

Fixes #965 - wl-clipboard dependency not found on setup

## Problem

When users run `/setup`, gptme reports wl-clipboard as missing even when it's installed because it checks for a `wl-clipboard` executable that doesn't exist. The `wl-clipboard` package provides `wl-copy` and `wl-paste` executables instead.

## Solution

Added a `check_command` field to the dependency definition that specifies the actual executable to check (`wl-copy`) while still displaying the package name (`wl-clipboard`) to users.

## Changes

1. Added `check_command` field to wl-clipboard dependency entry
2. Updated dependency check logic to use `check_command` if provided, falling back to `name`

## Testing

- `wl-copy` is the primary executable that gets checked
- Package name `wl-clipboard` still shown to users in output
- All pre-commit checks pass (ruff, mypy, etc.)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `wl-clipboard` dependency check in `setup.py` by verifying `wl-copy` executable in Wayland environments.
> 
>   - **Behavior**:
>     - Fixes issue #965 where `wl-clipboard` was reported missing by checking for `wl-copy` instead of `wl-clipboard`.
>     - Updates dependency check logic in `setup.py` to use `check_command` if provided, otherwise defaults to `name`.
>   - **Setup Logic**:
>     - Adds `check_command` field to `wl-clipboard` dependency entry in `setup.py`.
>     - Ensures `wl-copy` is checked in Wayland environments.
>   - **Testing**:
>     - Verifies `wl-copy` is checked and `wl-clipboard` is displayed to users.
>     - All pre-commit checks pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 2af883987ef4b3f11a06300ce0f03d0d85aa7668. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->