### PR TITLE
fix(eval): pass API keys to Docker container

### DIFF
--- a/gptme/eval/main.py
+++ b/gptme/eval/main.py
@@ -106,10 +106,15 @@ def docker_reexec(argv: list[str]) -> None:
         "AZURE_OPENAI_ENDPOINT",
     ]
 
+    # Get config to also check config.toml for API keys
+    config = get_config()
+
     env_args = []
     for var in env_vars_to_pass:
-        if var in os.environ:
-            env_args.extend(["-e", f"{var}={os.environ[var]}"])
+        # Check both environment variables and config.toml
+        value = config.get_env(var)
+        if value:
+            env_args.extend(["-e", f"{var}={value}"])
 
     # Construct docker run command
     docker_cmd = [


### PR DESCRIPTION
## Summary

Fixes Issue #995: Docker isolation permission errors with API keys.

## Problem

When using `gptme-eval --use-docker`, the command failed because API keys weren't passed through to the container.

## Solution

Pass common LLM provider API keys to the Docker container via `-e` environment flags.

**API keys are collected from:**
- Environment variables (e.g., `ANTHROPIC_API_KEY`)
- User's config file (`~/.config/gptme/config.toml`) via `config.get_env()`

This allows `gptme-eval --use-docker` to work without manual workarounds for users who store API keys in either location.

## Changes

- Pass common LLM provider API keys (`-e` flags) to Docker container
- Use `get_config().get_env()` to check both environment and config.toml
- Redact API keys in log output for security

Closes #995
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Passes API keys to Docker container in `main.py` to fix permission errors, collecting keys from environment and config file, and redacting them in logs.
> 
>   - **Behavior**:
>     - Passes common LLM provider API keys to Docker container using `-e` flags in `docker_reexec()` in `main.py`.
>     - Collects API keys from environment variables and `~/.config/gptme/config.toml` using `get_config().get_env()`.
>     - Redacts API keys in log output for security in `docker_reexec()`.
>   - **Misc**:
>     - Closes Issue #995.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for d7c28b676c2f6e158a010e0567b07bf85d5df42b. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->