### PR TITLE
fix: use VITE_GPTME_FLEET_BASE_URL as env var for base urls

### DIFF
--- a/webui/src/utils/connectionConfig.ts
+++ b/webui/src/utils/connectionConfig.ts
@@ -2,7 +2,7 @@ const DEFAULT_API_URL = 'http://127.0.0.1:5700';
 
 // Fleet operator URL for auth code exchange
 // Configure via VITE_FLEET_OPERATOR_URL environment variable
-const FLEET_OPERATOR_URL = import.meta.env.VITE_FLEET_OPERATOR_URL || 'https://fleet.gptme.ai';
+const FLEET_OPERATOR_URL = import.meta.env.VITE_GPTME_FLEET_BASE_URL || 'https://fleet.gptme.ai';
 
 export interface ConnectionConfig {
   baseUrl: string;
@@ -99,7 +99,11 @@ export function getConnectionConfigFromSources(hash?: string): ConnectionConfig 
   }
 
   return {
-    baseUrl: fragmentBaseUrl || storedBaseUrl || import.meta.env.VITE_API_URL || DEFAULT_API_URL,
+    baseUrl:
+      fragmentBaseUrl ||
+      storedBaseUrl ||
+      import.meta.env.VITE_GPTME_FLEET_BASE_URL ||
+      DEFAULT_API_URL,
     authToken: fragmentUserToken || storedUserToken || null,
     useAuthToken: Boolean(fragmentUserToken || storedUserToken),
   };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `connectionConfig.ts` to use `VITE_GPTME_FLEET_BASE_URL` for fleet operator URL configuration.
> 
>   - **Environment Variables**:
>     - Change `VITE_FLEET_OPERATOR_URL` to `VITE_GPTME_FLEET_BASE_URL` for `FLEET_OPERATOR_URL` in `connectionConfig.ts`.
>   - **Functions**:
>     - Update `getConnectionConfigFromSources` to use `VITE_GPTME_FLEET_BASE_URL` instead of `VITE_API_URL` for `baseUrl`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for d409d75d8c91f469e9dc5f1cb800b2a4c5f76794. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->