### PR TITLE
feat(cli): add visible prompt type-ahead using patch_stdout

### DIFF
--- a/gptme/util/async_input.py
+++ b/gptme/util/async_input.py
@@ -9,10 +9,15 @@ The approach:
 2. Use patch_stdout() context so that any stdout writes appear above the prompt
 3. Main thread continues with LLM streaming, output appears above the active prompt
 4. When user presses Enter, input is queued for processing
+
+Thread-safety: Uses queue.Queue for safe cross-thread communication.
 """
+
+from __future__ import annotations
 
 import asyncio
 import logging
+import queue
 import sys
 import threading
 from collections.abc import Callable
@@ -39,15 +44,18 @@ class VisiblePromptCollector:
     prompt. This allows users to see and edit their input while LLM
     responses stream above.
 
+    Thread-safety: Uses queue.Queue for safe cross-thread communication.
+    The collector owns the queue and provides thread-safe accessor methods.
+
     Usage:
-        collector = VisiblePromptCollector(prompt_queue)
+        collector = VisiblePromptCollector()
         collector.start()
+        msg = collector.get_message()  # Check for queued input
         collector.stop()
     """
 
     def __init__(
         self,
-        prompt_queue: list["Message"],
         on_input: Callable[[str], None] | None = None,
         max_queue_size: int = 100,
     ):
@@ -55,18 +63,18 @@ class VisiblePromptCollector:
         Initialize the visible prompt collector.
 
         Args:
-            prompt_queue: List to append collected prompts to
             on_input: Optional callback when input is collected
             max_queue_size: Maximum number of prompts to queue
         """
-        self._prompt_queue = prompt_queue
+        self._message_queue: queue.Queue[Message] = queue.Queue(maxsize=max_queue_size)
         self._on_input = on_input
         self._max_queue_size = max_queue_size
         self._running = False
         self._thread: threading.Thread | None = None
         self._stop_event = threading.Event()
-        self._lock = threading.Lock()
+        self._state_lock = threading.Lock()  # Protects _running and _thread state
         self._loop: asyncio.AbstractEventLoop | None = None
+        self._task: asyncio.Task | None = None
 
     def _create_session(self) -> PromptSession:
         """Create a prompt session with appropriate keybindings."""
@@ -111,23 +119,22 @@ class VisiblePromptCollector:
                     )
 
                     if result and result.strip():
-                        with self._lock:
-                            if len(self._prompt_queue) >= self._max_queue_size:
-                                logger.warning(
-                                    f"Prompt queue full ({self._max_queue_size}), "
-                                    "dropping input"
-                                )
-                                continue
-
+                        try:
                             msg = Message("user", result.strip(), quiet=True)
-                            self._prompt_queue.append(msg)
-                            queue_size = len(self._prompt_queue)
-
-                        print(
-                            f"\033[92mQueued\033[0m "
-                            f"({queue_size} prompt{'s' if queue_size > 1 else ''} ready)",
-                            file=sys.stderr,
-                        )
+                            # put_nowait raises queue.Full if full
+                            self._message_queue.put_nowait(msg)
+                            queue_size = self._message_queue.qsize()
+                            print(
+                                f"\033[92mQueued\033[0m "
+                                f"({queue_size} prompt{'s' if queue_size > 1 else ''} ready)",
+                                file=sys.stderr,
+                            )
+                        except queue.Full:
+                            logger.warning(
+                                f"Prompt queue full ({self._max_queue_size}), "
+                                "dropping input"
+                            )
+                            continue
 
                         if self._on_input:
                             try:
@@ -154,59 +161,117 @@ class VisiblePromptCollector:
         try:
             self._loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self._loop)
-            self._loop.run_until_complete(self._async_collect_loop())
+            self._task = self._loop.create_task(self._async_collect_loop())
+            self._loop.run_until_complete(self._task)
+        except asyncio.CancelledError:
+            pass  # Expected when stop() cancels the task
         except Exception as e:
             logger.debug(f"Collector thread error: {e}")
         finally:
             if self._loop:
                 self._loop.close()
                 self._loop = None
+            self._task = None
 
     def start(self) -> None:
-        """Start visible prompt collection in a background thread."""
-        if self._running:
-            return
+        """Start visible prompt collection in a background thread.
 
-        if not sys.stdin.isatty():
-            logger.debug("Skipping visible prompt collector: stdin is not a TTY")
-            return
+        Thread-safe: Can be called multiple times safely.
+        """
+        with self._state_lock:
+            if self._running:
+                return
 
-        self._running = True
-        self._stop_event.clear()
+            if not sys.stdin.isatty():
+                logger.debug("Skipping visible prompt collector: stdin is not a TTY")
+                return
 
-        self._thread = threading.Thread(
-            target=self._thread_main,
-            daemon=True,
-            name="VisiblePromptCollector",
-        )
-        self._thread.start()
-        logger.debug("Started visible prompt collector")
+            self._running = True
+            self._stop_event.clear()
+
+            self._thread = threading.Thread(
+                target=self._thread_main,
+                daemon=True,
+                name="VisiblePromptCollector",
+            )
+            self._thread.start()
+            logger.debug("Started visible prompt collector")
 
     def stop(self) -> None:
-        """Stop visible prompt collection."""
-        if not self._running:
-            return
+        """Stop visible prompt collection.
 
-        self._running = False
-        self._stop_event.set()
+        Thread-safe: Properly cancels the async task before stopping the loop.
+        """
+        with self._state_lock:
+            if not self._running:
+                return
 
-        if self._loop and self._loop.is_running():
-            self._loop.call_soon_threadsafe(self._loop.stop)
+            self._running = False
+            self._stop_event.set()
 
-        if self._thread and self._thread.is_alive():
-            self._thread.join(timeout=1.0)
-            if self._thread.is_alive():
-                logger.warning("Collector thread did not stop cleanly")
+            # Cancel the task properly before stopping the loop
+            if self._loop and self._task and not self._task.done():
+                self._loop.call_soon_threadsafe(self._task.cancel)
 
-        self._thread = None
-        logger.debug("Stopped visible prompt collector")
+            if self._thread and self._thread.is_alive():
+                self._thread.join(timeout=1.0)
+                if self._thread.is_alive():
+                    logger.warning("Collector thread did not stop cleanly")
+
+            self._thread = None
+            logger.debug("Stopped visible prompt collector")
+
+    def get_message(
+        self, block: bool = False, timeout: float | None = None
+    ) -> Message | None:
+        """Get a message from the queue.
+
+        Thread-safe accessor method for the internal queue.
+
+        Args:
+            block: If True, block until a message is available
+            timeout: If block is True, timeout after this many seconds
+
+        Returns:
+            Message or None if queue is empty (or timeout reached)
+        """
+        try:
+            return self._message_queue.get(block=block, timeout=timeout)
+        except queue.Empty:
+            return None
+
+    def has_messages(self) -> bool:
+        """Check if there are any messages in the queue.
+
+        Thread-safe: Uses queue.Queue's thread-safe qsize().
+        """
+        return not self._message_queue.empty()
 
     def get_queue_size(self) -> int:
-        """Get number of prompts in queue."""
-        with self._lock:
-            return len(self._prompt_queue)
+        """Get number of prompts in queue.
+
+        Thread-safe: Uses queue.Queue's thread-safe qsize().
+        """
+        return self._message_queue.qsize()
+
+    def clear_queue(self) -> None:
+        """Clear all messages from the queue.
+
+        Thread-safe: Drains the queue by getting all items.
+        """
+        while True:
+            try:
+                self._message_queue.get_nowait()
+            except queue.Empty:
+                break
 
     @property
     def is_running(self) -> bool:
-        """Check if collector is currently running."""
-        return self._running and self._thread is not None and self._thread.is_alive()
+        """Check if collector is currently running.
+
+        Thread-safe: Uses lock to read state.
+        """
+        with self._state_lock:
+            return (
+                self._running and self._thread is not None and self._thread.is_alive()
+            )

--- a/tests/test_visible_prompt.py
+++ b/tests/test_visible_prompt.py
@@ -16,8 +16,7 @@ class TestVisiblePromptCollector:
         """Test basic initialization."""
         from gptme.util.async_input import VisiblePromptCollector
 
-        prompt_queue: list[Message] = []
-        collector = VisiblePromptCollector(prompt_queue)
+        collector = VisiblePromptCollector()
 
         assert collector is not None
         assert not collector.is_running
@@ -27,15 +26,12 @@ class TestVisiblePromptCollector:
         """Test initialization with custom options."""
         from gptme.util.async_input import VisiblePromptCollector
 
-        prompt_queue: list[Message] = []
         callback_called: list[str] = []
 
         def on_input(text: str) -> None:
             callback_called.append(text)
 
-        collector = VisiblePromptCollector(
-            prompt_queue, on_input=on_input, max_queue_size=50
-        )
+        collector = VisiblePromptCollector(on_input=on_input, max_queue_size=50)
 
         assert collector is not None
         assert collector._max_queue_size == 50
@@ -49,8 +45,7 @@ class TestVisiblePromptCollector:
         # Mock stdin.isatty() to return False
         monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
 
-        prompt_queue: list[Message] = []
-        collector = VisiblePromptCollector(prompt_queue)
+        collector = VisiblePromptCollector()
 
         collector.start()
         # Should not actually start because stdin is not a TTY
@@ -58,25 +53,51 @@ class TestVisiblePromptCollector:
 
         collector.stop()  # Should be safe to call even when not running
 
-    def test_get_queue_size(self):
-        """Test queue size tracking."""
+    def test_queue_operations(self):
+        """Test queue operations - internal queue with thread-safe methods."""
         from gptme.util.async_input import VisiblePromptCollector
 
-        prompt_queue: list[Message] = []
-        collector = VisiblePromptCollector(prompt_queue)
+        collector = VisiblePromptCollector()
 
         assert collector.get_queue_size() == 0
+        assert not collector.has_messages()
+        assert collector.get_message() is None
 
-        # Add a message to the queue manually (simulating what happens on input)
-        prompt_queue.append(Message("user", "test"))
+        # Directly put a message into the internal queue (simulating async input)
+        msg = Message("user", "test message")
+        collector._message_queue.put(msg)
+
         assert collector.get_queue_size() == 1
+        assert collector.has_messages()
+
+        # Get the message back
+        retrieved = collector.get_message()
+        assert retrieved is not None
+        assert retrieved.content == "test message"
+        assert collector.get_queue_size() == 0
+
+    def test_clear_queue(self):
+        """Test clearing the queue."""
+        from gptme.util.async_input import VisiblePromptCollector
+
+        collector = VisiblePromptCollector()
+
+        # Add some messages
+        for i in range(3):
+            collector._message_queue.put(Message("user", f"msg{i}"))
+
+        assert collector.get_queue_size() == 3
+
+        collector.clear_queue()
+
+        assert collector.get_queue_size() == 0
+        assert not collector.has_messages()
 
     def test_stop_when_not_running(self):
         """Test that stop is safe to call when not running."""
         from gptme.util.async_input import VisiblePromptCollector
 
-        prompt_queue: list[Message] = []
-        collector = VisiblePromptCollector(prompt_queue)
+        collector = VisiblePromptCollector()
 
         # Should not raise
         collector.stop()


### PR DESCRIPTION
## Summary

Implements the `patch_stdout()` approach for prompt queueing as suggested by @ErikBjare in [PR #1140](https://github.com/gptme/gptme/pull/1140#issuecomment-3789178949).

## Changes

- Add `VisiblePromptCollector` class using prompt_toolkit's `patch_stdout()`
- Keeps a visible prompt at the bottom of the terminal while LLM output streams above
- Runs async prompt in a background thread with its own event loop
- Integrates into chat loop - active during message processing, stopped before normal user input
- Add tests for the new collector

## How it works

1. When the agent starts processing a message, `VisiblePromptCollector.start()` is called
2. A background thread starts with its own asyncio event loop
3. Inside the `patch_stdout()` context, `prompt_async()` shows a visible prompt at the bottom
4. Any stdout/stderr output (including LLM streaming) appears above the prompt
5. User can type at any time - input is visible and editable
6. When user presses Enter, the input is queued as a new prompt
7. When processing completes, `stop()` is called before the normal prompt

## Screenshots

(Will add after testing manually)

## Related

- Addresses discussion in #569
- Alternative to #1140 (which uses silent background input collection)

@ErikBjare - Here's the `patch_stdout()` approach you suggested. This keeps the prompt visible at the bottom while output streams above, without going full TUI.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `VisiblePromptCollector` to manage visible prompts during LLM output using `patch_stdout`, integrated into the chat loop with tests for functionality.
> 
>   - **Behavior**:
>     - Adds `VisiblePromptCollector` class in `async_input.py` to manage visible prompts using `patch_stdout()`.
>     - Integrates `VisiblePromptCollector` into `_run_chat_loop()` in `chat.py` to keep prompts visible during LLM output.
>     - Prompts are visible and editable, and input is queued when Enter is pressed.
>   - **Implementation**:
>     - `VisiblePromptCollector` runs in a background thread with its own event loop.
>     - Uses `prompt_toolkit` to manage input and display.
>     - Handles input queuing and manages prompt visibility during LLM streaming.
>   - **Testing**:
>     - Adds `test_visible_prompt.py` to test `VisiblePromptCollector` initialization, start/stop behavior, and queue size tracking.
>     - Tests ensure collector does not start when stdin is not a TTY and that stopping is safe when not running.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for bb5d051fb8af0d90931555efc68becc837b136ac. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->