### PR TITLE
fix(chat): restructure type checks for mypy narrowing

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -96,9 +96,13 @@ def chat(
 
     default_model = get_default_model()
     # Only require default_model if no explicit model was passed
-    if model is None and default_model is None:
-        raise AssertionError("No model loaded and no model specified")
-    model_to_use = model if model else default_model.full
+    # Use nested if/else for proper mypy type narrowing
+    if model is None:
+        if default_model is None:
+            raise AssertionError("No model loaded and no model specified")
+        model_to_use = default_model.full
+    else:
+        model_to_use = model
     modelmeta = get_model(model_to_use)
     if not modelmeta.supports_streaming and stream:
         logger.info(
@@ -467,9 +471,11 @@ def step(
     """Runs a single pass of the chat - generates response and executes tools."""
     default_model = get_default_model()
     # Only require default_model if no explicit model was passed
-    if model is None and default_model is None:
-        raise AssertionError("No model loaded and no model specified")
-    model = model if model else default_model.full
+    # Use nested if/else for proper mypy type narrowing
+    if model is None:
+        if default_model is None:
+            raise AssertionError("No model loaded and no model specified")
+        model = default_model.full
     if isinstance(log, list):
         log = Log(log)
 


### PR DESCRIPTION
## Summary

Fixes typecheck errors introduced in #1176 by restructuring the type checks to use nested if/else instead of combined condition + ternary.

## Problem

The combined condition `if model is None and default_model is None` didn't allow mypy to properly narrow types in the subsequent ternary expression `model if model else default_model.full`. 

mypy reported:
- `gptme/chat.py:101: error: Item "None" of "ModelMeta | None" has no attribute "full"`
- `gptme/chat.py:472: error: Item "None" of "ModelMeta | None" has no attribute "full"`

## Solution

Restructured to nested if/else which makes the type narrowing explicit:

```python
# Before (mypy can't narrow)
if model is None and default_model is None:
    raise AssertionError(...)
model_to_use = model if model else default_model.full  # mypy error

# After (explicit narrowing)
if model is None:
    if default_model is None:
        raise AssertionError(...)
    model_to_use = default_model.full  # mypy knows it's not None
else:
    model_to_use = model
```

## Testing

- Verified locally that the typecheck errors are resolved
- Pre-commit checks pass

Follow-up to #1176 as requested by @ErikBjare.