### PR TITLE
fix(llm): add supports_reasoning flag to Gemini 2.x models

### DIFF
--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -245,6 +245,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 0.15,
             "price_output": 0.60,
             "supports_vision": True,
+            "supports_reasoning": True,
         },
         "gemini-2.0-flash-lite": {
             "context": 1_048_576,
@@ -259,6 +260,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             # NOTE: $3.5/Mtok for thinking tokens
             "price_output": 0.60,
             "supports_vision": True,
+            "supports_reasoning": True,
         },
         "gemini-2.5-pro-preview-05-06": {
             "context": 1_048_576,
@@ -267,6 +269,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 1.25,
             "price_output": 10,
             "supports_vision": True,
+            "supports_reasoning": True,
         },
         "gemini-2.5-flash-lite": {
             "context": 1_000_000,
@@ -281,6 +284,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 0.3,
             "price_output": 2.5,
             "supports_vision": True,
+            "supports_reasoning": True,
         },
         "gemini-2.5-pro": {
             "context": 1_048_576,
@@ -289,6 +293,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 1.25,
             "price_output": 10,
             "supports_vision": True,
+            "supports_reasoning": True,
         },
     },
     # https://api-docs.deepseek.com/quick_start/pricing


### PR DESCRIPTION
## Summary

Add `supports_reasoning: True` to Gemini models that support thinking tokens.

## Affected Models

- `gemini-2.0-flash-thinking-exp-01-21` - has "thinking" in name
- `gemini-2.5-flash-preview-04-17` - pricing mentions thinking tokens
- `gemini-2.5-pro-preview-05-06`
- `gemini-2.5-flash`
- `gemini-2.5-pro`

## Impact

Users running `/models` with reasoning filter will now see Gemini models that support reasoning.

Fixes #1135
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `supports_reasoning` flag to specific Gemini models in `models.py` to enable reasoning filter support.
> 
>   - **Behavior**:
>     - Add `supports_reasoning: True` to `gemini-2.0-flash-thinking-exp-01-21`, `gemini-2.5-flash-preview-04-17`, `gemini-2.5-pro-preview-05-06`, `gemini-2.5-flash`, and `gemini-2.5-pro` in `models.py`.
>     - Models with `supports_reasoning` can now be filtered using the reasoning filter in `/models`.
>   - **Impact**:
>     - Users can now see Gemini models that support reasoning when using the reasoning filter.
>     - Fixes issue #1135.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 7710a19fb2035df558752e86dd04a97df9b27e66. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->