### PR TITLE
fix: fix `a` as acceptable answer for auto in confirmation

### DIFF
--- a/gptme/hooks/cli_confirm.py
+++ b/gptme/hooks/cli_confirm.py
@@ -147,7 +147,7 @@ def _handle_response(
     # Auto-confirm options
     import re
 
-    re_auto = r"a(?:uto)?(?:\s+(\d+))?"
+    re_auto = r"^a(?:uto)?(?:\s+(\d+))?$"
     match = re.match(re_auto, answer)
     if match:
         if num := match.group(1):


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modify regex in `cli_confirm.py` to accept `a` as shorthand for `auto` in auto-confirm options.
> 
>   - **Behavior**:
>     - Modify regex in `_handle_response()` in `cli_confirm.py` to accept `a` as shorthand for `auto` in auto-confirm options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for a94d33cf2f71f002a93266dd8572a5ec821b290c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->