### PR TITLE
fix: thread-safe singleton and interrupt handling

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,6 +145,7 @@ nitpick_ignore = [
     ("py:class", "Path"),
     ("py:class", "gptme.tools.subagent.SubtaskDef"),
     ("py:class", "gptme.tools.shell.BackgroundJob"),
+    ("py:class", "gptme.tools.shell.ShellSession"),
     # Phase 1 async subagent types
     ("py:class", "gptme.tools.subagent.ReturnType"),
     ("py:class", "gptme.tools.subagent.BatchJob"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,13 +118,14 @@ def cleanup_shell_after():
     the test runner to hang during cleanup (Issue #910).
     """
     yield
-    # Close shell if it exists
-    if shell_module._shell is not None:
+    # Close shell if it exists (using ContextVar API)
+    shell = shell_module._shell_var.get()
+    if shell is not None:
         try:
-            shell_module._shell.close()
+            shell.close()
         except Exception as e:
             logger.warning(f"Error closing shell during test cleanup: {e}")
-        shell_module._shell = None
+        shell_module._shell_var.set(None)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Fixes race conditions identified in issue #1021 by using ContextVar for thread-safe concurrent conversations.

### Changes

**shell.py - Context-Local Shell Sessions**
- Replaced `_shell` global with `_shell_var: ContextVar[ShellSession | None]`
- Each conversation/context now gets its own shell session with independent cwd
- Enables proper concurrent conversation support for server mode and subagents

**tests/conftest.py**
- Updated `cleanup_shell_after` fixture to use ContextVar API

**docs/conf.py**
- Added `ShellSession` to nitpick_ignore list for clean Sphinx builds

### Benefits

1. **Server compatibility**: Multiple concurrent conversations work correctly
2. **Subagent safety**: Threading with subagents won't share shell state
3. **Cleaner code**: ContextVar handles isolation; no lock boilerplate
4. **Better asyncio alignment**: Standard pattern for context-local state

### Note

The original PR also included thread-safety for `_recently_interrupted` in chat.py, but that variable was removed in PR #1039, so those changes are no longer needed.

Ref #1021