### PR TITLE
docs: document plugins in project config

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -84,6 +84,16 @@ This file currently supports a few options:
 - ``base_prompt``, a string that will be used as the base prompt for the project. This will override the global base prompt ("You are gptme v{__version__}, a general-purpose AI assistant powered by LLMs. [...]"). It can be useful to change the identity of the assistant and override some default behaviors.
 - ``context_cmd``, a command used to generate context to include when constructing the system prompt. The command will be run in the workspace root and should output a string that will be included in the system prompt. Examples can be ``git status -v`` or ``scripts/context.sh``.
 - ``rag``, a dictionary to configure the RAG tool. See :ref:`rag` for more information.
+- ``plugins``, a dictionary to configure plugins for this project. See :doc:`plugins` for more information. Example:
+
+  .. code-block:: toml
+
+      [plugins]
+      paths = ["./plugins", "~/.config/gptme/plugins"]
+      enabled = ["my_project_plugin"]
+
+- ``env``, a dictionary of environment variables to set for this project. These take precedence over global config but are overridden by shell environment variables.
+- ``mcp``, MCP server configuration for this project. See :ref:`mcp` for more information.
 
 See :class:`gptme.config.ProjectConfig` for the API reference.
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -27,7 +27,11 @@ A plugin is a Python package (directory with ``__init__.py``) that can contain:
 Configuration
 -------------
 
-Add plugin paths to your ``gptme.toml``:
+Plugins can be configured at two levels:
+
+**User-level** (``~/.config/gptme/config.toml``): Applies to all projects.
+
+**Project-level** (``gptme.toml`` in workspace root): Applies only to this project, merged with user config.
 
 .. code-block:: toml
 
@@ -36,10 +40,13 @@ Add plugin paths to your ``gptme.toml``:
    paths = [
        "~/.config/gptme/plugins",
        "~/.local/share/gptme/plugins",
+       "./plugins",  # Project-local plugins
    ]
 
    # Optional: only enable specific plugins (empty = all discovered)
    enabled = ["my_plugin", "another_plugin"]
+
+Project-level plugin paths are relative to the workspace root.
 
 Skills vs Plugins
 -----------------


### PR DESCRIPTION
Documents the previously undocumented ability to configure plugins at the project level in `gptme.toml`.

## Changes

### config.rst
- Added `plugins` to the list of project config options with example
- Added `env` and `mcp` (also undocumented but present in ProjectConfig)

### plugins.rst
- Clarified that plugins can be configured at both user-level (`~/.config/gptme/config.toml`) and project-level (`gptme.toml`)
- Added example of project-local plugins path (`./plugins`)
- Added note that project-level paths are relative to workspace root

## Context
The `ProjectConfig` class has had `plugins: PluginsConfig` support for a while, but it was not documented. This makes it clearer that projects can have their own plugin configurations.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Documents project-level plugin configuration in `gptme.toml`, updating `config.rst` and `plugins.rst` with examples and clarifications.
> 
>   - **Documentation**:
>     - Adds `plugins`, `env`, and `mcp` to project config options in `config.rst`.
>     - Clarifies plugin configuration at user-level and project-level in `plugins.rst`.
>     - Provides examples of project-local plugin paths and notes on relative paths.
>   - **Context**:
>     - Documents existing `ProjectConfig` support for `plugins`, making project-specific plugin configurations clearer.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 87ad4acee4cb75831ebaa977a520d5e56107e3af. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->