### PR TITLE
feat(gh): truncate verbose comment bodies to reduce token usage

### DIFF
--- a/gptme/util/gh.py
+++ b/gptme/util/gh.py
@@ -368,7 +368,8 @@ def get_github_pr_content(url: str) -> str | None:
                     content += "\n\n## Review Comments (Unresolved)\n"
                     for comment in unresolved_comments:
                         user = comment.get("user", {}).get("login", "unknown")
-                        body = _truncate_body(comment.get("body", ""))
+                        original_body = comment.get("body", "")
+                        body = _truncate_body(original_body)
                         path = comment.get("path", "")
                         comment_id = comment.get("id")
                         # Get line numbers (prefer current, fallback to original)
@@ -410,10 +411,11 @@ def get_github_pr_content(url: str) -> str | None:
                             content += "\n".join(context_lines)
                             content += "\n```\n"
 
-                        # Extract and display code suggestions
-                        if "```suggestion" in body:
-                            # Find suggestion blocks in the body
-                            lines = body.split("\n")
+                        # Extract and display code suggestions from ORIGINAL body
+                        # (truncation may remove suggestions in the middle)
+                        if "```suggestion" in original_body:
+                            # Find suggestion blocks in the original body
+                            lines = original_body.split("\n")
                             in_suggestion = False
                             suggestion_lines: list[str] = []
 


### PR DESCRIPTION
## Summary

Adds smart truncation for review comment bodies that exceed 1000 tokens (~4000 chars).

## Motivation

Per discussion in #1100, verbose bot comments (Greptile, Ellipsis) can consume significant tokens when reading PRs. This PR implements truncation to improve token efficiency.

## Empirical Analysis

Sampled comment lengths from real PRs:
- **Human comments**: typically 20-500 tokens (80-2000 chars) - all preserved
- **Bot comments**: can reach 900+ tokens (3600+ chars) - longest ones truncated

## Implementation

- Adds `_truncate_body()` helper function
- Default threshold: 1000 tokens (4000 chars)
- Preserves beginning and end, truncates middle
- Adds clear indicator: `[... truncated X chars (Y tokens) ...]`
- Applied to review comment bodies in `get_github_pr_content()`

## Testing

Added comprehensive tests for:
- Short bodies (unchanged)
- Empty bodies
- Long bodies (truncated)
- Custom max_tokens
- Structure preservation
- Integration with PR content fetching

Closes #1100
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds truncation for long GitHub review comments in `gh.py` to improve token efficiency, with comprehensive tests.
> 
>   - **Behavior**:
>     - Adds `_truncate_body()` in `gh.py` to truncate comment bodies exceeding 1000 tokens, preserving start and end.
>     - Truncation indicator: `[... truncated X chars (Y tokens) ...]`.
>     - Integrated into `get_github_pr_content()` for review comments.
>   - **Testing**:
>     - Tests for short, empty, long, and custom token limit bodies in `test_util_gh_mocked.py`.
>     - Ensures suggestions are extracted from original bodies before truncation.
>     - Verifies structure preservation and output within limits.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 19658b843c2acf7557bc6dc548c66b4957b01017. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->