### PR TITLE
feat(codeblock): support quad+ backticks for nested markdown (Issue #1005)

### DIFF
--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -1079,3 +1079,27 @@ def test_quad_backticks_not_closed_by_triple():
     assert "line 1" in blocks[0].content
     assert "```" in blocks[0].content
     assert "line 2" in blocks[0].content
+
+
+def test_mismatched_fence_lengths():
+    """Mismatched fence lengths should not be parsed as complete blocks.
+
+    Per CommonMark spec, opening and closing fences must have the same length.
+    E.g., ````text\nline 1\n``` should not parse as a valid block because
+    the opening fence (4 backticks) doesn't match the closing fence (3 backticks).
+    """
+    # Quad opening, triple closing - should NOT be extracted as complete block
+    markdown = "````text\nline 1\n```"
+    blocks = Codeblock.iter_from_markdown(markdown)
+    # No complete block should be extracted since closing fence doesn't match
+    assert len(blocks) == 0
+
+    # Quintuple opening, quad closing - should NOT be extracted
+    markdown2 = "`````text\nline 1\n````"
+    blocks2 = Codeblock.iter_from_markdown(markdown2)
+    assert len(blocks2) == 0
+
+    # Triple opening, quad closing - should NOT be extracted
+    markdown3 = "```text\nline 1\n````"
+    blocks3 = Codeblock.iter_from_markdown(markdown3)
+    assert len(blocks3) == 0


### PR DESCRIPTION
## Summary

Implements CommonMark-compliant support for variable-length backtick fences (4+), allowing nested markdown codeblocks without premature closure.

## Problem

When saving files containing markdown codeblocks (like documentation with code examples), the inner triple backticks close the outer save block prematurely (Issue #1005).

## Solution

- Updated regex patterns to capture variable backtick fence lengths  
- Modified extraction logic to track opening fence length
- Only close blocks when matching fence length encountered
- Inner blocks with fewer backticks preserved as content

## Tests

Added 3 new tests for quad/quintuple backtick scenarios, all passing.

Fixes #1005
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Support for variable-length backtick fences (4+ backticks) in markdown code blocks, allowing nested blocks without premature closure, with tests added for various scenarios.
> 
>   - **Behavior**:
>     - Support for variable-length backtick fences (4+ backticks) in `gptme/codeblock.py`.
>     - Updated regex patterns and extraction logic to handle nested markdown code blocks.
>     - Only close blocks when matching fence length is encountered.
>     - Inner blocks with fewer backticks are preserved as content.
>   - **Tests**:
>     - Added tests in `tests/test_codeblock.py` for quad and quintuple backtick scenarios.
>     - Tests cover cases like mismatched fence lengths and nested blocks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 6b5d465fed9607f106c97bcdc1408866edbd5f64. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->