### PR TITLE
feat(cli): add agent profiles for pre-configured system prompts + tool access

### DIFF
--- a/gptme/profiles.py
+++ b/gptme/profiles.py
@@ -1,12 +1,20 @@
 """Agent profiles for pre-configured system prompts and tool access.
 
-Profiles combine:
-- System prompt customization
-- Tool access restrictions
-- Behavior rules
+Profiles provide soft/prompting-based guidance combining:
+- System prompt customization (behavioral hints)
+- Tool access suggestions (which tools to prefer)
+- Behavior rules (read-only, no-network, etc.)
+
+IMPORTANT: Profile restrictions are soft enforcement via prompting only.
+The agent receives instructions about limitations but there's no hard
+technical enforcement at the tool level. The agent follows profile
+instructions as guidance, similar to how it follows system prompts.
 
 This enables creating specialized agents like "explorer" (read-only),
 "researcher" (web access), or "developer" (full capabilities).
+
+For hard technical enforcement of tool restrictions, see the shielded
+processing mode in PR #1158.
 """
 
 import logging
@@ -58,10 +66,14 @@ class Profile:
 
     @classmethod
     def from_dict(cls, data: dict) -> "Profile":
-        """Create a Profile from a dictionary (e.g., TOML config)."""
-        behavior_data = data.pop("behavior", {})
+        """Create a Profile from a dictionary (e.g., TOML config).
+
+        Note: This method does not mutate the input dictionary.
+        """
+        behavior_data = data.get("behavior", {})
         behavior = ProfileBehavior(**behavior_data)
-        return cls(behavior=behavior, **data)
+        profile_data = {k: v for k, v in data.items() if k != "behavior"}
+        return cls(behavior=behavior, **profile_data)
 
 
 # Built-in profiles

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -45,6 +45,21 @@ class TestProfile:
         assert profile.behavior.read_only is True
         assert profile.behavior.no_network is True
 
+    def test_profile_from_dict_no_mutation(self):
+        """Test that from_dict does not mutate the input dictionary."""
+        data = {
+            "name": "custom",
+            "description": "Custom profile",
+            "behavior": {"read_only": True},
+        }
+        original_data = dict(data)  # Copy to compare
+
+        Profile.from_dict(data)
+
+        # Input dict should not be mutated
+        assert data == original_data
+        assert "behavior" in data  # Key should still exist
+
     def test_profile_default_behavior(self):
         """Test profile with default behavior."""
         profile = Profile(name="test", description="Test")


### PR DESCRIPTION
## Summary

Add support for agent profiles that combine pre-configured system prompts, tool access restrictions, and behavior rules into named profiles.

## Built-in Profiles

| Profile | Description | Tools | Behavior |
|---------|-------------|-------|----------|
| default | Full capabilities | all | - |
| explorer | Read-only exploration | read, shell, chats | read-only, no-network |
| researcher | Web research | browser, read, screenshot, chats | read-only |
| developer | Full development | all | - |
| isolated | Untrusted content processing | read, ipython | read-only, no-network |

## Usage

```shell
gptme --list-profiles                  # List profiles
gptme --agent-profile explorer ...     # Use a profile
```

User profiles: TOML files in ~/.config/gptme/profiles/

## Security

Profiles enable defense-in-depth against prompt injection (#1158).

Closes #1157