### PR TITLE
fix(anthropic): improve sampling parameter detection for model compatibility

### DIFF
--- a/tests/test_anthropic_dual_sampling.py
+++ b/tests/test_anthropic_dual_sampling.py
@@ -1,0 +1,84 @@
+"""Tests for Anthropic dual sampling detection."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# Test the _supports_dual_sampling function
+class TestSupportsDualSampling:
+    """Tests for _supports_dual_sampling function."""
+
+    @pytest.fixture
+    def mock_model_meta(self):
+        """Create a mock ModelMeta."""
+        meta = MagicMock()
+        meta.supports_reasoning = False
+        return meta
+
+    @pytest.fixture
+    def mock_model_meta_reasoning(self):
+        """Create a mock ModelMeta with reasoning support."""
+        meta = MagicMock()
+        meta.supports_reasoning = True
+        return meta
+
+    def test_reasoning_model_no_dual_sampling(self, mock_model_meta_reasoning):
+        """Reasoning models should not support dual sampling."""
+        from gptme.llm.llm_anthropic import _supports_dual_sampling
+
+        result = _supports_dual_sampling(
+            "claude-3-7-sonnet-20250219", mock_model_meta_reasoning
+        )
+        assert result is False
+
+    def test_known_model_supports_dual_sampling(self, mock_model_meta):
+        """Known models in MODELS dict should support dual sampling."""
+        from gptme.llm.llm_anthropic import _supports_dual_sampling
+
+        # claude-3-5-sonnet-20241022 is a known model without reasoning
+        result = _supports_dual_sampling("claude-3-5-sonnet-20241022", mock_model_meta)
+        assert result is True
+
+    def test_unknown_model_conservative_no_dual_sampling(self, mock_model_meta):
+        """Unknown models should default to conservative behavior (no dual sampling)."""
+        from gptme.llm.llm_anthropic import _supports_dual_sampling
+
+        # A completely unknown model name
+        result = _supports_dual_sampling("claude-unknown-model-xyz", mock_model_meta)
+        assert result is False
+
+    def test_date_suffix_variant_matches_base(self, mock_model_meta):
+        """Model with date suffix should match base model configuration."""
+        from gptme.llm.llm_anthropic import _supports_dual_sampling
+
+        # claude-3-5-sonnet with a different date suffix
+        # Should match claude-3-5-sonnet-20241022 (non-reasoning model)
+        result = _supports_dual_sampling("claude-3-5-sonnet-20251231", mock_model_meta)
+        assert result is True
+
+    def test_reasoning_variant_no_dual_sampling(self, mock_model_meta):
+        """Variant of a reasoning model should inherit reasoning restriction."""
+        from gptme.llm.llm_anthropic import _supports_dual_sampling
+
+        # claude-3-7-sonnet is a reasoning model
+        # A variant with different date should also not support dual sampling
+        mock_meta_for_variant = MagicMock()
+        mock_meta_for_variant.supports_reasoning = (
+            False  # Fallback doesn't know it's reasoning
+        )
+
+        result = _supports_dual_sampling(
+            "claude-3-7-sonnet-20251231", mock_meta_for_variant
+        )
+        # Should match claude-3-7-sonnet base and inherit its reasoning config
+        assert result is False
+
+    def test_new_claude_model_format(self, mock_model_meta):
+        """New Claude model naming format should be handled conservatively."""
+        from gptme.llm.llm_anthropic import _supports_dual_sampling
+
+        # Models like "claude-sonnet-4-5-20250929" don't match existing patterns
+        result = _supports_dual_sampling("claude-sonnet-4-5-20250929", mock_model_meta)
+        # Should be conservative since it doesn't match known patterns
+        assert result is False


### PR DESCRIPTION
## Summary

This is a more thorough fix for issue #1110, as requested by @ErikBjare in the [comment on PR #1111](https://github.com/gptme/gptme/pull/1111#issuecomment-3743920437).

## Problem Analysis

Erik asked: "What about our existing thing makes it work for the sonnet-4-5 and not the sonnet-4-5-yyyymmdd?"

**Root cause**: When an unknown model like `anthropic/claude-sonnet-4-5-20250929` is used:
1. `get_model()` doesn't find it in the MODELS dict
2. Returns fallback metadata with `supports_reasoning=False` (default)
3. This causes `top_p=TOP_P` to be sent
4. But some model variants can't have both `temperature` AND `top_p`

Meanwhile, known models like `claude-3-7-sonnet-20250219` have `supports_reasoning=True` in the MODELS dict, so `top_p` is correctly omitted.

## Solution

Added `_supports_dual_sampling()` function with smart detection logic:

| Model Type | Behavior | Rationale |
|------------|----------|-----------|
| Reasoning models (`supports_reasoning=True`) | No top_p | Requires temperature=1 |
| Known models in MODELS dict | Send top_p | Tested and working |
| Unknown models matching known base | Inherit base config | Date suffix variants |
| Completely unknown models | No top_p (conservative) | Prevent API errors |

### Model Matching Logic

1. **Exact match**: Check MODELS dict directly
2. **Date suffix stripping**: `claude-3-5-sonnet-20251231` → `claude-3-5-sonnet` matches `claude-3-5-sonnet-20241022`
3. **Family pattern matching**: Check if unknown model starts with a known model's base name
4. **Conservative fallback**: Unknown models default to no top_p

## Changes

- Added `_supports_dual_sampling(model, model_meta)` helper function
- Updated `chat()` and `stream()` to use the new detection
- Added comprehensive tests for all detection scenarios

## Test Results

All 6 tests pass covering reasoning models, known models, unknown models, date suffix variants, reasoning variants, and new model formats.

Fixes #1110
Alternative to #1111
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves Anthropic model compatibility by adding `_supports_dual_sampling()` for better sampling parameter detection and updates `chat()` and `stream()` functions accordingly.
> 
>   - **Behavior**:
>     - Added `_supports_dual_sampling()` in `llm_anthropic.py` to determine if a model supports both `temperature` and `top_p`.
>     - Updated `chat()` and `stream()` in `llm_anthropic.py` to use `_supports_dual_sampling()` for parameter handling.
>   - **Detection Logic**:
>     - Exact match in `MODELS` dict supports dual sampling.
>     - Date suffix stripping and family pattern matching for unknown models.
>     - Conservative default for completely unknown models.
>   - **Tests**:
>     - Added `test_anthropic_dual_sampling.py` with tests for reasoning models, known models, unknown models, and new model formats.
>   - **Misc**:
>     - Fixes issue #1110 and provides an alternative to PR #1111.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 2fc5881edc35bf3df27431c98a995ecdcbead048. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->