### PR TITLE
fix(config): use TOOL_ALLOWLIST instead of TOOLS for consistency

### DIFF
--- a/gptme/config.py
+++ b/gptme/config.py
@@ -954,7 +954,7 @@ def setup_config_from_cli(
     elif existing_chat_config and existing_chat_config.tools:
         # When resuming, use saved conversation tools unless CLI override provided
         resolved_tool_allowlist = existing_chat_config.tools
-    elif tools_env := config.get_env("TOOLS"):
+    elif tools_env := config.get_env("TOOL_ALLOWLIST"):
         # Fall back to env/config for new conversations or when no saved tools
         resolved_tool_allowlist = [tool.strip() for tool in tools_env.split(",")]
 


### PR DESCRIPTION
## Summary

Fixes the inconsistency where `setup_config_from_cli()` was checking for `TOOLS` env var, while:
- Documentation (docs/config.rst) references `TOOL_ALLOWLIST`
- `init_tools()` checks for `TOOL_ALLOWLIST`

This caused user confusion when trying to use `TOOL_ALLOWLIST` at the project level.

## Changes

Changed `config.get_env("TOOLS")` to `config.get_env("TOOL_ALLOWLIST")` in `setup_config_from_cli()` for consistency.

Fixes #1164