### PR TITLE
fix(lessons): disable description-based word matching

### DIFF
--- a/gptme/lessons/matcher.py
+++ b/gptme/lessons/matcher.py
@@ -52,7 +52,7 @@ class LessonMatcher:
 
         Supports two formats:
         - Lessons: match by `keywords` in frontmatter
-        - Skills (Anthropic format): match by `name` and `description` in frontmatter
+        - Skills (Anthropic format): match by `name` in frontmatter
 
         Deduplication: Lessons are deduplicated by resolved path (realpath) to handle:
         - Symlinks pointing to the same file
@@ -135,73 +135,6 @@ class LessonMatcher:
         # Sort by score, descending
         results.sort(key=lambda r: r.score, reverse=True)
         return results
-
-    def _extract_description_keywords(self, description: str) -> list[str]:
-        """Extract significant keywords from skill description.
-
-        Args:
-            description: Skill description text
-
-        Returns:
-            List of significant keywords (lowercase)
-        """
-        # Common stop words to exclude
-        stop_words = {
-            "a",
-            "an",
-            "the",
-            "and",
-            "or",
-            "but",
-            "in",
-            "on",
-            "at",
-            "to",
-            "for",
-            "of",
-            "with",
-            "by",
-            "from",
-            "as",
-            "is",
-            "was",
-            "are",
-            "were",
-            "been",
-            "be",
-            "have",
-            "has",
-            "had",
-            "do",
-            "does",
-            "did",
-            "will",
-            "would",
-            "could",
-            "should",
-            "may",
-            "might",
-            "must",
-            "can",
-            "this",
-            "that",
-            "these",
-            "those",
-            "it",
-            "its",
-        }
-
-        # Split on non-word characters and filter
-        import re
-
-        words = re.split(r"\W+", description.lower())
-        keywords = [
-            w
-            for w in words
-            if len(w) > 2 and w not in stop_words  # Min 3 chars
-        ]
-
-        return keywords
 
     def match_keywords(
         self, lessons: list[Lesson], keywords: list[str]

--- a/tests/test_lessons_matcher.py
+++ b/tests/test_lessons_matcher.py
@@ -327,17 +327,17 @@ class TestSkillMatching:
         # Skills should use explicit keywords: in frontmatter
         assert len(results) == 0
 
-    def test_skill_name_preferred_over_description(self, sample_skills):
-        """Test that name match is preferred over description match."""
+    def test_skill_matches_by_name_only(self, sample_skills):
+        """Test that skills match by name (description matching is disabled)."""
         matcher = LessonMatcher()
         context = MatchContext(message="python-repl usage")
 
         results = matcher.match(sample_skills, context)
 
-        # Name match should take precedence
+        # Name match should work
         assert len(results) >= 1
         assert results[0].lesson.title == "Python REPL Skill"
-        # Should have skill: match, not description: match
+        # Should only match by skill name
         matched_types = [m.split(":")[0] for m in results[0].matched_by]
         assert "skill" in matched_types
 
@@ -364,40 +364,6 @@ class TestSkillMatching:
 
         # Should have no matches
         assert len(results) == 0
-
-    def test_extract_description_keywords(self):
-        """Test the _extract_description_keywords helper method."""
-        matcher = LessonMatcher()
-
-        keywords = matcher._extract_description_keywords(
-            "Interactive Python REPL automation with common helpers"
-        )
-
-        # Should extract meaningful words, not stop words
-        assert "interactive" in keywords
-        assert "python" in keywords
-        assert "repl" in keywords
-        assert "automation" in keywords
-        assert "helpers" in keywords
-        # Stop words should be excluded
-        assert "with" not in keywords
-
-    def test_description_requires_multiple_matches(self, sample_skills):
-        """Test that description matching requires at least 2 keyword matches."""
-        matcher = LessonMatcher()
-        # Only one word from description
-        context = MatchContext(message="Something about efficiency")
-
-        results = matcher.match(sample_skills, context)
-
-        # Should not match based on single description word
-        # (unless also matched by name)
-        for result in results:
-            matched_types = [m.split(":")[0] for m in result.matched_by]
-            if "description" in matched_types:
-                # If matched by description, should have matched by name too
-                # or multiple description words
-                assert result.score > 0.5
 
     def test_deduplication_by_resolved_path(self, tmp_path):
         """Test that duplicate lessons (same resolved path) are deduplicated.


### PR DESCRIPTION
## Summary

Disables description-based word matching for skills which caused 100% trigger rates.

**Problem**: Skills with common words in descriptions (e.g., "context", "agent", "model") triggered on every conversation. Analysis found all 10 agent-skills lessons triggered 217/217 sessions (100%).

**Solution**: Remove description-based word matching. Skills should use explicit `keywords:` in frontmatter for matching.

**Impact**:
- ~10-15k tokens saved per session (no more auto-included reference material)
- Skills still accessible via `/skills` command or shell tool
- Explicit keyword matching still works for lessons with `keywords:` field

## Test Results

All 24 matcher tests pass.

## Related

- Fixes: gptme/gptme-contrib#139 (analysis of confusing lessons)
- Root cause analysis: https://github.com/gptme/gptme-contrib/issues/139#issuecomment-3733967389
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove description-based word matching for skills in `matcher.py`, relying on explicit keywords for matching.
> 
>   - **Behavior**:
>     - Remove description-based word matching for skills in `matcher.py`, which caused 100% trigger rates.
>     - Skills now match by `name` in frontmatter, not `description`.
>     - Skills should use explicit `keywords:` in frontmatter for matching.
>   - **Tests**:
>     - Update `test_skill_description_match` in `test_lessons_matcher.py` to confirm description matching is disabled.
>     - Add `test_skill_matches_by_name_only` to ensure skills match by name only.
>     - Remove tests related to description keyword extraction.
>   - **Misc**:
>     - Remove `_extract_description_keywords` function from `matcher.py`.
>     - Update comments in `matcher.py` to reflect changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 6e46647071157f5e7f6f8754859ab25a3e24da02. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->