### PR TITLE
feat(server): add GPTME_DEBUG_ERRORS for verbose error messages in dev mode

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -120,3 +120,27 @@ def test_api_conversation_generate_stream(conv: str, client: FlaskClient):
             continue
         data = chunk_str.replace("data: ", "").strip()
         assert data  # Non-empty data
+
+
+def test_debug_errors_disabled(monkeypatch):
+    """Test that debug errors are disabled by default."""
+    from gptme.server.api import _is_debug_errors_enabled
+
+    # Clear the env var to test default behavior
+    monkeypatch.delenv("GPTME_DEBUG_ERRORS", raising=False)
+    assert _is_debug_errors_enabled() is False
+
+
+def test_debug_errors_enabled(monkeypatch):
+    """Test that debug errors can be enabled via environment variable."""
+    from gptme.server.api import _is_debug_errors_enabled
+
+    # Test various truthy values
+    for value in ["1", "true", "TRUE", "yes", "YES"]:
+        monkeypatch.setenv("GPTME_DEBUG_ERRORS", value)
+        assert _is_debug_errors_enabled() is True, f"Failed for value: {value}"
+
+    # Test falsy values
+    for value in ["0", "false", "no", ""]:
+        monkeypatch.setenv("GPTME_DEBUG_ERRORS", value)
+        assert _is_debug_errors_enabled() is False, f"Should be False for value: {value}"


### PR DESCRIPTION
## Summary

Add environment variable `GPTME_DEBUG_ERRORS` to enable verbose error messages in development, testing, CI, and staging environments.

## Changes

- Added `_is_debug_errors_enabled()` helper function
- Updated 3 error handlers to conditionally show detailed errors when enabled:
  - File access error handler (line ~144)
  - Non-streaming generation error handler (line ~337)  
  - Streaming generation error handler (line ~468)
- Added tests for the new functionality

## Usage

```bash
# Enable verbose errors for debugging
GPTME_DEBUG_ERRORS=1 gptme-server

# Production (default) - errors are sanitized
gptme-server
```

## Motivation

This addresses @ErikBjare's review comment on PR #1090:
> "This is fine, but in dev mode/staging/CI we actually want to see the errors. Consider adding some kind of flag which includes more details when not running 'prod' (or when a dev-mode env variable is given, so it can be enabled)."

## Testing

- Added unit tests for `_is_debug_errors_enabled()` function
- Syntax validation passes
- CI will verify full test suite
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `GPTME_DEBUG_ERRORS` to enable verbose error messages in non-production environments and updates error handlers accordingly.
> 
>   - **Behavior**:
>     - Introduces `GPTME_DEBUG_ERRORS` environment variable to enable verbose error messages in non-production environments.
>     - Updates error handlers in `api.py` to show detailed errors when `GPTME_DEBUG_ERRORS` is enabled.
>   - **Functions**:
>     - Adds `_is_debug_errors_enabled()` in `api.py` to check the environment variable.
>   - **Testing**:
>     - Adds tests in `test_server.py` for `_is_debug_errors_enabled()` to verify behavior with different environment variable values.
>     - Updates existing tests to ensure compatibility with new error handling behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for c7df7e5b7935a007c3c68d48bb25a0713fcf6b46. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->