### PR TITLE
fix(llm): replace assert with runtime checks for production safety

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -327,7 +327,8 @@ def _summarize_str(content: str) -> str:
     ]
 
     model = get_default_model_summary()
-    assert model, "No default model set"
+    if not model:
+        raise RuntimeError("No default model set")
 
     if len_tokens(messages, model.model) > model.context:
         raise ValueError(
@@ -335,7 +336,8 @@ def _summarize_str(content: str) -> str:
         )
 
     summary, _metadata = _chat_complete(messages, model.full, None)
-    assert summary
+    if not summary:
+        raise RuntimeError("Summarization produced no output")
     logger.debug(
         f"Summarized long output ({len_tokens(content, model.model)} -> {len_tokens(summary, model.model)} tokens): "
         + summary

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -351,7 +351,8 @@ def chat(
 ) -> tuple[str, MessageMetadata | None]:
     from anthropic import NOT_GIVEN  # fmt: skip
 
-    assert _anthropic, "LLM not initialized"
+    if not _anthropic:
+        raise RuntimeError("LLM not initialized")
     messages_dicts, system_messages, tools_dict = _prepare_messages_for_api(
         messages, tools
     )
@@ -433,7 +434,8 @@ def stream(
     # Variable to capture metadata from usage recording
     captured_metadata: MessageMetadata | None = None
 
-    assert _anthropic, "LLM not initialized"
+    if not _anthropic:
+        raise RuntimeError("LLM not initialized")
     messages_dicts, system_messages, tools_dict = _prepare_messages_for_api(
         messages, tools
     )


### PR DESCRIPTION
## Summary

Replace `assert` statements with proper `if not: raise RuntimeError` checks.

## Problem

`assert` statements are stripped when Python runs with `-O` flag. These critical checks would silently fail in optimized environments.

## Changes

- **llm_anthropic.py**: Convert 2 `_anthropic` initialization checks  
- **__init__.py**: Convert `model` and `summary` validation checks

Addresses Issue #1028 (Assert in production - HIGH severity)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `assert` statements with runtime checks in `llm_anthropic.py` and `__init__.py` for production safety.
> 
>   - **Behavior**:
>     - Replace `assert` with `if not: raise RuntimeError` in `llm_anthropic.py` for `_anthropic` initialization checks in `chat()` and `stream()`.
>     - Replace `assert` with `if not: raise RuntimeError` in `__init__.py` for `model` and `summary` validation in `_summarize_str()`.
>   - **Files Affected**:
>     - `llm_anthropic.py`: Changes in `chat()` and `stream()` functions.
>     - `__init__.py`: Changes in `_summarize_str()` function.
>   - **Issue Addressed**:
>     - Fixes Issue #1028 regarding the use of `assert` in production environments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for da5aa63c4631736ae284ca82d6cbf50d12b7067a. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->