### PR TITLE
fix(security): validate screenshot path stays within OUTPUT_DIR

### DIFF
--- a/gptme/tools/screenshot.py
+++ b/gptme/tools/screenshot.py
@@ -94,31 +94,6 @@ def screenshot(path: Path | None = None) -> Path:
         )
 
 
-def test_screenshot_path_validation():
-    """Test that path traversal attempts are blocked."""
-    import pytest
-
-    # Valid paths within OUTPUT_DIR should work
-    valid_path = OUTPUT_DIR / "test.png"
-    result = _validate_screenshot_path(valid_path)
-    assert result == valid_path.resolve()
-
-    # Subdirectory within OUTPUT_DIR should work
-    subdir_path = OUTPUT_DIR / "subdir" / "test.png"
-    result = _validate_screenshot_path(subdir_path)
-    # Note: parent may not exist yet, but the path should still validate
-
-    # Path traversal attempts should be blocked
-    with pytest.raises(ValueError, match="must be within"):
-        _validate_screenshot_path(Path("/etc/passwd"))
-
-    with pytest.raises(ValueError, match="must be within"):
-        _validate_screenshot_path(OUTPUT_DIR / ".." / "etc" / "passwd")
-
-    with pytest.raises(ValueError, match="must be within"):
-        _validate_screenshot_path(Path("/tmp/outputs/../evil.png"))
-
-
 tool = ToolSpec(
     name="screenshot",
     desc="Take a screenshot",

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -1,0 +1,30 @@
+"""Tests for screenshot tool security."""
+
+from pathlib import Path
+
+import pytest
+
+from gptme.tools.screenshot import OUTPUT_DIR, _validate_screenshot_path
+
+
+def test_screenshot_path_validation():
+    """Test that path traversal attempts are blocked."""
+    # Valid paths within OUTPUT_DIR should work
+    valid_path = OUTPUT_DIR / "test.png"
+    result = _validate_screenshot_path(valid_path)
+    assert result == valid_path.resolve()
+
+    # Subdirectory within OUTPUT_DIR should work
+    subdir_path = OUTPUT_DIR / "subdir" / "test.png"
+    result = _validate_screenshot_path(subdir_path)
+    # Note: parent may not exist yet, but the path should still validate
+
+    # Path traversal attempts should be blocked
+    with pytest.raises(ValueError, match="must be within"):
+        _validate_screenshot_path(Path("/etc/passwd"))
+
+    with pytest.raises(ValueError, match="must be within"):
+        _validate_screenshot_path(OUTPUT_DIR / ".." / "etc" / "passwd")
+
+    with pytest.raises(ValueError, match="must be within"):
+        _validate_screenshot_path(Path("/tmp/outputs/../evil.png"))


### PR DESCRIPTION
## Summary

Security fix that validates user-provided screenshot paths stay within the `OUTPUT_DIR` (/tmp/outputs). Prevents path traversal attacks that could write screenshots to arbitrary system locations.

## Problem

The screenshot tool accepts an optional `path` parameter that was used directly without validation:
```python
screenshot(Path('/etc/cron.d/malicious'))  # Would write to system directory!
```

## Solution

Added `_validate_screenshot_path()` function that:
1. Resolves both OUTPUT_DIR and user path (handles `..` and symlinks)
2. Uses `relative_to()` to verify path stays within OUTPUT_DIR
3. Raises `ValueError` for escape attempts

## Testing

Added `test_screenshot_path_validation()` covering:
- ✅ Valid paths within OUTPUT_DIR
- ✅ Path traversal attempts (`../`)
- ✅ Absolute paths outside OUTPUT_DIR

## Security Impact

This is a **CRITICAL** security fix from the security audit (gptme/gptme#1021).

Blocks:
- Arbitrary file writes via screenshot path parameter
- Path traversal attacks
- Writing to system directories

---
Co-authored-by: Bob <bob@superuserlabs.org>
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds path validation to `screenshot.py` to prevent path traversal attacks by ensuring paths stay within `OUTPUT_DIR`.
> 
>   - **Security Fix**:
>     - Adds `_validate_screenshot_path()` in `screenshot.py` to ensure paths stay within `OUTPUT_DIR`.
>     - Uses `resolve()` and `relative_to()` to prevent path traversal and symlink attacks.
>     - Raises `ValueError` for invalid paths.
>   - **Functionality**:
>     - Updates `screenshot()` in `screenshot.py` to use `_validate_screenshot_path()` for user-provided paths.
>   - **Testing**:
>     - Adds `test_screenshot_path_validation()` in `test_screenshot.py` to test valid paths, path traversal, and absolute paths outside `OUTPUT_DIR`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for b6a48bca78fa3cfbc10b02b2b436c5000df3c8a7. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->