### PR TITLE
fix(llm): explicitly close stream generator in finally block

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -340,6 +340,9 @@ def _reply_stream(
             "assistant", output + "... ^C Interrupted", metadata=stream.metadata
         )
     finally:
+        # Explicitly close the underlying generator to release resources
+        # This handles all exit paths: normal completion, KeyboardInterrupt, and tool break
+        stream.gen.close()
         print_clear()
         if first_token_time:
             end_time = time.time()


### PR DESCRIPTION
## Summary

Addresses Finding 4 (HIGH - Reliability) from Issue #1034.

## Changes

- Add `stream.gen.close()` in finally block of `_reply_stream`
- Ensures underlying generator is properly closed on all exit paths

## Exit Paths Covered

1. **Normal completion**: Generator naturally exhausts
2. **KeyboardInterrupt**: User interrupts, generator closed before return
3. **Tool use break**: Early exit to run tool, generator closed

## Testing

- Module imports successfully
- Generator close is idempotent (safe to call multiple times)

## Related

- Issue #1034 (Finding 4)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `stream.gen.close()` in `_reply_stream` to ensure generator closure on all exit paths, enhancing reliability.
> 
>   - **Behavior**:
>     - Adds `stream.gen.close()` in the `finally` block of `_reply_stream` to ensure the generator is closed on all exit paths.
>     - Handles exit paths: normal completion, `KeyboardInterrupt`, and tool use break.
>   - **Testing**:
>     - Confirms module imports successfully.
>     - Verifies generator close is idempotent.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 7cd529ee23196384c6a6708f04d7320d1035e7ec. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->