### PR TITLE
fix(prompts): restore missing truncation line in context_cmd safeguard

### DIFF
--- a/gptme/prompts.py
+++ b/gptme/prompts.py
@@ -556,6 +556,7 @@ def _truncate_context_output(
     # Find a good break point (newline) to avoid cutting mid-line
     last_newline = truncated.rfind("\n", max(0, max_chars - 1000), max_chars)
     if last_newline > max(0, max_chars - 1000):
+        truncated = truncated[:last_newline]
 
     original_chars = len(output)
     kept_chars = len(truncated)


### PR DESCRIPTION
## Summary

Fixes a syntax error introduced in PR #1178 that breaks mypy for all downstream repos.

## Problem

The `if` statement checking for a good newline break point had its body accidentally deleted when applying a Greptile suggestion:

```python
# Before (broken):
if last_newline > max(0, max_chars - 1000):

original_chars = len(output)  # ← Syntax error: expected indented block

# After (fixed):
if last_newline > max(0, max_chars - 1000):
    truncated = truncated[:last_newline]

original_chars = len(output)
```

## Impact

Without this fix:
- All mypy type checks fail with `error: expected an indented block after 'if' statement`
- CI fails for gptme-contrib and other downstream repos

## Testing

- `python3 -m py_compile gptme/prompts.py` passes
- Pre-commit checks pass

@greptileai review
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes syntax error in `gptme/prompts.py` by restoring missing line in `_truncate_context_output()` to resolve mypy and CI failures.
> 
>   - **Fix**:
>     - Restores missing line `truncated = truncated[:last_newline]` in `if` statement in `_truncate_context_output()` in `gptme/prompts.py`.
>     - Fixes syntax error causing mypy type checks to fail with `error: expected an indented block after 'if' statement`.
>   - **Impact**:
>     - CI failures resolved for gptme-contrib and other downstream repos.
>   - **Testing**:
>     - `python3 -m py_compile gptme/prompts.py` passes.
>     - Pre-commit checks pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 7234352b39d7ab091ca86232449d962639906f49. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->