### PR TITLE
fix(anthropic): prevent empty message content error

### DIFF
--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -802,7 +802,13 @@ def _prepare_messages_for_api(
                 filtered_parts.append(part)
         content_parts = filtered_parts
 
-        messages_dicts_new.append({"role": msg["role"], "content": content_parts})
+        # Only add message if it has content (prevents Anthropic API error)
+        if content_parts:
+            messages_dicts_new.append({"role": msg["role"], "content": content_parts})
+        else:
+            logger.warning(
+                f"Skipping message with role '{msg['role']}' - all content was filtered out"
+            )
 
     # Apply cache control for Anthropic prompt caching
     # See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching


### PR DESCRIPTION
## Problem

During autonomous gptme runs, the Anthropic API returns a 400 error:
```
messages.67: all messages must have non-empty content except for 
the optional final assistant message
```

## Root Cause

**Regression introduced by PR #1064** (Jan 3, 2026): "fix(message): preserve whitespace in TOML serialization"

That PR removed `.strip()` calls to preserve whitespace for data integrity (important for code indentation). However, this means messages with only whitespace are now preserved through TOML serialization.

**The chain of events:**
1. PR #1064 removed `.strip()` from message serialization (correct change for preserving code indentation)
2. Messages with only whitespace (e.g., `"\n\n\n"`) now pass through TOML serialization
3. In `llm_anthropic.py`, content filtering checks `text_content.strip()` and removes empty blocks
4. If ALL content is whitespace → all blocks filtered → `content_parts = []`
5. Empty array sent to Anthropic → 400 error

## Solution

Added a check after content filtering to skip messages where all content was filtered out, with a warning log for debugging.

This properly handles the new behavior introduced by PR #1064 where whitespace-only messages are preserved. It's not just a defensive fix - it addresses a real regression from a recent intentional change.

## Testing

This fix prevents the error that was occurring during autonomous runs when messages with only whitespace were created and preserved through serialization.