### PR TITLE
refactor(llm): add TypedDict for message dict typing

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -5,10 +5,11 @@ import re
 import time
 from collections.abc import Generator, Iterable
 from functools import lru_cache, wraps
-from typing import TYPE_CHECKING, Any, NotRequired, TypedDict, cast
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 import requests
 from openai import NOT_GIVEN
+from typing_extensions import NotRequired
 
 from ..config import Config, get_config
 from ..constants import TEMPERATURE, TOP_P

--- a/tests/test_llm_openai.py
+++ b/tests/test_llm_openai.py
@@ -441,7 +441,7 @@ def test_message_conversion_gpt5_with_tool_results():
     # 1. Regular system message is converted to user message
     # 2. Tool result (system with call_id) is converted to tool message
     assert messages_list[0]["role"] == "user"  # System prompt -> user
-    assert "<system>" in messages_list[0]["content"][0]["text"]
+    assert "<system>" in messages_list[0]["content"][0]["text"]  # type: ignore[index]
 
     assert messages_list[1]["role"] == "user"  # User message stays user
 
@@ -452,7 +452,7 @@ def test_message_conversion_gpt5_with_tool_results():
     # The critical assertion: tool result should be role="tool", not role="user"
     assert messages_list[3]["role"] == "tool"  # Tool result preserved!
     assert messages_list[3]["tool_call_id"] == "call_123"
-    assert messages_list[3]["content"][0]["text"] == "Saved to file.txt"
+    assert messages_list[3]["content"][0]["text"] == "Saved to file.txt"  # type: ignore[index]
 
 
 def test_transform_msgs_for_groq():
@@ -1064,8 +1064,8 @@ def test_transform_msgs_handles_list_content():
     assert result[0]["reasoning_content"] == "Reasoning here"
 
     # Content should be cleaned (reasoning extracted)
-    assert "<think>" not in result[0]["content"]
-    assert "Actual response content" in result[0]["content"]
+    assert "<think>" not in result[0]["content"]  # type: ignore[operator]
+    assert "Actual response content" in result[0]["content"]  # type: ignore[operator]
 
 
 def test_transform_msgs_handles_string_list_content():


### PR DESCRIPTION
## Summary

This PR adds proper TypedDict definitions for the internal message dictionary format used in the OpenAI LLM module, as requested in #1192.

## Changes

- Add `MessageDict` TypedDict documenting the message dict structure with fields:
  - `role`, `content` (core fields)
  - `tool_calls`, `tool_call_id`, `call_id` (tool-related)
  - `reasoning_content` (reasoning models)
  - `files` (multimodal)
- Add supporting TypedDicts: `ContentPart`, `ToolCall`, `ToolCallFunction`
- Rename duplicate `result` variable in different branches to `openrouter_result` to fix mypy redefinition error

## Design Decision

The TypedDict definitions serve as **documentation** for the message structure. Function signatures continue to use `dict[str, Any]` for compatibility with existing untyped code (`_process_file`, `_handle_tools`, etc.). This allows gradual typing adoption without requiring changes to all related functions.

A future PR could update all related functions to use the TypedDict for stricter typing.

Closes #1192

*Co-authored-by: Bob <bob@superuserlabs.org>*
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add TypedDicts for message dict typing in OpenAI LLM module and fix mypy error by renaming a variable.
> 
>   - **TypedDicts**:
>     - Add `MessageDict` TypedDict in `llm_openai.py` for message structure with fields: `role`, `content`, `tool_calls`, `tool_call_id`, `call_id`, `reasoning_content`, `files`.
>     - Add `ContentPart`, `ToolCall`, `ToolCallFunction` TypedDicts for supporting structures.
>   - **Variable Renaming**:
>     - Rename `result` to `openrouter_result` in `llm_openai.py` to fix mypy redefinition error.
>   - **Design Decision**:
>     - Function signatures remain `dict[str, Any]` for compatibility, allowing gradual typing adoption.
>   - **Tests**:
>     - Update tests in `test_llm_openai.py` to align with new TypedDict structures and ensure correct behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 32a001832cf5ef2fa17d55a090563aef82e4d9d4. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->