### PR TITLE
fix(auto-naming): validate LLM responses to reject error-like titles

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -324,8 +324,10 @@ def _process_message_conversation(
         # Runs in background thread to avoid blocking the chat loop
         # TODO: Consider implementing via hook system to streamline with server implementation
         # See: gptme/server/api_v2_sessions.py for server's implementation
+        # Try auto-naming on first few assistant messages until we get a name
+        # This allows retry when initial context is insufficient
         assistant_messages = [m for m in manager.log.messages if m.role == "assistant"]
-        if len(assistant_messages) == 1:
+        if len(assistant_messages) <= 3:
             chat_config = ChatConfig.from_logdir(manager.logdir)
             if not chat_config.name:
 

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -406,8 +406,10 @@ def step(
         # Auto-generate display name for first assistant response if not already set
         # TODO: Consider implementing via hook system to streamline with CLI implementation
         # See: gptme/chat.py for CLI's implementation
+        # Try auto-naming on first few assistant messages until we get a name
+        # This allows retry when initial context is insufficient
         assistant_messages = [m for m in manager.log.messages if m.role == "assistant"]
-        if len(assistant_messages) == 1 and not chat_config.name:
+        if len(assistant_messages) <= 3 and not chat_config.name:
             try:
                 display_name = auto_generate_display_name(manager.log.messages, model)
                 if display_name:

--- a/tests/test_auto_naming.py
+++ b/tests/test_auto_naming.py
@@ -249,3 +249,33 @@ def test_invalid_title_detection():
 
     for title in valid_titles:
         assert not _is_invalid_title(title), f"Expected '{title}' to be valid"
+
+
+def test_generate_conversation_name_returns_none_on_llm_failure():
+    """Test that generate_conversation_name returns None (not random) when LLM strategy fails.
+
+    This allows callers to retry on subsequent turns when more context is available,
+    rather than immediately falling back to a random name.
+    """
+    from gptme.message import Message
+    from gptme.util.auto_naming import generate_conversation_name
+
+    # Short conversation that will cause LLM naming to fail
+    short_messages = [
+        Message("user", "hi"),
+        Message("assistant", "Hello!"),
+    ]
+
+    # With LLM strategy, should return None (not a random name) when context is insufficient
+    result = generate_conversation_name(
+        strategy="llm",
+        messages=short_messages,
+        model="test/model",
+    )
+
+    # Should be None to allow retry, not a random name
+    assert result is None, (
+        f"Expected None when LLM naming fails, got '{result}'. "
+        "generate_conversation_name should not fall back to random names when "
+        "LLM strategy is explicitly requested."
+    )


### PR DESCRIPTION
## Summary
When the LLM fails to generate a proper title, it sometimes returns error-like messages such as 'Conversation content missing' or 'Missing Conversation Details' instead of a proper title. These were being used as-is, resulting in confusing titles in both CLI and web UI.

## Fix
This PR adds validation to detect and reject such responses:
- Rejects error patterns like 'content missing', 'unable to', etc.
- Rejects explanation prefixes like 'I ', 'Based on ', etc.
- Rejects overly long responses (>8 words, likely explanations)

When invalid titles are detected, the system falls back to generating a random name instead.

## Testing
- Added unit tests for the new `_is_invalid_title()` validation function
- Tests verify both rejection of invalid titles and acceptance of valid titles

## Related
Fixes SUDO-40 (Linear issue: Chat titles broken in web UI)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds validation for LLM-generated titles in `auto_naming.py` to reject error-like messages, with unit tests in `test_auto_naming.py`.
> 
>   - **Behavior**:
>     - Adds `_is_invalid_title()` in `auto_naming.py` to validate LLM-generated titles, rejecting error-like messages and overly long responses.
>     - Falls back to generating a random name if the title is invalid.
>   - **Testing**:
>     - Adds unit tests in `test_auto_naming.py` for `_is_invalid_title()` to verify rejection of invalid titles and acceptance of valid ones.
>   - **Misc**:
>     - Logs a warning if an invalid title is detected in `_generate_llm_name()` in `auto_naming.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 55c58467dea13fd916f8a191908ece40bbb5565b. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->