### PR TITLE
fix(server): validate role against allowed values

### DIFF
--- a/gptme/server/api.py
+++ b/gptme/server/api.py
@@ -184,7 +184,15 @@ def api_conversation_put(logfile: str):
     )
 
     # Add any additional messages from request
+    valid_roles = ("system", "user", "assistant")
     for msg in req_json.get("messages", []):
+        if msg.get("role") not in valid_roles:
+            return (
+                flask.jsonify(
+                    {"error": f"Invalid role: {msg.get('role')}. Must be one of: {valid_roles}"}
+                ),
+                400,
+            )
         timestamp: datetime = (
             isoparse(msg["timestamp"]) if "timestamp" in msg else datetime.now()
         )

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -191,7 +191,15 @@ def api_conversation_put(conversation_id: str):
         agent_path=chat_config.agent,
     )
 
+    valid_roles = ("system", "user", "assistant")
     for msg in req_json.get("messages", []):
+        if msg.get("role") not in valid_roles:
+            return (
+                flask.jsonify(
+                    {"error": f"Invalid role: {msg.get('role')}. Must be one of: {valid_roles}"}
+                ),
+                400,
+            )
         timestamp: datetime = (
             isoparse(msg["timestamp"]) if "timestamp" in msg else datetime.now()
         )


### PR DESCRIPTION
## Summary

Adds validation for the `role` field in message POST endpoints to ensure it's one of the valid values: `system`, `user`, `assistant`.

## Changes

- **api.py**: Added role validation before creating Message
- **api_v2.py**: Added role validation before creating Message

## Problem

Previously, invalid roles (e.g., `admin`, `moderator`, arbitrary strings) would be passed directly to the Message constructor. While the Message class uses `Literal["system", "user", "assistant"]` for type checking, this is only enforced at static analysis time, not runtime.

The server would silently accept invalid roles, potentially causing:
- Unexpected behavior in downstream processing
- Type errors if the invalid role is compared against expected values
- Confusion in logs and debugging

## Fix

Added explicit runtime validation that returns a 400 error with a descriptive message when an invalid role is provided:

```json
{"error": "Invalid role: admin. Must be one of: ('system', 'user', 'assistant')"}
```

## Ref

- Issue #1033 (MEDIUM: Input validation finding)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds runtime validation for `role` field in message POST endpoints to ensure it is `system`, `user`, or `assistant`, returning a 400 error for invalid roles.
> 
>   - **Behavior**:
>     - Adds runtime validation for `role` field in message POST endpoints in `api.py` and `api_v2.py`.
>     - Returns 400 error with message if `role` is not `system`, `user`, or `assistant`.
>   - **Problem**:
>     - Previously, invalid roles were accepted, causing potential downstream issues.
>   - **Fix**:
>     - Explicit validation added to prevent invalid roles from being processed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 159386bdca83e64a751e2a3de78691b7adeaa305. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->