### PR TITLE
fix: correct typo 'seperately' to 'separately'

### DIFF
--- a/gptme/prompts.py
+++ b/gptme/prompts.py
@@ -128,7 +128,7 @@ def get_prompt(
         if tools and include_tools:
             core_msgs.extend(prompt_tools(tools=tools, tool_format=tool_format))
 
-    # TODO: generate context_cmd outputs seperately and put them last in a "dynamic context" section
+    # TODO: generate context_cmd outputs separately and put them last in a "dynamic context" section
     #       with context known not to cache well across conversation starts, so that cache points can be set before and better utilized/changed less frequently.
     #       probably together with chat history since it's also dynamic/live context.
     #       as opposed to static (core/system prompt) and semi-static (workspace/project prompt, like files).


### PR DESCRIPTION
Simple typo fix in prompts.py TODO comment.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix typo in `prompts.py` TODO comment: 'seperately' to 'separately'.
> 
>   - Fix typo in `prompts.py` TODO comment: 'seperately' to 'separately'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 9835c121b2bf6b3169303b38c4a7ecc46f61d6cc. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->