### PR TITLE
fix: Add tsroot to eslint config

### DIFF
--- a/webui/eslint.config.js
+++ b/webui/eslint.config.js
@@ -22,6 +22,7 @@ export default tseslint.config(
           jsx: true,
         },
         sourceType: 'module',
+        tsconfigRootDir: import.meta.dirname,
       },
     },
     plugins: {


### PR DESCRIPTION
Eslint was complaining that it didn't know which root to use when this repo is a submodule inside another repo.

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `tsconfigRootDir` to ESLint config to resolve TypeScript config relative to ESLint config directory.
> 
>   - **Configuration**:
>     - Adds `tsconfigRootDir: import.meta.dirname` to `parserOptions` in `eslint.config.js` to ensure TypeScript config is resolved relative to ESLint config directory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 5e600585be19f429035168e8315d10e5685ca364. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->