### PR TITLE
fix(llm): handle list content in OpenRouter reasoning extraction

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -836,6 +836,18 @@ def _transform_msgs_for_special_provider(
             ):
                 # Extract reasoning and clean content to prevent context duplication
                 content = msg.get("content", "")
+
+                # Handle list content (multi-modal messages)
+                if isinstance(content, list):
+                    # Extract text from list items
+                    text_parts = []
+                    for item in content:
+                        if isinstance(item, str):
+                            text_parts.append(item)
+                        elif isinstance(item, dict) and item.get("type") == "text":
+                            text_parts.append(item.get("text", ""))
+                    content = "\n".join(text_parts)
+
                 reasoning, cleaned_content = _extract_and_strip_reasoning(content)
                 result.append(
                     {**msg, "reasoning_content": reasoning, "content": cleaned_content}


### PR DESCRIPTION
## Summary

Fixes `expected string or bytes-like object, got 'list'` error when content is a list (multi-modal message format) instead of a string.

## Problem

The `_extract_and_strip_reasoning` function expects a string, but content can be a list of content parts for multi-modal messages. This caused a crash when running:
```
gptme -m openrouter/moonshotai/kimi-k2.5@moonshotai --tool-format tool 'try ipython'
```

Error reported by Erik in #1187:
```
ERROR    Fatal error occurred
ERROR    expected string or bytes-like object, got 'list'
ERROR      at gptme/llm/llm_openai.py:806 in _extract_and_strip_reasoning
```

## Solution

Add handling to extract text from list content items before performing reasoning extraction:
- If content is a list of dicts with `{"type": "text", "text": ...}`, extract text from those
- If content is a list of strings, join them
- Then proceed with normal reasoning extraction

## Tests

Added two new test cases:
- `test_transform_msgs_handles_list_content` - Tests dict-based list content
- `test_transform_msgs_handles_string_list_content` - Tests string-based list content

Closes follow-up from #1187
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes list content handling in OpenRouter reasoning extraction in `llm_openai.py`.
> 
>   - **Behavior**:
>     - Fixes `expected string or bytes-like object, got 'list'` error in `_extract_and_strip_reasoning` in `llm_openai.py` by handling list content.
>     - Extracts text from list items if content is a list of dicts with `{"type": "text", "text": ...}` or joins if list of strings.
>   - **Tests**:
>     - Adds `test_transform_msgs_handles_list_content` for dict-based list content in `test_llm_openai.py`.
>     - Adds `test_transform_msgs_handles_string_list_content` for string-based list content in `test_llm_openai.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 530073b530a6d352a0d433bd6ae48339d6c1cbc3. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->