### PR TITLE
fix(eval): prevent SIGTERM self-kill from overwriting success result

### DIFF
--- a/gptme/eval/run.py
+++ b/gptme/eval/run.py
@@ -443,5 +443,9 @@ def act_process(
     sync_dict["result"] = result_success
     subprocess_logger.info("Success")
 
+    # Reset SIGTERM handler before cleanup to prevent self-termination
+    # from overwriting the success result
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
     # kill child processes gracefully
     _graceful_killpg(pgrp)


### PR DESCRIPTION
## Problem

CI on master started failing after PR #1042 was merged. The `test_eval_cli` and `test_eval[hello-patch]` tests fail with `results=[]` even when the generation completes successfully.

## Root Cause

When `act_process` successfully completes, it:
1. Writes `result_success` to `sync_dict`
2. Calls `_graceful_killpg(pgrp)` to clean up child processes

However, `_graceful_killpg` sends SIGTERM to the **entire process group**, which includes `act_process` itself! This triggers the SIGTERM handler which overwrites `sync_dict['result']` with an error result.

The sequence:
1. ✅ `sync_dict['result'] = result_success`
2. `_graceful_killpg(pgrp)` called
3. `os.killpg(pgrp, signal.SIGTERM)` - sends SIGTERM to self!
4. SIGTERM handler fires
5. ❌ `sync_dict['result'] = result_error` - overwrites success!

## Fix

Reset SIGTERM handler to `SIG_IGN` before cleanup in the success path, preventing the self-termination signal from clobbering the result.

## Testing

This fix should restore CI to green on master.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes SIGTERM signal handling in `act_process()` to prevent overwriting success results with errors in `run.py`.
> 
>   - **Behavior**:
>     - Fixes issue in `act_process()` in `run.py` where SIGTERM signal overwrites success result with error.
>     - Resets SIGTERM handler to `SIG_IGN` before calling `_graceful_killpg()` to prevent self-termination.
>   - **Testing**:
>     - Aims to restore CI functionality by preventing erroneous result overwrites.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for b8292cb8bf200e5a15d659a8d0d79d1177eb6092. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->