### PR TITLE
feat(telemetry): add GPTME_RUN_TYPE env var support

### DIFF
--- a/gptme/util/_telemetry.py
+++ b/gptme/util/_telemetry.py
@@ -371,6 +371,13 @@ def init_telemetry(
             if not interactive:
                 logger.debug("Running in autonomous mode")
 
+        # Add run type from environment (e.g., "autonomous", "monitoring", "manual")
+        # This allows distinguishing different types of non-interactive runs
+        run_type = os.getenv("GPTME_RUN_TYPE")
+        if run_type:
+            resource_attrs["agent.run_type"] = run_type
+            logger.debug(f"Adding agent.run_type to resource: {run_type}")
+
         resource = Resource.create(resource_attrs)
         trace.set_tracer_provider(TracerProvider(resource=resource))
         _tracer = trace.get_tracer(service_name)


### PR DESCRIPTION
Reads GPTME_RUN_TYPE environment variable and adds it as an agent.run_type resource attribute in telemetry.

This allows distinguishing between different types of non-interactive runs (e.g., autonomous, monitoring, manual) in Grafana/Jaeger.

## Usage

````bash
# In autonomous run scripts
export GPTME_RUN_TYPE=autonomous

# In project monitoring scripts  
export GPTME_RUN_TYPE=monitoring
````

The attribute will then appear in telemetry traces as \`agent.run_type\`.

Closes: SUDO-33
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for `GPTME_RUN_TYPE` environment variable in `init_telemetry()` to distinguish run types in telemetry.
> 
>   - **Behavior**:
>     - Reads `GPTME_RUN_TYPE` environment variable in `init_telemetry()` in `gptme/util/_telemetry.py`.
>     - Adds `agent.run_type` attribute to telemetry resource attributes if `GPTME_RUN_TYPE` is set.
>     - Supports distinguishing run types like "autonomous", "monitoring", "manual" in telemetry traces.
>   - **Logging**:
>     - Logs the addition of `agent.run_type` to resource attributes for debugging purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for d40d848beaa973fba20e7af10412782ea8843eba. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->