### PR TITLE
fix(prompts): attach workspace files to Message instead of reading inline

### DIFF
--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -707,6 +707,11 @@ ALLOWED_FILE_EXTS = ["jpg", "jpeg", "png", "gif"]
 
 
 def _process_file(message_dict: dict) -> dict:
+    """Process remaining file attachments (images only).
+
+    Text files are already embedded by embed_attached_file_content() in
+    prepare_messages(). Only non-text files (images, binaries) remain here.
+    """
     message_content = message_dict["content"]
 
     # combines a content message with a list of files

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -790,7 +790,10 @@ def _merge_tool_results_with_same_call_id(
 
 
 def _process_file(msg: dict[str, Any], model: ModelMeta) -> dict[str, Any]:
-    """Process file attachments in a message dict, converting to API format.
+    """Process remaining file attachments (images only).
+
+    Text files are already embedded by embed_attached_file_content() in
+    prepare_messages(). Only non-text files (images, binaries) remain here.
 
     Args:
         msg: A message dict (expected to conform to MessageDict structure)

--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -223,6 +223,12 @@ def embed_attached_file_content(
 ) -> Message:
     """Embed attached file contents inline in a message.
 
+    This is the canonical path for reading text file attachments into message
+    content. It runs in prepare_messages() before messages reach LLM providers.
+    Text files are embedded as codeblocks and removed from msg.files.
+    Non-text files (images, binaries) remain in msg.files for provider-specific
+    handling in _process_file().
+
     If the message has file_hashes, attempts to read from content-addressed
     storage first (preserving the file version at message creation time).
     Falls back to the original file path if stored content is not available.

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -135,6 +135,14 @@ files = ["../outside/secret.txt", "README.md"]
     msgs = list(prompt_workspace(workspace))
     content = "\n".join(msg.content for msg in msgs)
 
-    # Should include README but NOT secret file
-    assert "# Test" in content, "README.md should be included"
-    assert "secret data" not in content, "secret.txt should be blocked (path traversal)"
+    # Collect attached files from all messages
+    attached_files: list[str] = []
+    for msg in msgs:
+        attached_files.extend(str(f) for f in msg.files)
+
+    # README should be attached, secret file should be blocked (path traversal)
+    assert any("README.md" in f for f in attached_files), "README.md should be attached"
+    assert not any(
+        "secret.txt" in f for f in attached_files
+    ), "secret.txt should NOT be attached (path traversal)"
+    assert "../outside/secret.txt" not in content, "Path traversal should be blocked"


### PR DESCRIPTION
## Summary

Instead of reading files inline in `prompt_workspace()` (which crashes on binary files like PNG), attach them via `Message.files` and let the LLM providers handle file processing through the existing `_process_file()` pipeline.

- Add `detect_binary_type()` in `util/` for magic-byte binary detection
- Add shared `process_file_as_text()` in `llm/utils.py` (used by both providers — no duplicated text handling)
- Providers: try image first (provider-specific format), fall back to shared text/binary handling
- `prompt_workspace()`: attach files via `Message.files` instead of `read_text()`

Fixes #1228

## Key design decisions

- **Text handling is shared**: `process_file_as_text()` in `llm/utils.py` handles binary detection, UTF-8 reading with replacement, and error cases — used by both Anthropic and OpenAI providers
- **Image handling stays provider-specific**: Each provider has its own image format (Anthropic uses `image` blocks, OpenAI uses `image_url`)
- **Minimal diff**: Only changes the workspace file inclusion path and adds the shared utilities

## Testing

- Added tests for `detect_binary_type()` (PNG, PDF, text)
- Updated `test_prompts.py` to verify file attachment behavior
- All tests pass, typecheck passes
----
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `prompt_workspace()` now attaches files to `Message.files` to prevent crashes on binary files, with processing handled by LLM providers.
> 
>   - **Behavior**:
>     - `prompt_workspace()` now attaches files via `Message.files` instead of reading inline, preventing crashes on binary files.
>     - LLM providers handle file processing through `_process_file()`.
>   - **Utilities**:
>     - Add `detect_binary_type()` in `util/` for binary detection.
>     - Add `process_file_as_text()` in `llm/utils.py` for shared text handling.
>   - **Providers**:
>     - Anthropic and OpenAI providers first try image processing, then fall back to shared text/binary handling.
>   - **Testing**:
>     - Add tests for `detect_binary_type()`.
>     - Update `test_prompts.py` to verify file attachment behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 28ba5f6f77ebe05af4b2389fd54252b3d2defb30. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->