### PR TITLE
feat(vision): add PIL.Image support to view_image

### DIFF
--- a/gptme/tools/vision.py
+++ b/gptme/tools/vision.py
@@ -13,8 +13,14 @@ from ..message import Message
 from .base import ToolSpec
 
 
-def view_image(image_path: Path | str) -> Message:
+def view_image(image_path: Path | str | Image.Image) -> Message:
     """View an image. Large images (>1MB) will be automatically scaled down."""
+    # Handle PIL Image objects
+    if isinstance(image_path, Image.Image):
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+            image_path.save(tmp.name)
+            image_path = Path(tmp.name)
+
     if isinstance(image_path, str):
         image_path = Path(image_path)
 


### PR DESCRIPTION
Allows passing PIL Image objects directly to view_image() without needing to save to a temporary file first.

Before: Required saving PIL Image to a temp file, then passing the path
After: Can pass PIL Image object directly

This makes it more convenient when generating images programmatically in ipython.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `view_image` in `vision.py` now supports direct `PIL.Image` input, improving convenience for programmatic image handling.
> 
>   - **Behavior**:
>     - `view_image` in `vision.py` now accepts `PIL.Image` objects directly, saving them to a temporary file internally.
>     - Eliminates the need to manually save `PIL.Image` to a file before calling `view_image`.
>   - **Convenience**:
>     - Enhances usability in environments like IPython by allowing direct image object handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for eb4724f8ade99ffc7c9922442b078066f8e6eff5. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->