### PR TITLE
fix(chat): allow explicit model param to bypass default_model assertion

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -95,8 +95,11 @@ def chat(
             initial_msgs = initial_msgs + [hook_msg]
 
     default_model = get_default_model()
-    assert default_model is not None, "No model loaded and no model specified"
-    modelmeta = get_model(model or default_model.full)
+    # Only require default_model if no explicit model was passed
+    if model is None and default_model is None:
+        raise AssertionError("No model loaded and no model specified")
+    model_to_use = model if model else default_model.full
+    modelmeta = get_model(model_to_use)
     if not modelmeta.supports_streaming and stream:
         logger.info(
             "Disabled streaming for '%s/%s' model (not supported)",
@@ -463,8 +466,10 @@ def step(
 ) -> Generator[Message, None, None]:
     """Runs a single pass of the chat - generates response and executes tools."""
     default_model = get_default_model()
-    assert default_model is not None, "No model loaded and no model specified"
-    model = model or default_model.full
+    # Only require default_model if no explicit model was passed
+    if model is None and default_model is None:
+        raise AssertionError("No model loaded and no model specified")
+    model = model if model else default_model.full
     if isinstance(log, list):
         log = Log(log)
 


### PR DESCRIPTION
## Summary

Fixes the assertion 'No model loaded and no model specified' being triggered unconditionally, even when a model was explicitly passed via the `model` parameter.

## Problem

In threaded contexts (like the Discord bot using `run_in_executor`), the `ContextVar` for the default model doesn't propagate to thread pool workers. This caused the Discord bot to crash with:

```
AssertionError: No model loaded and no model specified
```

...even though a model was explicitly passed to `step()`:

```python
step(
    current_log,
    model=settings.model,  # Model IS being passed!
    ...
)
```

## Root Cause

The assertion at lines 97-98 and 468-469 in `chat.py` was:
```python
default_model = get_default_model()
assert default_model is not None, "No model loaded and no model specified"
```

This asserts unconditionally, before checking if a model was explicitly passed.

## Solution

Now the assertion only fails if BOTH:
1. The explicit `model` parameter is `None`
2. AND the `default_model` is `None`

```python
if model is None and default_model is None:
    raise AssertionError("No model loaded and no model specified")
```

## Testing

This fix allows the Discord bot (and any other threaded usage) to work correctly when passing an explicit model parameter.

Fixes ErikBjare/bob#276