### PR TITLE
fix: throw lock on tmux tool new_session to prevent race

### DIFF
--- a/gptme/tools/tmux.py
+++ b/gptme/tools/tmux.py
@@ -142,23 +142,22 @@ def _capture_pane(pane_id: str) -> str:
 
 
 # decorator for lock
-def flock():
-    lock = threading.Lock()
+# Lock for new_session to avoid race conditions when creating sessions concurrently
+_new_session_lock = threading.Lock()
 
+def flock(lock):
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             with lock:
                 return func(*args, **kwargs)
-
         return wrapper
-
     return decorator
 
 
 # @flock to avoid race conditions when creating new sessions concurrently
 # as can happen in tests, causing flakiness
-@flock()
+@flock(_new_session_lock)
 def new_session(command: str) -> Message:
     _max_session_id = 0
     for session in get_sessions():


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a lock to `new_session()` in `tmux.py` to prevent race conditions during concurrent tmux session creation.
> 
>   - **Behavior**:
>     - Adds `flock` decorator to `new_session()` in `tmux.py` to prevent race conditions during concurrent session creation.
>     - Uses `threading.Lock` to ensure mutual exclusion when creating new tmux sessions.
>   - **Misc**:
>     - Imports `functools` and `threading` in `tmux.py` to support the new locking mechanism.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 334c5511a69440f69ffa687bf1e269a54d08c010. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->