### PR TITLE
fix(eval): add thread-safe locking for environment variable mutation

### DIFF
--- a/gptme/eval/run.py
+++ b/gptme/eval/run.py
@@ -188,7 +188,12 @@ def run_evals(
 
 # TODO: rewrite to run in Docker? Would help with capturing output + process management.
 def execute(
-    test: EvalSpec, agent: Agent, timeout: int, parallel: bool, use_docker: bool = False
+    test: EvalSpec,
+    agent: Agent,
+    timeout: int,
+    parallel: bool,
+    use_docker: bool = False,
+    suppress_output: bool = False,
 ) -> EvalResult:
     """
     Executes the code for a specific model with a timeout.
@@ -209,6 +214,7 @@ def execute(
                 test["files"],
                 sync_dict,
                 parallel,
+                suppress_output,
             ),
         )
 
@@ -338,6 +344,7 @@ def act_process(
     files: dict[str, str | bytes],
     sync_dict: SyncedDict,
     parallel: bool,
+    suppress_output: bool = False,
 ):
     # Configure logging for this subprocess
     subprocess_logger = logging.getLogger(f"gptme.eval:{agent.model}@{test_name}")
@@ -351,9 +358,7 @@ def act_process(
     # Fix #130: Suppress verbose gptme output during optimization
     # Only keep output if not in parallel mode (i.e., interactive testing)
     # During GEPA optimization, suppress full trajectories
-    suppress_output = (
-        os.environ.get("GPTME_EVAL_SUPPRESS_OUTPUT", "false").lower() == "true"
-    )
+    # Note: suppress_output is passed directly to avoid os.environ race conditions
     if suppress_output:
         # Redirect to null during optimization
         import io


### PR DESCRIPTION
## Summary

Adds thread-safe locking around environment variable modifications in the prompt optimizer.

## Problem

The code modifies global `os.environ` in code that can run in parallel:

```python
os.environ["GPTME_EVAL_SUPPRESS_OUTPUT"] = "true"
try:
    eval_result = execute(...)
finally:
    os.environ.pop("GPTME_EVAL_SUPPRESS_OUTPUT", None)
```

In parallel execution:
1. Thread A sets `GPTME_EVAL_SUPPRESS_OUTPUT = "true"`
2. Thread B sets `GPTME_EVAL_SUPPRESS_OUTPUT = "true"`
3. Thread A finishes and pops it
4. Thread B's execution now runs without suppression (race condition)

## Solution

Use a module-level `threading.Lock` to serialize environment modifications:

```python
_env_lock = threading.Lock()

# In the function:
with _env_lock:
    os.environ["GPTME_EVAL_SUPPRESS_OUTPUT"] = "true"
    try:
        eval_result = execute(...)
    finally:
        os.environ.pop("GPTME_EVAL_SUPPRESS_OUTPUT", None)
```

## Related

- HIGH priority Finding 9 from Issue #1031
- Part of systematic code quality improvements from ErikBjare/bob#220
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `suppress_output` parameter to `execute()` to handle output suppression directly, avoiding `os.environ` race conditions in parallel execution.
> 
>   - **Behavior**:
>     - Adds `suppress_output` parameter to `execute()` in `run.py` to handle output suppression directly, avoiding `os.environ` race conditions.
>     - Updates `forward()` in `prompt_optimizer.py` to pass `suppress_output=True` to `execute()`.
>   - **Functions**:
>     - Modifies `act_process()` in `run.py` to use `suppress_output` parameter for output redirection.
>   - **Misc**:
>     - Removes `os.environ` manipulation for `GPTME_EVAL_SUPPRESS_OUTPUT` in `prompt_optimizer.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 41e3a660e37213a47c8679cd2a5a451a545cee00. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->