### PR TITLE
test(gh): fix mocked tests for comment ID format

### DIFF
--- a/tests/test_util_gh_mocked.py
+++ b/tests/test_util_gh_mocked.py
@@ -230,7 +230,7 @@ def test_code_context_extraction(mock_pr_with_context_response):
     assert content is not None
 
     # Should have review comment
-    assert "**@reviewer** on test.py:10:" in content
+    assert "**@reviewer** on test.py:10 (ID: 1001):" in content
     assert "Please fix this" in content
 
     # Should have code context section
@@ -272,7 +272,7 @@ def test_code_suggestion_extraction(mock_pr_with_suggestion_response):
     assert content is not None
 
     # Should have review comment
-    assert "**@reviewer** on test.py:15:" in content
+    assert "**@reviewer** on test.py:15 (ID: 1002):" in content
     assert "Consider this change:" in content
 
     # Should have extracted suggestion
@@ -292,7 +292,7 @@ def test_both_context_and_suggestion(mock_pr_with_both_response):
     assert content is not None
 
     # Should have review comment
-    assert "**@reviewer** on module.py:20:" in content
+    assert "**@reviewer** on module.py:20 (ID: 1003):" in content
 
     # Should have code context
     assert "Referenced code in module.py:20:" in content
@@ -313,7 +313,7 @@ def test_multiple_suggestions(mock_pr_multiple_suggestions):
     assert content is not None
 
     # Should have review comment
-    assert "**@reviewer** on test.py:25:" in content
+    assert "**@reviewer** on test.py:25 (ID: 1004):" in content
 
     # Should have both suggestions
     assert content.count("Suggested change:") == 2
@@ -359,7 +359,7 @@ def test_no_context_or_suggestion(mock_pr_basic_response):
     assert content is not None
 
     # Should have review comment
-    assert "**@reviewer** on test.py:5:" in content
+    assert "**@reviewer** on test.py:5 (ID: 1005):" in content
     assert "Looks good!" in content
 
     # Should NOT have context or suggestion sections


### PR DESCRIPTION
## Summary

Fixes the test assertions in `test_util_gh_mocked.py` to expect the new output format with comment IDs added in PR #1101.

## Changes

Updated 5 test assertions to expect the new format:
- `**@reviewer** on file.py:line (ID: XXXX):`

Tests updated:
- `test_code_context_extraction` (ID: 1001)
- `test_code_suggestion_extraction` (ID: 1002)
- `test_both_context_and_suggestion` (ID: 1003)
- `test_multiple_suggestions` (ID: 1004)
- `test_no_context_or_suggestion` (ID: 1005)

## Context

Per @ErikBjare's request in PR #1101: "Make follow-up PR that fixes the broken tests"

All 8 tests in `test_util_gh_mocked.py` now pass locally.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update test assertions in `test_util_gh_mocked.py` to expect new comment ID format, ensuring tests pass with changes from PR #1101.
> 
>   - **Tests**:
>     - Update 5 test assertions in `test_util_gh_mocked.py` to expect comment IDs in format `**@reviewer** on file.py:line (ID: XXXX):`.
>     - Affected tests: `test_code_context_extraction`, `test_code_suggestion_extraction`, `test_both_context_and_suggestion`, `test_multiple_suggestions`, `test_no_context_or_suggestion`.
>   - **Context**:
>     - Aligns with changes from PR #1101 as requested by @ErikBjare.
>     - All tests in `test_util_gh_mocked.py` pass locally after changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 3d9ec33132b957be522a820d9590f078c29b3f47. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->