### PR TITLE
fix(eval): move init_tools outside inner function to avoid repeated calls

### DIFF
--- a/gptme/eval/dspy/metrics.py
+++ b/gptme/eval/dspy/metrics.py
@@ -262,6 +262,8 @@ def create_tool_usage_metric() -> Callable[[Any, Any, Any | None], float]:
     Returns:
         A metric function that evaluates tool usage patterns
     """
+    # Initialize tools once when metric is created, not on every evaluation
+    init_tools(["save", "shell", "patch", "read", "ipython"])
 
     def tool_usage_metric(gold: Any, pred: Any, trace: Any | None = None) -> float:
         """
@@ -282,9 +284,6 @@ def create_tool_usage_metric() -> Callable[[Any, Any, Any | None], float]:
         # Count tool calls
         tool_calls = []
         used_tools = set()
-
-        # Initialize tools first (they're not loaded in this context)
-        init_tools(["save", "shell", "patch", "read", "ipython"])
 
         for msg in messages:
             if msg.role == "assistant":


### PR DESCRIPTION
## Summary

Move `init_tools()` call from `tool_usage_metric()` inner function to `create_tool_usage_metric()` outer function. This ensures tools are initialized once when the metric is created, not on every evaluation.

## Issue

Addresses **Finding 12** from Issue #1031: `dspy/metrics.py:287 - init_tools called repeatedly`

## Changes

- Move `init_tools(["save", "shell", "patch", "read", "ipython"])` from inside the inner `tool_usage_metric()` function to the outer `create_tool_usage_metric()` function
- Tools are now initialized once when the metric factory is called, not on every evaluation

## Impact

- Reduces redundant tool initialization overhead during evaluation runs
- No functional change to the evaluation logic itself
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move `init_tools()` call to `create_tool_usage_metric()` to avoid repeated initialization in `metrics.py`.
> 
>   - **Behavior**:
>     - Move `init_tools()` call from `tool_usage_metric()` to `create_tool_usage_metric()` in `metrics.py`.
>     - Tools initialized once when metric is created, not on every evaluation.
>   - **Impact**:
>     - Reduces redundant tool initialization overhead during evaluation runs.
>     - No change to evaluation logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 59f58e54c3761e0eaacdfa1b34f8b419ecfe8369. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->