### PR TITLE
feat(prompts): add safeguard truncation for context_cmd output

### DIFF
--- a/gptme/prompts.py
+++ b/gptme/prompts.py
@@ -554,9 +554,8 @@ def _truncate_context_output(
     # Keep the first portion of output with truncation notice
     truncated = output[:max_chars]
     # Find a good break point (newline) to avoid cutting mid-line
-    last_newline = truncated.rfind("\n", max_chars - 1000, max_chars)
-    if last_newline > max_chars - 1000:
-        truncated = truncated[:last_newline]
+    last_newline = truncated.rfind("\n", max(0, max_chars - 1000), max_chars)
+    if last_newline > max(0, max_chars - 1000):
 
     original_chars = len(output)
     kept_chars = len(truncated)


### PR DESCRIPTION
## Summary

Prevents context explosion when `context_cmd` produces excessively long output (e.g., accidentally tracked large files in git status).

## Changes

- Add `CONTEXT_CMD_MAX_CHARS` constant (100k chars ≈ 25k tokens)
- Add `_truncate_context_output()` helper that truncates at line boundaries
- Apply truncation to both success and error cases
- Include clear truncation notice in output

## Motivation

From Erik's feedback on Coop investigation (ErikBjare/bob#227):

> The `context_cmd` option in gptme.toml should have some safeguard too, truncating excessively long outputs from it. That way a bad context_cmd output won't prevent startup like this.

The existing warning at >10k tokens is preserved. This adds a hard safety limit (100k chars) to prevent startup failures from bad context_cmd configurations.

## Testing

Manual verification:
- Small outputs unchanged
- Large outputs (>100k chars) truncated at line boundaries with clear notice
- Warning logged when truncation occurs

Resolves: ErikBjare/bob#227 (Coop workspace feedback)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds safeguard to truncate `context_cmd` output in `gptme/prompts.py` to prevent excessively long outputs from causing issues.
> 
>   - **Behavior**:
>     - Introduces `CONTEXT_CMD_MAX_CHARS` constant (100,000 chars) in `gptme/prompts.py` to limit `context_cmd` output.
>     - Adds `_truncate_context_output()` function to truncate output at line boundaries with a notice.
>     - Applies truncation in `get_project_context_cmd_output()` for both success and error cases.
>   - **Logging**:
>     - Logs a warning when truncation occurs, indicating original and truncated sizes.
>   - **Testing**:
>     - Manual verification ensures small outputs remain unchanged and large outputs are truncated with a notice.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for c8b672be1c0c4e55f2447a503917068f11fddb7c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->