### PR TITLE
fix(llm): prevent division by zero in token rate calculation

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -346,11 +346,14 @@ def _reply_stream(
         print_clear()
         if first_token_time:
             end_time = time.time()
+            gen_time = max(
+                end_time - first_token_time, 0.001
+            )  # Prevent division by zero
             logger.debug(
                 f"Generation finished in {end_time - start_time:.1f}s "
                 f"(ttft: {first_token_time - start_time:.2f}s, "
-                f"gen: {end_time - first_token_time:.2f}s, "
-                f"tok/s: {len_tokens(output, model)/(end_time - first_token_time):.1f})"
+                f"gen: {gen_time:.2f}s, "
+                f"tok/s: {len_tokens(output, model) / gen_time:.1f})"
             )
 
     return Message("assistant", output, metadata=stream.metadata)


### PR DESCRIPTION
## Summary

Fixes HIGH severity finding from Issue #1030.

## Problem

The token rate calculation in `_reply_stream` could cause a `ZeroDivisionError` if `end_time` equals `first_token_time`. This can happen due to:
- Timing precision (instant generation)
- Cached responses returning immediately
- Very fast token generation

## Solution

Use `max(duration, 0.001)` to ensure the divisor is never zero, providing a safe minimum of 1ms.

## Changes

- Added `gen_time` variable with safe minimum to prevent division by zero
- Updated logger.debug call to use the safe duration value

## Testing

- Verified import works without syntax errors
- Minimal change, low risk

## Related

- Fixes finding #1 from Issue #1030 (llm/ code quality findings)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `ZeroDivisionError` in `_reply_stream` by ensuring a minimum duration of 1ms for token rate calculation in `gptme/llm/__init__.py`.
> 
>   - **Behavior**:
>     - Fixes `ZeroDivisionError` in `_reply_stream` by ensuring `end_time - first_token_time` is at least 0.001 seconds.
>     - Updates `logger.debug` in `_reply_stream` to use the safe duration value `gen_time`.
>   - **Testing**:
>     - Verified import works without syntax errors.
>     - Minimal change, low risk.
>   - **Related**:
>     - Fixes finding #1 from Issue #1030.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for ee05dc92ac8a98f35fb34bbc82905ee4aa233180. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->