### PR TITLE
feat(llm): add retry logic for OpenAI API transient errors

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -374,17 +374,32 @@ def retry_generator_on_openai_error(max_retries: int = 5, base_delay: float = 1.
     """Decorator to retry generator functions on OpenAI API transient errors with exponential backoff.
 
     Handles 5xx server errors, rate limits, and other transient API issues.
+
+    Note: Retries only happen if no content has been yielded yet. Once streaming
+    has started, errors are raised immediately to prevent duplicate output.
     """
 
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
             for attempt in range(max_retries):
+                has_yielded = False
                 try:
-                    # Use 'return (yield from ...)' to propagate the generator's return value
-                    # Without 'return', the metadata returned by stream() would be lost
-                    return (yield from func(*args, **kwargs))
+                    gen = func(*args, **kwargs)
+                    while True:
+                        try:
+                            value = next(gen)
+                        except StopIteration as e:
+                            # Generator finished normally, return its value
+                            return e.value
+                        # Mark as yielded BEFORE yielding to consumer
+                        # This ensures we don't retry if consumer throws
+                        has_yielded = True
+                        yield value
                 except Exception as e:
+                    if has_yielded:
+                        # Can't retry after streaming has started - would cause duplicates
+                        raise
                     _handle_openai_transient_error(e, attempt, max_retries, base_delay)
 
         return wrapper


### PR DESCRIPTION
## Summary

Add exponential backoff retry logic to the OpenAI provider, matching the pattern already implemented in the Anthropic provider. This addresses Issue #1030 Finding 6 (MEDIUM priority).

## Changes

- Add `_handle_openai_transient_error()` to handle 429, 5xx, and connection errors
- Add `retry_on_openai_error()` decorator for regular functions  
- Add `retry_generator_on_openai_error()` decorator for generator functions
- Apply decorators to `chat()` and `stream()` functions
- Add 6 comprehensive tests for retry logic

## Retry Logic

The implementation retries on:
- 429 rate limit errors with exponential backoff
- 5xx server errors (500-599, transient)
- `APIConnectionError` (network issues)
- Error messages containing 'overload', 'internal', 'timeout'

Configuration:
- 5 max retries (same as Anthropic)
- 1 second base delay with exponential backoff
- Respects `GPTME_TEST_MAX_RETRIES` env var for test control

## Testing

Added 6 tests covering:
- Rate limit error handling
- Server error (5xx) handling  
- Client error (4xx) not retried
- Max retries reached behavior
- Regular function decorator retry behavior
- Generator function decorator retry behavior

All tests pass.

## Related

- Issue #1030 Finding 6 (MEDIUM): No retry logic for OpenAI transient errors
- Mirrors the retry pattern in `llm_anthropic.py`
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds retry logic for OpenAI API transient errors with exponential backoff and comprehensive tests.
> 
>   - **Behavior**:
>     - Adds `_handle_openai_transient_error()` in `llm_openai.py` for handling 429, 5xx, and connection errors with exponential backoff.
>     - Introduces `retry_on_openai_error()` and `retry_generator_on_openai_error()` decorators for retrying functions and generator functions.
>     - Applies these decorators to `chat()` and `stream()` functions in `llm_openai.py`.
>   - **Testing**:
>     - Adds 6 tests in `test_llm_openai.py` to cover retry logic for rate limit errors, server errors, client errors, max retries, and behavior of retry decorators.
>   - **Configuration**:
>     - Supports configuration of max retries and base delay via environment variables, with a default of 5 retries and 1 second base delay.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 99e81724afa2f29726d25212c4f38499f701f535. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->