### PR TITLE
fix(llm): add reasoning_content for OpenRouter reasoning models with tool_calls

### DIFF
--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -1010,3 +1010,7 @@ def test_transform_msgs_extracts_reasoning_content():
     # Should extract the actual reasoning content
     assert "reasoning_content" in result[0]
     assert result[0]["reasoning_content"] == "I need to run ls to list files"
+
+    # Should remove <think> tags from content to prevent context duplication
+    assert result[0]["content"] == "Let me check the files."
+    assert "<think>" not in result[0]["content"]


### PR DESCRIPTION
## Problem

When using `--tool-format tool` with OpenRouter models that support reasoning (like Moonshot AI Kimi K2.5), the API returns an error:

```
thinking is enabled but reasoning_content is missing in assistant tool call message at index 11
```

This happens because Moonshot AI's API expects assistant messages with tool_calls to include a `reasoning_content` field when thinking mode is enabled.

## Solution

Add empty `reasoning_content` to assistant messages with tool_calls for OpenRouter models that have `supports_reasoning=True`, similar to the existing DeepSeek handling at line 761-767.

## Changes

- Extended `_transform_msgs_for_special_provider()` to handle OpenRouter reasoning models
- Added 2 new tests:
  - `test_transform_msgs_for_openrouter_reasoning_tool_calls` - verifies reasoning models get the fix
  - `test_transform_msgs_for_openrouter_non_reasoning` - verifies non-reasoning models are unchanged

## Testing

```bash
pytest tests/test_llm_openai.py -k 'transform' -v
# All 7 tests pass
```

## Related

- Fixes #1181 for OpenRouter models (Kimi K2.5)
- Similar to existing DeepSeek handling

---

Co-authored-by: Bob <bob@superuserlabs.org>
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `reasoning_content` to OpenRouter reasoning models' assistant messages with tool calls to fix API errors.
> 
>   - **Behavior**:
>     - Adds `reasoning_content` to assistant messages with `tool_calls` for OpenRouter models with `supports_reasoning=True` in `_transform_msgs_for_special_provider()`.
>     - Extracts reasoning content from `<think>` tags and cleans content to prevent duplication.
>   - **Testing**:
>     - Adds `test_transform_msgs_for_openrouter_reasoning_tool_calls` to verify `reasoning_content` is added.
>     - Adds `test_transform_msgs_for_openrouter_non_reasoning` to ensure non-reasoning models remain unchanged.
>     - Adds `test_transform_msgs_extracts_reasoning_content` to check extraction and cleaning of reasoning content.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 96154996d27452019da5e52abda506c921488d62. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->