### PR TITLE
fix(logmanager): ensure lock is released if atexit registration fails

### DIFF
--- a/gptme/logmanager.py
+++ b/gptme/logmanager.py
@@ -131,18 +131,23 @@ class LogManager:
             # Try to acquire an exclusive lock
             try:
                 fcntl.flock(self._lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                # logger.debug(f"Acquired lock on {self.logdir}")
-
-                # Register cleanup handler to release lock on exit
-                import atexit
-
-                atexit.register(self._release_lock)
             except BlockingIOError:
                 self._lock_fd.close()
                 self._lock_fd = None
                 raise RuntimeError(
                     f"Another gptme instance is using {self.logdir}"
                 ) from None
+
+            # Lock acquired successfully - register cleanup handler
+            # Use try/except to ensure lock is released if registration fails
+            try:
+                import atexit
+
+                atexit.register(self._release_lock)
+            except Exception:
+                # Release lock if atexit registration fails
+                self._release_lock()
+                raise
 
         # load branches from adjacent files
         self._branches = {self.current_branch: Log(log or [])}


### PR DESCRIPTION
## Summary

Fixes **HIGH severity finding #6** from Issue #1034 (chat.py code quality analysis).

## Problem

If `fcntl.flock` succeeds but subsequent code raises an exception before `atexit.register`, the lock is never released. This could leave the log directory permanently locked.

## Changes

- Separated lock acquisition try/except from atexit registration
- Added try/except around atexit registration that releases the lock if registration fails
- Ensures the lock is always released if any part of the initialization fails after acquiring the lock

## Testing

- `test_logmanager.py` passes (1/1)
- Manual verification of code flow

## Related

- Issue #1034 (Finding 6: Log File Lock Not Released on Exception)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes lock release issue in `LogManager` by ensuring lock is released if `atexit.register` fails.
> 
>   - **Behavior**:
>     - Ensures lock is released if `atexit.register` fails in `LogManager.__init__()` in `logmanager.py`.
>     - Separates lock acquisition and `atexit` registration into distinct try/except blocks.
>   - **Testing**:
>     - `test_logmanager.py` passes all tests.
>     - Manual verification of code flow.
>   - **Related**:
>     - Fixes HIGH severity issue #6 from Issue #1034.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for f05945e6bd7eaf5d4752a009cd05bbcc14cc9550. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->