### PR TITLE
fix(llm): check raw file size instead of base64 encoded size

### DIFF
--- a/gptme/llm/utils.py
+++ b/gptme/llm/utils.py
@@ -173,11 +173,9 @@ def process_image_file(
         )
         return None
 
-    data = base64.b64encode(data_bytes).decode("utf-8")
-
-    # check that the file is not too large
+    # check that the file is not too large (check raw bytes before encoding)
     max_size_bytes = max_size_mb * 1_024 * 1_024
-    if len(data) > max_size_bytes:
+    if len(data_bytes) > max_size_bytes:
         content_parts.append(
             {
                 "type": "text",
@@ -186,6 +184,7 @@ def process_image_file(
         )
         return None
 
+    data = base64.b64encode(data_bytes).decode("utf-8")
     return data, media_type
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,69 @@
+"""Tests for llm/utils.py"""
+
+import base64
+from pathlib import Path
+
+
+def test_image_size_check_uses_raw_bytes(tmp_path: Path) -> None:
+    """Test that image size validation uses raw bytes, not base64-encoded size.
+
+    This test verifies the fix for Issue #1030 Finding 3: the size check
+    should compare raw file bytes against the limit, not the base64-encoded
+    size (which is ~33% larger).
+    """
+    from gptme.llm.utils import process_image_file
+
+    # Create a test image file that is 0.8MB raw (within 1MB limit)
+    # but would be ~1.07MB when base64 encoded (exceeds limit if checked wrong)
+    raw_size_bytes = int(0.8 * 1024 * 1024)  # 0.8 MB
+    test_image = tmp_path / "test.png"
+
+    # Write raw bytes (just need file of correct size, not valid image)
+    # Use PNG magic bytes so it's detected as an image
+    png_header = b"\x89PNG\r\n\x1a\n"
+    test_image.write_bytes(png_header + b"\x00" * (raw_size_bytes - len(png_header)))
+
+    # With max_size_mb=1.0, a 0.8MB file should pass
+    # If the check used base64 size (~1.07MB), it would incorrectly fail
+    content_parts: list[dict] = []
+    result = process_image_file(
+        file_path=str(test_image),
+        max_size_mb=1.0,
+        content_parts=content_parts,
+    )
+
+    # Should succeed - file is within raw size limit
+    assert (
+        result is not None
+    ), f"0.8MB file should pass 1MB limit, but got error: {content_parts}"
+    data, media_type = result
+    assert media_type == "image/png"
+    assert data is not None
+
+    # Verify the returned data is base64 encoded and larger than raw
+    decoded = base64.b64decode(data)
+    assert len(decoded) == raw_size_bytes
+    assert len(data) > raw_size_bytes  # base64 is ~33% larger
+
+
+def test_image_size_check_rejects_oversized_files(tmp_path: Path) -> None:
+    """Test that files exceeding the raw size limit are rejected."""
+    from gptme.llm.utils import process_image_file
+
+    # Create a file that is 1.2MB (exceeds 1MB limit)
+    raw_size_bytes = int(1.2 * 1024 * 1024)  # 1.2 MB
+    test_image = tmp_path / "large.png"
+    png_header = b"\x89PNG\r\n\x1a\n"
+    test_image.write_bytes(png_header + b"\x00" * (raw_size_bytes - len(png_header)))
+
+    content_parts: list[dict] = []
+    result = process_image_file(
+        file_path=str(test_image),
+        max_size_mb=1.0,
+        content_parts=content_parts,
+    )
+
+    # Should fail - file exceeds raw size limit
+    assert result is None
+    assert len(content_parts) == 2
+    assert "exceeds 1.0MB" in content_parts[1]["text"]


### PR DESCRIPTION
## Summary

Fix for Issue #1030 Finding 3 (MEDIUM): Image size validation was comparing base64-encoded size against raw byte limit.

### Problem
Base64 encoding adds ~33% overhead, so a 0.8MB file becomes ~1.07MB encoded. This caused files within the raw size limit to be incorrectly rejected.

### Fix
- Check `len(data_bytes)` (raw size) instead of `len(data)` (base64 size)
- Move size check before base64 encoding for efficiency

### Tests
Added `tests/test_utils.py` with 2 tests verifying correct size check behavior.

Related: #1030 (Finding 3)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `process_image_file()` to validate image size using raw bytes instead of base64 size, with tests added for verification.
> 
>   - **Behavior**:
>     - Fix `process_image_file()` in `utils.py` to check `len(data_bytes)` (raw size) instead of `len(data)` (base64 size).
>     - Move size check before base64 encoding for efficiency.
>   - **Tests**:
>     - Add `test_image_size_check_uses_raw_bytes()` in `test_utils.py` to verify raw byte size check.
>     - Add `test_image_size_check_rejects_oversized_files()` in `test_utils.py` to ensure oversized files are rejected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for d3faf20e778c38fa9810b1fec8434a8ef105cc0f. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->