### PR TITLE
fix(lessons): deduplicate lessons by resolved path in matcher

### DIFF
--- a/tests/test_lessons_matcher.py
+++ b/tests/test_lessons_matcher.py
@@ -443,3 +443,45 @@ Test content.
         # Should have both keywords in matched_by
         assert "keyword:keyword one" in results[0].matched_by
         assert "keyword:keyword two" in results[0].matched_by
+
+    def test_match_keywords_deduplication(self, tmp_path):
+        """Test that match_keywords also deduplicates by resolved path.
+
+        Ensures consistency between match() and match_keywords() methods.
+        """
+        # Create a lesson file
+        lesson_dir = tmp_path / "lessons"
+        lesson_dir.mkdir()
+        lesson_file = lesson_dir / "test-lesson.md"
+        lesson_file.write_text(
+            """---
+match:
+  keywords:
+    - "keyword one"
+    - "keyword two"
+status: active
+---
+# Test Lesson
+
+Test content.
+"""
+        )
+
+        # Parse the lesson twice (simulating duplicate entries)
+        from gptme.lessons.parser import parse_lesson
+
+        lesson1 = parse_lesson(lesson_file)
+        lesson2 = parse_lesson(lesson_file)
+
+        # Create list with duplicates
+        lessons_with_duplicates = [lesson1, lesson2]
+
+        # match_keywords should also deduplicate
+        matcher = LessonMatcher()
+        results = matcher.match_keywords(
+            lessons_with_duplicates, ["keyword one", "keyword two"]
+        )
+
+        # Should only return ONE result despite two entries in input
+        assert len(results) == 1
+        assert results[0].lesson.title == "Test Lesson"


### PR DESCRIPTION
## Summary

Fixes #1059 - Lessons matching multiple keywords could appear multiple times in the same inclusion block.

## Problem

When a lesson matches multiple keywords in the same context, it could appear multiple times in the results. Analysis showed ~14% of lesson inclusions were duplicates (276 of 889 blocks affected).

Example from Bob's workspace:
```
Block 5 with duplicates:
  - Cross-Agent Workspace Review
  - Respond to ALL Actionable Items [DUP]
  - Respond to ALL Actionable Items [DUP]
  - CASCADE (Context Management Strategy)
```

## Root Cause

While `LessonIndex` deduplicates during indexing, the same directory can appear multiple times in `lesson_dirs` (e.g., `./lessons` is both auto-discovered AND explicitly configured in gptme.toml). Additionally, symlinks or multiple path representations could slip past the index-level deduplication.

## Solution

Added path-based deduplication in `LessonMatcher.match()` using `os.path.realpath()` to ensure each unique lesson file only appears once in results. This is a defense-in-depth fix that:

1. Tracks seen lesson paths during matching
2. Skips any lesson whose resolved path has already been processed
3. Logs debug message when duplicates are skipped

## Testing

- Added new test `test_deduplication_by_resolved_path` that verifies duplicate lessons are deduplicated
- All 23 matcher tests pass
- All 18 index tests pass

## Impact

- Eliminates ~14% wasted context tokens from duplicate lessons
- Fixes confusing output (e.g., "Auto-included 5 lessons" when only 3 unique)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds path-based deduplication in `LessonMatcher` to prevent duplicate lessons in results, with tests verifying the fix.
> 
>   - **Behavior**:
>     - Adds path-based deduplication in `LessonMatcher.match()` and `LessonMatcher.match_keywords()` using `os.path.realpath()` to ensure unique lesson files in results.
>     - Logs debug message when duplicates are skipped.
>   - **Testing**:
>     - Adds `test_deduplication_by_resolved_path` and `test_match_keywords_deduplication` to verify deduplication logic.
>     - All existing matcher and index tests pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for b2ed1f6966fe20d03ba2dccad4c11bdf4e73bd38. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->