### PR TITLE
fix(server): improve skip message to prevent LLM re-suggestion

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -867,7 +867,13 @@ def api_conversation_tool_confirm(conversation_id: str):
         tool_exec.status = ToolStatus.SKIPPED
         del session.pending_tools[tool_id]
 
-        msg = Message("system", f"Skipped tool {tool_id}")
+        # Provide meaningful message to prevent LLM from re-suggesting the same tool
+        tool_name = tool_exec.tooluse.tool
+        msg = Message(
+            "system",
+            f"User chose not to execute this {tool_name} tool. "
+            "Do not re-suggest the same action unless explicitly requested.",
+        )
         _append_and_notify(LogManager.load(conversation_id, lock=False), session, msg)
 
         # Resume generation


### PR DESCRIPTION
When user skips a tool execution, provide a meaningful message that instructs the LLM not to re-suggest the same action.

## Changes

**Before:** `Skipped tool {tool_id}`

**After:** `User chose not to execute this {tool_name} tool. Do not re-suggest the same action unless explicitly requested.`

This addresses the issue where the LLM would keep suggesting the same tool call after the user declined to execute it.

## Testing

- Syntax check passed
- Pre-commit hooks passed
- Change is minimal and localized to message string

Fixes: gptme/gptme-webui#66
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update skip message in `api_conversation_tool_confirm()` to prevent LLM from re-suggesting skipped tools.
> 
>   - **Behavior**:
>     - Update skip message in `api_conversation_tool_confirm()` in `api_v2_sessions.py` to prevent LLM from re-suggesting skipped tools.
>     - New message: `User chose not to execute this {tool_name} tool. Do not re-suggest the same action unless explicitly requested.`
>   - **Testing**:
>     - Syntax check and pre-commit hooks passed.
>     - Change is minimal and localized to message string.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for a6efd1011e41fb02a2a8830bc5277f01cac776c0. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->