### PR TITLE
fix(message): prevent call_id=None from serializing as literal 'None' string

### DIFF
--- a/gptme/message.py
+++ b/gptme/message.py
@@ -209,6 +209,8 @@ class Message:
             metadata_toml = _format_metadata_toml(self.metadata)
         else:
             metadata_toml = ""
+        # Serialize call_id only if present (avoid serializing "None" as string)
+        call_id_toml = f'call_id = "{self.call_id}"' if self.call_id else ""
         extra = (
             flags_toml
             + "\n"
@@ -217,6 +219,8 @@ class Message:
             + file_hashes_toml
             + "\n"
             + metadata_toml
+            + "\n"
+            + call_id_toml
         ).strip()
 
         # doublequotes need to be escaped
@@ -231,7 +235,6 @@ content = """
 {content}
 """
 timestamp = "{self.timestamp.isoformat()}"
-call_id = "{self.call_id}"
 {extra}
 '''
 


### PR DESCRIPTION
## Summary

Fixes a MEDIUM issue from #1035: `call_id=None` was being serialized as `call_id = "None"` in TOML, which then gets parsed back as the string "None" instead of `None`.

## Changes

- Make `call_id` serialization conditional in `to_toml()` (only serialize when not None)
- Add test verifying correct `call_id` serialization roundtrip

## Testing

- All 14 message tests pass
- New test specifically validates:
  - Messages without call_id don't produce `call_id = "None"`
  - Messages with call_id serialize and roundtrip correctly

## Related

- Issue #1035 (message.py code quality findings)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `call_id` serialization in `Message` to prevent `None` from being serialized as "None" string in TOML.
> 
>   - **Behavior**:
>     - Fix `call_id` serialization in `to_toml()` in `message.py` to avoid serializing `None` as "None".
>     - Add test `test_call_id_serialization()` in `test_message.py` to verify `call_id` handling.
>   - **Testing**:
>     - New test ensures `call_id=None` does not appear in TOML output and roundtrips correctly.
>     - Confirms `call_id` with value serializes and deserializes accurately.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 19e639525ae656051da5f70b5add1ec04b1eb7d2. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->