### PR TITLE
fix(cli): validate non-interactive mode requires prompt

### DIFF
--- a/gptme/cli.py
+++ b/gptme/cli.py
@@ -489,6 +489,18 @@ def main(
         except (ImportError, AttributeError) as e:
             logger.warning(f"Could not load output_schema {output_schema}: {e}")
 
+    # Validate non-interactive mode requires a prompt or existing conversation
+    if not interactive and not prompt_msgs and not is_existing_conversation:
+        logger.error(
+            "Non-interactive mode requires a prompt. Provide a prompt as an argument, "
+            "use --resume to continue an existing conversation, or pipe input via stdin.\n\n"
+            "Examples:\n"
+            "  gptme --non-interactive 'hello world'\n"
+            "  gptme --non-interactive --resume\n"
+            "  echo 'hello' | gptme --non-interactive"
+        )
+        sys.exit(1)
+
     try:
         chat(
             prompt_msgs,


### PR DESCRIPTION
## Summary

When running `gptme --non-interactive` without a prompt, the current behavior is to silently start and exit with "Goodbye!". This is confusing for users who expect either an error or a chance to provide input.

## Changes

Added validation before entering the chat loop to catch this case early and provide a clear error message with examples of correct usage:
- Provide a prompt argument
- Use `--resume` to continue an existing conversation  
- Pipe input via stdin

## Example

Before (confusing):
```
$ gptme --non-interactive
... (some initialization) ...
Goodbye!
```

After (helpful):
```
$ gptme --non-interactive
ERROR: Non-interactive mode requires a prompt. Provide a prompt as an argument, use --resume to continue an existing conversation, or pipe input via stdin.

Examples:
  gptme --non-interactive 'hello world'
  gptme --non-interactive --resume
  echo 'hello' | gptme --non-interactive
```

## Testing

- Syntax validated with `python3 -m py_compile`
- CI will run full test suite

Fixes #1124
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds validation in `cli.py` to ensure non-interactive mode requires a prompt, existing conversation, or piped input, logging an error with usage examples if not met.
> 
>   - **Behavior**:
>     - Adds validation in `main()` in `cli.py` to ensure non-interactive mode requires a prompt, existing conversation, or piped input.
>     - Logs an error and exits if the conditions are not met, providing usage examples.
>   - **Logging**:
>     - Error message includes examples for correct usage when non-interactive mode is misused.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 70cc00526ec6c472a0af45daa9efff46201c1e04. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->