### PR TITLE
fix(server): make session_id optional for tool confirmation

### DIFF
--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -146,7 +146,10 @@ class StepRequest(BaseModel):
 class ToolConfirmRequest(BaseModel):
     """Request to confirm or modify tool execution."""
 
-    session_id: str = Field(..., description="Session ID")
+    session_id: str | None = Field(
+        None,
+        description="Session ID. Optional - if not provided, the tool will be found across all sessions for the conversation.",
+    )
     tool_id: str = Field(..., description="Tool ID")
     action: str = Field(..., description="Action: confirm, edit, skip, auto")
     content: str | None = Field(None, description="Modified content (for edit action)")


### PR DESCRIPTION
## Summary

Fixes a race condition where the client may not have received the `session_id` yet when confirming a tool (the 'connected' event hasn't arrived before the user clicks confirm).

## Problem

When a user opens a conversation with pending tools:
1. Client subscribes to SSE events
2. Server creates session and sends `connected` event (with session_id)
3. User sees pending tool in UI (from previous step)
4. User clicks confirm **BEFORE** `connected` event arrives
5. `confirmTool()` is called but client doesn't have session_id yet → 404 error

This race condition was first reported in gptme/gptme-webui#105.

## Solution

Make `session_id` optional for the tool confirmation endpoint. If not provided, the server searches across all sessions for the conversation to find the tool by `tool_id` (which are unique UUIDs).

This is safe because:
- Tool IDs are UUIDs, so collision is impossible
- The endpoint already knows the `conversation_id` from the URL path
- For single-client conversations (the common case), there's only one session anyway

## Changes

- Make `session_id` optional in `api_conversation_tool_confirm` endpoint
- If `session_id` not provided, search across all sessions using `SessionManager.get_sessions_for_conversation()`
- Update OpenAPI docs to reflect optional `session_id`
- Add tests for tool confirmation without `session_id`

## Testing

Added two new tests:
1. `test_tool_confirmation_without_session_id` - Verifies confirmation works without session_id
2. `test_tool_confirmation_without_session_id_tool_not_found` - Verifies proper 404 for non-existent tools

Related: gptme/gptme-webui#105
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `session_id` optional in tool confirmation endpoint, allowing search across all sessions if not provided, with updated OpenAPI docs and tests.
> 
>   - **Behavior**:
>     - Make `session_id` optional in `api_conversation_tool_confirm` endpoint in `api_v2_sessions.py`.
>     - If `session_id` not provided, search across all sessions using `SessionManager.get_sessions_for_conversation()`.
>     - Update OpenAPI docs in `openapi_docs.py` to reflect optional `session_id`.
>   - **Testing**:
>     - Add `test_tool_confirmation_without_session_id` in `test_server_v2_tool_confirmation.py` to verify confirmation without `session_id`.
>     - Add `test_tool_confirmation_without_session_id_tool_not_found` to verify 404 for non-existent tools.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 3680a96256aaf7f6aad462e8c4edc88406a749d5. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->