### PR TITLE
fix(server): add @require_auth to tasks and workspace API endpoints

### DIFF
--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -23,6 +23,7 @@ from ..logmanager import LogManager
 from ..message import Message
 from ..prompts import get_prompt
 from ..tools import get_toolchain
+from .auth import require_auth
 from .openapi_docs import ErrorResponse, StatusResponse, api_doc_simple
 
 logger = logging.getLogger(__name__)
@@ -642,6 +643,7 @@ def setup_task_workspace(task_id: str, target_repo: str | None = None) -> Path:
 
 
 @tasks_api.route("/api/v2/tasks")
+@require_auth
 @api_doc_simple(
     responses={200: TaskListResponse, 500: ErrorResponse},
     tags=["tasks"],
@@ -664,6 +666,7 @@ def api_tasks_list():
 
 
 @tasks_api.route("/api/v2/tasks", methods=["POST"])
+@require_auth
 @api_doc_simple(
     request_body=TaskCreateRequest,
     responses={201: TaskResponse, 400: ErrorResponse, 500: ErrorResponse},
@@ -715,6 +718,7 @@ def api_tasks_create():
 
 
 @tasks_api.route("/api/v2/tasks/<string:task_id>")
+@require_auth
 @api_doc_simple(
     responses={200: TaskResponse, 404: ErrorResponse, 500: ErrorResponse},
     tags=["tasks"],
@@ -747,6 +751,7 @@ def api_tasks_get(task_id: str):
 
 
 @tasks_api.route("/api/v2/tasks/<string:task_id>", methods=["PUT"])
+@require_auth
 @api_doc_simple(
     request_body=TaskUpdateRequest,
     responses={
@@ -792,6 +797,7 @@ def api_tasks_update(task_id: str):
 
 
 @tasks_api.route("/api/v2/tasks/<string:task_id>/archive", methods=["POST"])
+@require_auth
 @api_doc_simple(
     responses={
         200: StatusResponse,
@@ -827,6 +833,7 @@ def api_tasks_archive(task_id: str):
 
 
 @tasks_api.route("/api/v2/tasks/<string:task_id>/unarchive", methods=["POST"])
+@require_auth
 @api_doc_simple(
     responses={
         200: StatusResponse,

--- a/gptme/server/workspace_api.py
+++ b/gptme/server/workspace_api.py
@@ -14,6 +14,7 @@ from flask import request
 from pydantic import BaseModel, Field
 
 from ..logmanager import LogManager
+from .auth import require_auth
 from .openapi_docs import ErrorResponse, api_doc_simple
 
 logger = logging.getLogger(__name__)
@@ -177,6 +178,7 @@ def list_directory(
 @workspace_api.route(
     "/api/v2/conversations/<string:conversation_id>/workspace/<path:subpath>"
 )
+@require_auth
 @api_doc_simple(
     responses={
         200: FileMetadata,
@@ -228,6 +230,7 @@ def browse_workspace(conversation_id: str, subpath: str | None = None):
 @workspace_api.route(
     "/api/v2/conversations/<string:conversation_id>/workspace/<path:filepath>/preview"
 )
+@require_auth
 @api_doc_simple(
     responses={
         200: FilePreviewResponse,


### PR DESCRIPTION
## Summary

Addresses MEDIUM security findings from Issue #1033 regarding missing authentication on server endpoints.

## Changes

### tasks_api.py
Added `@require_auth` decorator to all 6 endpoints:
- `GET /api/v2/tasks` - List tasks
- `POST /api/v2/tasks` - Create task
- `GET /api/v2/tasks/<id>` - Get task
- `PUT /api/v2/tasks/<id>` - Update task
- `POST /api/v2/tasks/<id>/archive` - Archive task
- `POST /api/v2/tasks/<id>/unarchive` - Unarchive task

### workspace_api.py
Added `@require_auth` decorator to both endpoints:
- `GET /api/v2/conversations/<id>/workspace` - Browse workspace
- `GET /api/v2/conversations/<id>/workspace/<path>/preview` - Preview file

## Security Impact

These endpoints previously allowed unauthenticated access (when auth was enabled server-wide). Now they follow the same authentication pattern as other v2 API endpoints.

Ref: #1033
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `@require_auth` to tasks and workspace API endpoints for authentication.
> 
>   - **Security**:
>     - Added `@require_auth` decorator to all endpoints in `tasks_api.py` and `workspace_api.py` to enforce authentication.
>     - Affects 6 endpoints in `tasks_api.py` and 2 endpoints in `workspace_api.py`.
>   - **Endpoints**:
>     - `tasks_api.py`: `GET /api/v2/tasks`, `POST /api/v2/tasks`, `GET /api/v2/tasks/<id>`, `PUT /api/v2/tasks/<id>`, `POST /api/v2/tasks/<id>/archive`, `POST /api/v2/tasks/<id>/unarchive`.
>     - `workspace_api.py`: `GET /api/v2/conversations/<id>/workspace`, `GET /api/v2/conversations/<id>/workspace/<path>/preview`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 3fb9f411885b5e427d612aa60acaf373b3e563d6. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->