### PR TITLE
feat(acp): add Phase 3 session persistence and cancellation

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -648,7 +648,9 @@ class GptmeAgent:
         except SessionCancelled:
             logger.info(f"Session {session_id[:8]} cancelled during prompt")
             # Clear cancellation flag for future operations
-            self._cancel_requested[session_id] = False
+            # Use pop() to atomically remove the entry, avoiding race condition
+            # where a new cancel() request during cleanup would be lost
+            self._cancel_requested.pop(session_id, None)
             # Tool calls already marked as failed by _complete_pending_tool_calls in cancel()
             assert PromptResponse is not None
             return PromptResponse(stop_reason="cancelled")


### PR DESCRIPTION
## Summary

Implements Phase 3 of ACP (Agent Client Protocol) support: Session Persistence and Cancellation.

### Session Persistence
- **Persistent storage**: Sessions stored in `~/.local/share/gptme/acp-sessions/`
- **Metadata tracking**: Store cwd, model, mcp_servers for each session
- **Session reload**: Implement `load_session` to restore sessions across agent restarts
- **Helper methods**: `_get_session_dir`, `_save_session_metadata`, `_load_session_metadata`, `_list_persistent_sessions`

### Cancellation Support
- **Cancel flag**: Per-session cancellation via `_cancel_requested` dict
- **SessionCancelled exception**: Clean interruption mechanism
- **Confirm callback integration**: Check for cancellation before each tool execution
- **Proper cleanup**: Mark pending tool calls as failed, clear flag after handling

### Tests
Added `tests/test_acp.py` with 8 unit tests covering:
- Session directory creation
- Metadata save/load roundtrip
- Nonexistent session handling
- Persistent session listing
- Cancellation flag setting
- Unknown session cancellation
- SessionCancelled exception
- Phase 3 attribute existence

### Depends On
- PR #979 (Phase 2: Tool call reporting and permissions)

Refs: #977
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Implements session persistence and cancellation for ACP in `agent.py`, with tests in `test_acp.py`.
> 
>   - **Session Persistence**:
>     - Sessions stored in `~/.local/share/gptme/acp-sessions/` with metadata tracking (cwd, model, mcp_servers).
>     - Implemented `_get_session_dir`, `_save_session_metadata`, `_load_session_metadata`, `_list_persistent_sessions` in `agent.py`.
>     - `load_session` method to restore sessions across restarts.
>   - **Cancellation Support**:
>     - Added `_cancel_requested` dict for per-session cancellation flags in `agent.py`.
>     - Introduced `SessionCancelled` exception for clean interruption.
>     - Integrated cancellation checks in `confirm_callback` and cleanup in `run_chat_step`.
>   - **Tests**:
>     - Added `tests/test_acp.py` with tests for session directory creation, metadata save/load, session listing, cancellation flag, and exception handling.
>     - Tests for loading sessions from memory and disk, and handling unknown sessions.
>   - **Dependencies**:
>     - Depends on PR #979 for Phase 2 features.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for cf33e52adfc87858b3b88b3f89f9ab502328e5b9. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->