### PR TITLE
fix(anthropic): remove top_p parameter to fix model compatibility

### DIFF
--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -15,7 +15,7 @@ from typing import (
 from httpx import RemoteProtocolError
 from pydantic import BaseModel  # fmt: skip
 
-from ..constants import TEMPERATURE, TOP_P
+from ..constants import TEMPERATURE
 from ..message import Message, MessageMetadata, msgs2dicts
 from ..telemetry import record_llm_request
 from ..tools.base import ToolSpec
@@ -392,7 +392,6 @@ def chat(
         messages=messages_dicts,
         system=system_messages,
         temperature=TEMPERATURE if not model_meta.supports_reasoning else 1,
-        top_p=TOP_P if not model_meta.supports_reasoning else NOT_GIVEN,
         max_tokens=max_tokens,
         tools=tools_dict if tools_dict else NOT_GIVEN,
         thinking=(
@@ -476,7 +475,6 @@ def stream(
         messages=messages_dicts,
         system=system_messages,
         temperature=TEMPERATURE if not model_meta.supports_reasoning else 1,
-        top_p=TOP_P if not model_meta.supports_reasoning else NOT_GIVEN,
         max_tokens=max_tokens,
         tools=tools_dict if tools_dict else NOT_GIVEN,
         thinking=(


### PR DESCRIPTION
## Summary
Fixes #1110

Some Anthropic models (especially versioned ones like `claude-sonnet-4-5-20250929`) don't allow both `temperature` and `top_p` to be specified together.

## Changes
- Remove `top_p` parameter from Anthropic API calls in both `chat()` and `stream()` functions
- Remove unused `TOP_P` import

## Rationale
Since `temperature=0` already provides deterministic output (which is desired for code generation), removing `top_p` doesn't change the effective behavior. The `top_p=0.1` was redundant when `temperature=0` because:
- `temperature=0` means the model always selects the highest probability token
- `top_p` only affects the sampling distribution, which doesn't matter when temperature eliminates sampling

## Testing
- Syntax validation passed
- Pre-commit checks passed

This allows gptme to work with all Anthropic model versions including those with date suffixes.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `top_p` parameter from Anthropic API calls in `chat()` and `stream()` to ensure model compatibility, and remove unused `TOP_P` import.
> 
>   - **Behavior**:
>     - Remove `top_p` parameter from Anthropic API calls in `chat()` and `stream()` functions to ensure compatibility with models like `claude-sonnet-4-5-20250929`.
>     - Removing `top_p` does not affect behavior when `temperature=0` as it already provides deterministic output.
>   - **Imports**:
>     - Remove unused `TOP_P` import from `llm_anthropic.py`.
>   - **Testing**:
>     - Syntax validation and pre-commit checks passed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 76c346c1bf59a2d85225527a8fbbe32be06ceca5. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->