### PR TITLE
fix(eval): prevent race condition in result retrieval

### DIFF
--- a/gptme/eval/run.py
+++ b/gptme/eval/run.py
@@ -226,6 +226,10 @@ def execute(
             if p.is_alive():
                 p.terminate()
                 p.join(timeout=1)
+                # Force kill if still alive to prevent race condition on sync_dict
+                if p.is_alive():
+                    p.kill()
+                    p.join()  # Wait for forced termination
 
         if "result" in sync_dict:
             result = sync_dict["result"]


### PR DESCRIPTION
## Summary

Fixes race condition when reading evaluation results from shared dictionary.

## Problem

After calling `p.terminate()` and `p.join(timeout=1)`, the code continues to access `sync_dict` even if the process is still alive:

```python
finally:
    if p.is_alive():
        p.terminate()
        p.join(timeout=1)
    # Process might STILL be alive here, writing to sync_dict!

if "result" in sync_dict:  # Race condition - reading while writing
```

## Solution

Force-kill the process if it doesn't respond to SIGTERM within 1 second:

```python
finally:
    if p.is_alive():
        p.terminate()
        p.join(timeout=1)
        if p.is_alive():
            p.kill()  # Force kill
            p.join()  # Wait for forced termination
```

This ensures the subprocess is definitely dead before reading from the shared dictionary.

## Related

- HIGH priority Finding 2 from Issue #1031
- Part of systematic code quality improvements from ErikBjare/bob#220
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes race condition in `execute()` in `run.py` by forcefully terminating subprocesses to ensure safe access to shared dictionary.
> 
>   - **Behavior**:
>     - Fixes race condition in `execute()` in `run.py` by ensuring subprocess is forcefully terminated if still alive after SIGTERM.
>     - Adds `p.kill()` and `p.join()` after `p.terminate()` and `p.join(timeout=1)` to ensure process is dead before accessing `sync_dict`.
>   - **Related**:
>     - Addresses HIGH priority Finding 2 from Issue #1031.
>     - Part of code quality improvements from ErikBjare/bob#220.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for d50e380efaa0685e1141d936e8396a5d5aac3c31. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->