### PR TITLE
fix: remove duplicate Goodbye message on Ctrl+D exit

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -521,7 +521,6 @@ def prompt_user(value=None) -> str:  # pragma: no cover
             except KeyboardInterrupt:
                 print("\nInterrupted. Press Ctrl-D to exit.")
             except EOFError:
-                print("\nGoodbye!")
                 raise  # Let _get_user_input handle the normal exit flow
     clear_interruptible()
     return response


### PR DESCRIPTION
Fixes the duplicate "Goodbye!" message when exiting with Ctrl+D.

**Before:** "Goodbye!" printed twice - once from prompt_user() and once from cli.py with resume info.

**After:** Only the cli.py message is shown, which includes the useful resume info.

This follows up on #1146 which fixed Ctrl+D to properly trigger SESSION_END hooks.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes duplicate "Goodbye!" message in `prompt_user()` in `chat.py` when exiting with Ctrl+D, showing only the `cli.py` message with resume info.
> 
>   - **Behavior**:
>     - Removes duplicate "Goodbye!" message in `prompt_user()` in `chat.py` when exiting with Ctrl+D.
>     - Now only the message from `cli.py` is shown, which includes resume info.
>   - **Context**:
>     - Follows up on #1146 which fixed Ctrl+D to trigger SESSION_END hooks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 580b87e62fc7274ad977dffd13b00fb4f4bb00b9. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->