### PR TITLE
fix: propagate metadata in Anthropic retry decorator

### DIFF
--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -260,8 +260,9 @@ def retry_generator_on_overloaded(max_retries: int = 5, base_delay: float = 1.0)
         def wrapper(*args, **kwargs):
             for attempt in range(max_retries):
                 try:
-                    yield from func(*args, **kwargs)
-                    break  # If generator completes successfully, exit retry loop
+                    # Use 'return (yield from ...)' to propagate the generator's return value
+                    # Without 'return', the metadata returned by stream() would be lost
+                    return (yield from func(*args, **kwargs))
                 except Exception as e:
                     _handle_anthropic_transient_error(
                         e, attempt, max_retries, base_delay


### PR DESCRIPTION
## Summary

Fixes `/cost` command showing no data when using the Anthropic provider directly.

## Problem

The `retry_generator_on_overloaded` decorator in `llm_anthropic.py` was using `yield from func(...)` without capturing the return value. This caused the metadata (token counts, cost) returned by `stream()` to be silently discarded.

This explains why:
- ✅ `/cost` works with OpenRouter (uses `llm_openai.py` which has no such decorator)  
- ❌ `/cost` shows no data with Anthropic provider (metadata lost in decorator)

## Fix

Changed from:
```python
yield from func(*args, **kwargs)
break  # If generator completes successfully, exit retry loop
```

To:
```python
return (yield from func(*args, **kwargs))
```

In Python, when a generator returns a value, it becomes `StopIteration.value`. Using bare `yield from` discards this value - you need `return (yield from ...)` to propagate it.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes metadata propagation in `retry_generator_on_overloaded` in `llm_anthropic.py` by using `return (yield from ...)`, resolving `/cost` command issue with Anthropic provider.
> 
>   - **Behavior**:
>     - Fixes metadata propagation in `retry_generator_on_overloaded` in `llm_anthropic.py` by changing `yield from func(...)` to `return (yield from func(...))`.
>     - Ensures metadata (token counts, cost) from `stream()` is not discarded.
>   - **Problem**:
>     - `/cost` command showed no data with Anthropic provider due to lost metadata.
>   - **Fix**:
>     - Uses `return (yield from ...)` to capture generator's return value, fixing metadata loss.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 0beb45cb4f0854feddd5e5982d3c48fe03d74b3f. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->