### PR TITLE
fix(llm): log exceptions instead of silently swallowing them

### DIFF
--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -519,9 +519,13 @@ def get_model(model: str) -> ModelMeta:
                     for model_meta in models:
                         if model_meta.model == model_name:
                             return model_meta
-                except Exception:
+                except Exception as e:
                     # Fall back to unknown model metadata
-                    pass
+                    logger.debug(
+                        "Failed to fetch OpenRouter models for %s: %s",
+                        model_name,
+                        e,
+                    )
 
             # Unknown model, use fallback metadata
             if provider not in ["openrouter", "local"]:
@@ -547,8 +551,8 @@ def get_model(model: str) -> ModelMeta:
             for model_meta in openrouter_models:
                 if model_meta.model == model:
                     return model_meta
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Failed to fetch OpenRouter models for %s: %s", model, e)
 
         logger.warning(f"Unknown model {model}, using fallback metadata")
         return ModelMeta(provider="unknown", model=model, context=128_000)
@@ -611,8 +615,13 @@ def _get_models_for_provider(
         try:
             dynamic_models = get_available_models(provider)
             models_to_show = dynamic_models
-        except Exception:
+        except Exception as e:
             # Fall back to static models (only for built-in providers)
+            logger.debug(
+                "Failed to fetch dynamic models for %s, falling back to static: %s",
+                provider,
+                e,
+            )
             if provider in MODELS:
                 static_models = [
                     get_model(f"{provider}/{name}") for name in MODELS[provider]


### PR DESCRIPTION
## Summary

Add debug-level logging to three exception handlers in `models.py` that were silently swallowing exceptions. This helps developers debug auth/network issues while maintaining the graceful fallback behavior.

## Changes

- **Line 522**: Log exception when OpenRouter model fetch fails (in `get_model()`)
- **Line 554**: Log exception when OpenRouter model fetch fails (in `get_model()` different branch)
- **Line 618**: Log exception when dynamic model fetch fails (in `_get_models_for_provider()`)

All logging uses `logger.debug()` level to avoid noise in normal operation while being available when developers need to diagnose issues.

## Fixes

Closes finding 8 from #1030 (Silent exception swallowing in `models.py:522,550,614`)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add debug-level logging to exception handlers in `models.py` to aid debugging of model fetch failures while maintaining fallback behavior.
> 
>   - **Logging**:
>     - Add `logger.debug()` to log exceptions in `get_model()` at lines 522 and 554 when OpenRouter model fetch fails.
>     - Add `logger.debug()` to log exceptions in `_get_models_for_provider()` at line 618 when dynamic model fetch fails.
>   - **Misc**:
>     - Closes finding 8 from #1030 regarding silent exception swallowing in `models.py:522,550,614`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for d2f8eca5a75fb0138dc695fb65d5d82ae4460521. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->