### PR TITLE
fix(server): include hide property in SSE message_added events

### DIFF
--- a/gptme/server/api_v2_common.py
+++ b/gptme/server/api_v2_common.py
@@ -9,15 +9,14 @@ from ..message import Message
 from .api import _abs_to_rel_workspace
 
 
-class MessageDict(TypedDict, total=False):
+class MessageDict(TypedDict):
     """Message dictionary type."""
 
     role: str
     content: str
     timestamp: str
-    files: list[str] | None
-    hide: bool
-
+    files: NotRequired[list[str] | None]
+    hide: NotRequired[bool]
 
 class ToolUseDict(TypedDict):
     """Tool use dictionary type."""


### PR DESCRIPTION
When system messages with `hide=True` (like auto-included lessons, token budget info) were added to conversations, the `hide` property was not being sent in the SSE `message_added` events. This caused gptme-webui to display these messages during streaming.

## Changes

- Added `hide: bool` to `MessageDict` TypedDict
- Updated `msg2dict()` to include `hide` property when `msg.hide` is `True`

## Related

- gptme-webui PR #122: https://github.com/gptme/gptme-webui/pull/122
- Fixes the need for pattern-based fallback detection in gptme-webui
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Include `hide` property in SSE `message_added` events to prevent display of hidden system messages in gptme-webui.
> 
>   - **Behavior**:
>     - Include `hide` property in SSE `message_added` events for system messages with `hide=True`.
>     - Prevents unintended display of hidden messages in gptme-webui.
>   - **Code Changes**:
>     - Add `hide: bool` to `MessageDict` in `api_v2_common.py`.
>     - Update `msg2dict()` in `api_v2_common.py` to include `hide` property when `msg.hide` is `True`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 3ed55d658fd953ce9ee3ae6d451d0cdf1546e528. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->