### PR TITLE
fix(server): remove stale init_tools FIXME comments

### DIFF
--- a/gptme/server/api.py
+++ b/gptme/server/api.py
@@ -99,7 +99,7 @@ def api_conversation(logfile: str):
 
     Retrieve a conversation with all its messages and metadata.
     """
-    init_tools(None)  # FIXME: this is not thread-safe
+    init_tools(None)
     log = LogManager.load(logfile, lock=False)
     log_dict = log.to_dict(branches=True)
     # add workspace to response
@@ -228,7 +228,7 @@ def api_conversation_post(logfile: str):
     req_json = flask.request.json
     branch = (req_json or {}).get("branch", "main")
     tool_allowlist = (req_json or {}).get("tools", None)
-    init_tools(tool_allowlist)  # FIXME: this is not thread-safe
+    init_tools(tool_allowlist)
     log = LogManager.load(logfile, branch=branch)
     assert req_json
     assert "role" in req_json


### PR DESCRIPTION
## Summary

Removes stale FIXME comments claiming `init_tools` is not thread-safe.

## Context

The init_tools function has been thread-safe since PR #506 added `_tools_init_lock`:

```python
_tools_init_lock = threading.Lock()

def init_tools(...):
    with _tools_init_lock:
        # ... thread-safe implementation
```

The FIXME comments in api.py were never updated after this fix.

## Changes

Removes two comments:
- Line 102: `init_tools(None)  # FIXME: this is not thread-safe`
- Line 231: `init_tools(tool_allowlist)  # FIXME: this is not thread-safe`

## Ref

#1033 (server security findings)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove outdated FIXME comments in `api.py` about `init_tools` thread-safety.
> 
>   - **Comments**:
>     - Remove stale FIXME comments in `api.py` at lines 102 and 231 that incorrectly stated `init_tools` was not thread-safe.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for e0c1b4c8b27cb7187aeb3756243737d81842653a. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->