### PR TITLE
fix(lessons): exclude worktree and .git directories from indexing

### DIFF
--- a/gptme/lessons/index.py
+++ b/gptme/lessons/index.py
@@ -266,7 +266,7 @@ class LessonIndex:
                 continue
 
             # Skip files in excluded directories (worktrees, .git, etc.)
-            lesson_path_str = str(lesson_file)
+            lesson_path_str = lesson_file.as_posix()
             if any(pattern in lesson_path_str for pattern in excluded_patterns):
                 logger.debug(f"Skipping lesson in excluded directory: {lesson_file}")
                 continue

--- a/tests/test_lessons_index.py
+++ b/tests/test_lessons_index.py
@@ -400,6 +400,7 @@ class TestWorktreeExclusion:
 
     def test_worktree_lessons_excluded(self, tmp_path):
         """Lessons in worktree/ subdirectories should be excluded."""
+        clear_cache()
         from gptme.lessons.index import LessonIndex
 
         # Create a normal lesson
@@ -426,6 +427,7 @@ class TestWorktreeExclusion:
 
     def test_git_directory_excluded(self, tmp_path):
         """Lessons in .git directories should be excluded."""
+        clear_cache()
         from gptme.lessons.index import LessonIndex
 
         # Create a normal lesson


### PR DESCRIPTION
## Summary

Fixes #1212

Lessons in `worktree/` subdirectories and `.git/` directories are now excluded from indexing. This fixes the issue where agent workspaces using gptme-contrib would have thousands of duplicate lessons indexed from git worktrees.

## Problem

In Bob's workspace, lesson directories showed:
- `lessons/`: 146 files (legitimate)
- `gptme-contrib/lessons/`: 44 files (legitimate)  
- `gptme-contrib/worktree/*/lessons/`: 2,253 files (duplicates!)

The log showed "Indexed 181 lessons (skipped 10 duplicates)" but missed thousands of worktree copies.

## Solution

Added exclusion patterns in `_index_directory()` to skip:
- `worktree/` - git worktree directories
- `/.git/` - git internal directories

This prevents worktree lesson copies from being indexed while still allowing normal lesson deduplication via realpath resolution.

## Testing

- ✅ All existing tests pass (18 tests)
- ✅ Added 2 new tests for worktree/git exclusion
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Excludes `worktree/` and `.git/` directories from lesson indexing to prevent duplicate entries, with tests verifying the exclusion.
> 
>   - **Behavior**:
>     - `_index_directory()` in `index.py` now excludes `worktree/` and `.git/` directories from lesson indexing.
>     - Prevents indexing of duplicate lessons from git worktrees.
>   - **Testing**:
>     - Added `test_worktree_lessons_excluded()` and `test_git_directory_excluded()` in `test_lessons_index.py` to verify exclusion of `worktree/` and `.git/` directories.
>     - All existing tests pass, ensuring no regression.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 98116b0ff49bde50036ae4cef99927fda5207cc0. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->