### PR TITLE
fix(llm): replace bare assert with proper error for empty LLM responses

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -350,7 +350,10 @@ def chat(
         if choice.message.content:
             result.append(choice.message.content)
 
-    assert result
+    if not result:
+        raise ValueError(
+            f"LLM returned empty response (finish_reason={choice.finish_reason})"
+        )
     return "\n".join(result), metadata
 
 


### PR DESCRIPTION
## Problem

When an OpenAI-compatible API returns an empty response, the bare `assert result` on line 353 raises an `AssertionError` with an **empty message**, making debugging impossible.

## Root Cause

```python
assert result  # If result is empty list, raises AssertionError('')
```

This can happen when:
- API returns empty response
- Model refuses to respond  
- Network/timeout issues cause truncated responses
- Rate limiting returns empty content

## Solution

Replace bare assert with proper error handling:

```python
if not result:
    raise ValueError(
        f"LLM returned empty response (finish_reason={choice.finish_reason})"
    )
```

Now users see a helpful message like:
```
LLM returned empty response (finish_reason=stop)
```

## Related

- PR #1056 - Fixed similar issue in autocompact.py
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces bare `assert` with `ValueError` in `chat()` in `llm_openai.py` for better error handling of empty LLM responses.
> 
>   - **Behavior**:
>     - Replaces bare `assert result` with `if not result: raise ValueError(...)` in `chat()` in `llm_openai.py`.
>     - Handles cases where LLM response is empty due to API issues, model refusal, network problems, or rate limiting.
>   - **Error Message**:
>     - New error message includes `finish_reason` for better debugging context.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for cb11d1d91f47a01e9c477141bd09d209fc719317. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->