### PR TITLE
fix(setup): recognize Gemini API keys in setup wizard

### DIFF
--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -429,6 +429,8 @@ def get_model_from_api_key(api_key: str) -> tuple[str, Provider, str] | None:
         return api_key, "openrouter", "OPENROUTER_API_KEY"
     elif api_key.startswith("sk-"):
         return api_key, "openai", "OPENAI_API_KEY"
+    elif api_key.startswith("AIza"):
+        return api_key, "gemini", "GEMINI_API_KEY"
 
     return None
 

--- a/gptme/setup.py
+++ b/gptme/setup.py
@@ -589,7 +589,7 @@ def _prompt_api_key() -> tuple[str, str, str]:  # pragma: no cover
         console.print("[red]Invalid API key format. Please try again.[/red]")
         console.print(
             "[dim]Supported formats: OpenAI (sk-...), Anthropic (sk-ant-...), "
-            "OpenRouter (sk-or-...)[/dim]"
+            "OpenRouter (sk-or-...), Gemini (AIza...)[/dim]"
         )
         return _prompt_api_key()
 


### PR DESCRIPTION
## Summary

The API key setup wizard wasn't recognizing Gemini keys (AIza...) because `get_model_from_api_key()` only checked for OpenAI/Anthropic/OpenRouter prefixes.

## Changes

- Add Gemini key detection (`AIza...` prefix) to `get_model_from_api_key()`
- Update error message to mention Gemini format

## Testing

Verified key detection works correctly:
```python
from gptme.llm import get_model_from_api_key

result = get_model_from_api_key('AIzaSyAtest123key456')
# Returns: ('AIzaSyAtest123key456', 'gemini', 'GEMINI_API_KEY')
```

Fixes #1134
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for recognizing Gemini API keys in setup wizard by updating `get_model_from_api_key()` and error message in `setup.py`.
> 
>   - **Behavior**:
>     - Add Gemini key detection (`AIza...` prefix) to `get_model_from_api_key()` in `__init__.py`.
>     - Update error message in `_prompt_api_key()` in `setup.py` to include Gemini format.
>   - **Testing**:
>     - Verified key detection for Gemini keys using `get_model_from_api_key()` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for a341983062829925ba05b72bcd1bb0153d150c9e. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->