### PR TITLE
feat(autocompact): add Phase 4 revert fallback for context compaction

### DIFF
--- a/gptme/tools/autocompact.py
+++ b/gptme/tools/autocompact.py
@@ -387,13 +387,18 @@ def auto_compact_log(
 
         # Find indices of user-assistant pairs (excluding the most recent exchange)
         # We want to remove older exchanges, not the current one
+        #
+        # The -2 boundary ensures we never consider the last two messages as candidates:
+        # - If the last two are user+assistant, they're the most recent exchange (preserved)
+        # - If they're not, there's no complete exchange to preserve at the end anyway
         pairs_to_remove: list[tuple[int, int]] = []  # (user_idx, assistant_idx)
         i = 0
         while i < len(compacted_log) - 2:  # -2 to preserve most recent exchange
             msg = compacted_log[i]
             if msg.role == "user" and not msg.pinned:
                 # Look for following assistant message
-                if i + 1 < len(compacted_log) - 1:
+                # Note: i+1 is always < len-1 due to outer loop constraint (i < len-2)
+                if i + 1 < len(compacted_log):
                     next_msg = compacted_log[i + 1]
                     if next_msg.role == "assistant" and not next_msg.pinned:
                         pairs_to_remove.append((i, i + 1))


### PR DESCRIPTION
## Summary

Adds a new compaction phase (Phase 4) inspired by oh-my-opencode's multi-stage fallback strategy. When Phases 1-3 (reasoning strip, tool truncation, extractive compression) are insufficient to bring the conversation under the token limit, Phase 4 removes the oldest user-assistant exchange to free context space.

## Motivation

This addresses the RANK 1 improvement from Issue ErikBjare/bob#210 (Context Compaction Research). The current autocompact has a gap: if Phases 1-3 don't reduce enough, it falls back to reduce_log which may also be insufficient. This new phase provides an additional fallback before giving up.

## Implementation

**Safety measures:**
- Only activates for conversations with 5+ messages (preserves short conversations)
- Preserves the most recent exchange (never removes current conversation)
- Never removes pinned messages
- Adds a system message indicating what was removed (user knows context was lost)

**How it works:**
1. After Phase 3 check, if still over limit
2. Find oldest user-assistant pair (not pinned, not most recent)
3. Remove it and insert a notice message
4. Check if under limit, otherwise fall back to reduce_log

## Testing

- Added tests for Phase 4 behavior with sufficient messages
- Added tests ensuring Phase 4 skips short conversations
- All 31 autocompact tests pass

## Related

- Issue: ErikBjare/bob#210
- Inspiration: oh-my-opencode's multi-stage fallback (truncate → summarize → revert)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds Phase 4 to `auto_compact_log()` to remove the oldest user-assistant exchange when previous compaction phases are insufficient, with tests verifying its behavior.
> 
>   - **Behavior**:
>     - Adds Phase 4 to `auto_compact_log()` in `autocompact.py` to remove the oldest user-assistant exchange if Phases 1-3 don't reduce tokens enough.
>     - Phase 4 only activates for conversations with 5+ messages, preserving the most recent exchange and pinned messages.
>     - Inserts a system message indicating the removal of an exchange.
>   - **Testing**:
>     - Adds `test_auto_compact_phase4_revert_with_enough_messages()` and `test_auto_compact_phase4_skips_short_conversations()` in `test_auto_compact.py` to verify Phase 4 behavior.
>     - Ensures Phase 4 does not trigger for short conversations and correctly logs token savings when it does trigger.
>   - **Misc**:
>     - Updates logging in `auto_compact_log()` to reflect Phase 4 actions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for a5644e70af4ef555712a92e686daa8ebedd76554. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->