### PR TITLE
fix(shell): truncate long commands in output to reduce context waste

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1030,7 +1030,9 @@ def _format_shell_output(
     if len(cmd) > 100 or cmd.count("\n") > 2:
         first_line = cmd.split("\n")[0][:80]
         line_count = cmd.count("\n") + 1
-        cmd_display = f"{first_line}... ({line_count} lines)"
+        cmd_display = (
+            f"{first_line}... ({line_count} {'line' if line_count == 1 else 'lines'})"
+        )
     else:
         cmd_display = cmd
 


### PR DESCRIPTION
## Summary

Addresses Issue #974 - Reduce context waste by truncating long command echo in shell output.

## Problem

When shell commands are executed, the output includes `Ran command: <full command>` which duplicates the command that was just shown in the assistant's code block. For long commands (heredocs, multi-line pipelines), this creates significant context waste.

## Solution

Add truncation logic to `_format_shell_output()`:
- Commands > 100 chars OR > 2 lines are truncated
- Show first 80 chars of first line + line count
- Short commands remain unchanged

## Example

**Before** (heredoc):
```
Ran command: `cat <<'EOF' > test.py
#!/usr/bin/env python3
print('Hello')
# lots more content...
EOF`
```

**After**:
```
Ran command: `cat <<'EOF' > test.py... (15 lines)`
```

## Impact

- Reduces context token usage for file writes with heredocs
- Saves tokens for complex multi-line commands
- No information loss (full command visible in assistant's code block)

## Testing

- All shell tests pass (45/51, 6 skipped due to unrelated import issue)
- Manual truncation logic verification passed

Closes #974
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Truncates long shell commands in `_format_shell_output()` to reduce context waste, while ensuring no information loss.
> 
>   - **Behavior**:
>     - Truncates long shell commands in `_format_shell_output()` if they exceed 100 characters or 2 lines.
>     - Displays first 80 characters of the first line and the total line count for truncated commands.
>     - Short commands remain unchanged.
>   - **Impact**:
>     - Reduces context token usage for long commands, especially heredocs and multi-line pipelines.
>     - No information loss as full command is visible in the assistant's code block.
>   - **Testing**:
>     - All shell tests pass except 6 skipped due to unrelated issues.
>     - Manual verification of truncation logic passed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for e778979487dc0e9106bf275500e7824bbbac9403. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->