### PR TITLE
fix(llm): add safe parsing for environment variables

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -159,9 +159,10 @@ def init(provider: Provider, config: Config):
     timeout_str = config.get_env("LLM_API_TIMEOUT")
     try:
         timeout = float(timeout_str) if timeout_str else NOT_GIVEN
-    except ValueError:
-        logger.warning(f"Invalid LLM_API_TIMEOUT value: {timeout_str!r}, using default")
-        timeout = NOT_GIVEN
+    except ValueError as parse_err:
+        raise ValueError(
+            f"Invalid LLM_API_TIMEOUT value: {timeout_str!r}. Must be a valid number."
+        ) from parse_err
 
     if provider == "openai":
         api_key = proxy_key or config.get_env_required("OPENAI_API_KEY")

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -380,10 +380,11 @@ def test_timeout_all_providers(monkeypatch):
                 ), f"Provider {provider} didn't receive correct timeout"
 
 
-def test_timeout_invalid_value(monkeypatch, caplog):
-    """Test that invalid timeout values log a warning and use default."""
-    import logging
+def test_timeout_invalid_value(monkeypatch):
+    """Test that invalid timeout values raise ValueError with clear message."""
     from unittest.mock import patch
+
+    import pytest
 
     import gptme.llm.llm_openai as llm_openai
     from gptme.config import get_config
@@ -398,13 +399,10 @@ def test_timeout_invalid_value(monkeypatch, caplog):
     # Get config instance
     config = get_config()
 
-    with caplog.at_level(logging.WARNING):
-        with patch("openai.OpenAI"):
-            # Should NOT raise - instead logs warning and uses default
+    with patch("openai.OpenAI"):
+        # Should raise ValueError on invalid config
+        with pytest.raises(ValueError, match="Invalid LLM_API_TIMEOUT"):
             llm_openai.init("openai", config)
-
-    # Verify warning was logged about invalid timeout
-    assert any("Invalid LLM_API_TIMEOUT" in record.message for record in caplog.records)
 
 
 def test_message_conversion_gpt5_with_tool_results():


### PR DESCRIPTION
## Summary
Fixes unsafe environment variable parsing that could crash with ValueError on malformed inputs.

### Changes
- Wrap `int()` conversion for GPTME_TEST_MAX_RETRIES in try-except
- Wrap `float()` conversion for LLM_API_TIMEOUT in try-except (both providers)
- Wrap `int()` conversion for reasoning budget in try-except (2 locations)
- Log warnings for invalid values and use safe defaults

### Before
```bash
LLM_API_TIMEOUT=invalid gptme
# Crashes with ValueError: could not convert string to float: 'invalid'
```

### After
```bash
LLM_API_TIMEOUT=invalid gptme
# Logs warning, uses default timeout, continues working
```

Addresses Issue #1028 (CC analysis findings)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add safe parsing for environment variables in `llm_anthropic.py` and `llm_openai.py` to prevent crashes from invalid inputs.
> 
>   - **Behavior**:
>     - Wrap `int()` conversion for `GPTME_TEST_MAX_RETRIES` in `llm_anthropic.py` with try-except to handle `ValueError`.
>     - Wrap `float()` conversion for `LLM_API_TIMEOUT` in `llm_anthropic.py` and `llm_openai.py` with try-except to handle `ValueError`.
>     - Wrap `int()` conversion for `ENV_REASONING_BUDGET` in `llm_anthropic.py` (2 locations) with try-except to handle `ValueError`.
>     - Log warnings for invalid values and use safe defaults.
>   - **Tests**:
>     - Add `test_timeout_invalid_value` in `test_llm_openai.py` to verify `ValueError` is raised for invalid `LLM_API_TIMEOUT` values.
>     - Update `test_timeout_all_providers` in `test_llm_openai.py` to ensure timeout is passed to all providers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 5a29386d25f8e567d41a497d926346b071da4780. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->