### PR TITLE
fix(patch): handle RST heading underlines in content

### DIFF
--- a/gptme/tools/patch.py
+++ b/gptme/tools/patch.py
@@ -224,7 +224,10 @@ class Patch:
                 modified, _ = re.split(re.escape(UPDATED), after_divider, maxsplit=1)
 
                 # Check for extra ======= markers in the updated content
-                if "\n=======" in modified:
+                # Use regex with negative lookahead to match exactly 7 equals signs
+                # This avoids matching longer sequences like RST heading underlines
+                # (e.g., ===================) while still catching actual extra dividers
+                if re.search(r"\n=======(?!=)", modified):
                     raise ValueError(
                         "invalid patch format: extra ======= marker found in updated content. "
                         "Use only one ======= between original and updated content."

--- a/tests/test_tools_patch.py
+++ b/tests/test_tools_patch.py
@@ -357,3 +357,50 @@ modified lines
         assert "Path traversal detected" in messages[0].content
     finally:
         os.chdir(original_cwd)
+
+
+def test_apply_rst_heading_underlines():
+    """Test that RST heading underlines (===================) don't trigger separator detection.
+
+    Regression test for https://github.com/gptme/gptme/issues/1201
+    """
+    content = """System Dependencies
+===================
+
+Some gptme features require additional dependencies.
+"""
+
+    codeblock = """
+<<<<<<< ORIGINAL
+Some gptme features require additional dependencies.
+=======
+Some gptme features require system packages.
+>>>>>>> UPDATED
+"""
+    result = apply(codeblock, content)
+    assert "system packages" in result
+    assert "===================" in result  # RST underline preserved
+
+
+def test_apply_rst_heading_in_updated_content():
+    """Test that adding RST headings in updated content works.
+
+    Regression test for https://github.com/gptme/gptme/issues/1201
+    """
+    content = """Some text here.
+"""
+
+    # Patch that adds an RST heading
+    codeblock = """
+<<<<<<< ORIGINAL
+Some text here.
+=======
+System Dependencies
+===================
+
+Some text here.
+>>>>>>> UPDATED
+"""
+    result = apply(codeblock, content)
+    assert "System Dependencies" in result
+    assert "===================" in result


### PR DESCRIPTION
## Summary

The patch tool was incorrectly rejecting files containing RST heading underlines like `===================` because the check for extra dividers used `\n=======` which matched longer sequences of equals signs.

## Changes

- Changed the extra divider check to use a regex with negative lookahead `\n=======(?!=)` that matches exactly 7 equals signs not followed by another equals sign
- Added two regression tests for RST heading handling

## Test Results

All 17 patch tool tests pass:
- `test_apply_rst_heading_underlines`: verifies patching files with RST headings
- `test_apply_rst_heading_in_updated_content`: verifies adding RST headings  
- `test_apply_with_extra_divider_fails`: verifies actual extra dividers are still caught

Fixes #1201
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes patch tool to correctly handle RST heading underlines by updating regex and adding regression tests.
> 
>   - **Behavior**:
>     - Updated regex in `patch.py` to use `\n=======(?!=)` for detecting extra dividers, allowing RST heading underlines.
>     - Added error handling for extra dividers in `Patch._from_codeblock()`.
>   - **Tests**:
>     - Added `test_apply_rst_heading_underlines` to verify RST headings don't trigger separator detection.
>     - Added `test_apply_rst_heading_in_updated_content` to verify adding RST headings in updated content.
>     - Ensured `test_apply_with_extra_divider_fails` still catches actual extra dividers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for a724143c5b282734040726e4b268ca2a6f4022f8. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->