### PR TITLE
fix(save): remove duplicate overwrite confirmation

### DIFF
--- a/gptme/tools/save.py
+++ b/gptme/tools/save.py
@@ -134,14 +134,9 @@ def execute_save_impl(
         content += "\n"
 
     # Check if file exists and store original content for comparison
-    overwrite = False
-    original_content = None
-    if path.exists():
-        original_content = path.read_text()
-        if not confirm(f"File {path_display} exists, overwrite?"):
-            yield Message("system", "Save aborted: user refused to overwrite the file.")
-            return
-        overwrite = True
+    # Note: User already confirmed via execute_with_confirmation() with diff preview
+    overwrite = path.exists()
+    original_content = path.read_text() if overwrite else None
 
     # Check if folder exists
     missing_parent_created = False


### PR DESCRIPTION
## Problem

After the hook-based confirmation refactor (#1105), the save tool was asking for confirmation twice when overwriting a file:

1. First via `execute_with_confirmation()` showing a diff preview with "Execute save? [Y/n/c/e/a/?]"
2. Then AGAIN inside `execute_save_impl()` asking "File exists, overwrite? [Y/n/c/e/a/?]"

This was confusing UX as noted in #1202 - the user already saw a diff and confirmed the save, so the second confirmation was redundant.

## Solution

Remove the `confirm()` call inside `execute_save_impl()` since confirmation is already handled by the `execute_with_confirmation()` wrapper before the impl function is called.

The folder creation confirmation (`Folder doesn't exist, create it?`) is kept since that's a different edge case - the user might not realize a new directory will be created.

Fixes #1202

---
Co-authored-by: Bob <bob@superuserlabs.org>
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove redundant overwrite confirmation in `execute_save_impl()` in `save.py`, fixing issue #1202.
> 
>   - **Behavior**:
>     - Removes redundant `confirm()` call in `execute_save_impl()` in `save.py`.
>     - Keeps folder creation confirmation prompt in `execute_save_impl()`.
>   - **Fixes**:
>     - Resolves issue #1202 where users were asked for confirmation twice when overwriting a file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 63ac9c3dcf646b726692702578a55b61dcf84559. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->