### PR TITLE
fix(shell): correct markdown heading level for Background Jobs section

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -347,7 +347,7 @@ The shell tool will respond with the output of the execution.
 These programs are available, among others:
 {shell_programs_str}
 
-## Background Jobs
+### Background Jobs
 
 For long-running commands (dev servers, builds, etc.), use background jobs:
 - `bg <command>` - Start command in background, returns job ID


### PR DESCRIPTION
## Summary

Fixes the markdown heading level for the 'Background Jobs' section in the shell tool documentation.

## Problem

As reported in #1164, when `TOOL_ALLOWLIST = "shell"` is used, the system prompt shows:

```md
# Tools Overview
## shell
## Background Jobs
*End of Tools List.*
```

The 'Background Jobs' section appears at the same level as 'shell' (both `##`), when it should be a subsection:

```md
# Tools Overview
## shell
### Background Jobs
*End of Tools List.*
```

## Fix

Changed `## Background Jobs` to `### Background Jobs` in the shell tool's instructions string.

Related to #1164