### PR TITLE
fix(security): block file:// protocol in lynx browser backend

### DIFF
--- a/gptme/tools/_browser_lynx.py
+++ b/gptme/tools/_browser_lynx.py
@@ -69,24 +69,3 @@ def test_search():
     # result = search("Python", "google")
     result = search("Erik Bjäreholt", "duckduckgo")
     assert "erik.bjareholt.com" in result
-
-
-def test_url_scheme_validation():
-    """Test that dangerous URL schemes are blocked."""
-    import pytest
-
-    # Valid schemes should work (will fail if lynx not installed, but that's OK)
-    # We're testing the validation, not the actual fetch
-    _validate_url_scheme("https://example.com")
-    _validate_url_scheme("http://example.com")
-    _validate_url_scheme("HTTP://EXAMPLE.COM")  # Case insensitive
-
-    # Dangerous schemes should be blocked
-    with pytest.raises(ValueError, match="not allowed"):
-        _validate_url_scheme("file:///etc/passwd")
-
-    with pytest.raises(ValueError, match="not allowed"):
-        _validate_url_scheme("ftp://example.com")
-
-    with pytest.raises(ValueError, match="not allowed"):
-        _validate_url_scheme("javascript:alert(1)")

--- a/tests/test_browser_lynx.py
+++ b/tests/test_browser_lynx.py
@@ -1,0 +1,23 @@
+"""Tests for lynx browser backend security."""
+
+import pytest
+
+from gptme.tools._browser_lynx import _validate_url_scheme
+
+
+def test_url_scheme_validation():
+    """Test that dangerous URL schemes are blocked in lynx backend."""
+    # Valid schemes should work
+    _validate_url_scheme("https://example.com")
+    _validate_url_scheme("http://example.com")
+    _validate_url_scheme("HTTP://EXAMPLE.COM")  # Case insensitive
+
+    # Dangerous schemes should be blocked
+    with pytest.raises(ValueError, match="not allowed"):
+        _validate_url_scheme("file:///etc/passwd")
+
+    with pytest.raises(ValueError, match="not allowed"):
+        _validate_url_scheme("ftp://example.com")
+
+    with pytest.raises(ValueError, match="not allowed"):
+        _validate_url_scheme("javascript:alert(1)")


### PR DESCRIPTION
## Summary

Security fix that validates URL schemes before passing to the lynx subprocess. Only `http://` and `https://` URLs are now permitted.

## Problem

The lynx browser backend accepts any URL scheme, including `file://`. This allows reading local files on the system via:
```python
read_url('file:///etc/passwd')  # Would read local file!
```

## Solution

Added `_validate_url_scheme()` function that:
1. Parses the URL to extract the scheme
2. Validates against allowlist: `{"http", "https"}`
3. Raises `ValueError` for disallowed schemes

## Testing

Added `test_url_scheme_validation()` test covering:
- Valid schemes (http, https) - pass
- Dangerous schemes (file, ftp, javascript) - blocked

## Security Impact

This is a **CRITICAL** security fix from the security audit (gptme/gptme#1021).

Blocks:
- Local file access via `file://` protocol
- Other dangerous protocols (ftp, javascript, etc.)

---
Co-authored-by: Bob <bob@superuserlabs.org>
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add URL scheme validation to block dangerous protocols in lynx browser backend.
> 
>   - **Security Fix**:
>     - Add `_validate_url_scheme()` in `_browser_lynx.py` to allow only `http` and `https` schemes.
>     - Block `file://`, `ftp://`, `javascript:`, and other dangerous protocols.
>   - **Functionality**:
>     - Modify `read_url()` in `_browser_lynx.py` to use `_validate_url_scheme()` for URL validation.
>   - **Testing**:
>     - Add `test_url_scheme_validation()` in `test_browser_lynx.py` to test valid and invalid URL schemes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for db4306b04ff25175f1cc133b666826e14a080c7e. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->