### PR TITLE
fix(codeblock): handle Kimi K2.5 missing newlines before code blocks

### DIFF
--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -107,21 +107,13 @@ def _preprocess_kimi_markdown(markdown: str) -> str:
     # Common tool/language names that should start on their own line
     common_tools = r"(?:save|append|patch|shell|ipython|python|gh|git|cat|ls|echo|mkdir|cd|pwd|rm|cp|mv|npm|pip|uv|cargo|go|rustc)"
 
-    # Pattern 1: Opening fences - word char OR punctuation OR backtick followed by ``` followed by a common tool name
-    # Preceded by: word char (letter, digit, underscore), sentence-ending punctuation, or backtick (for consecutive codeblocks)
-    opening_pattern = rf"(?<!^)(?<!\n)(?<=[\w.!?`])(```+)({common_tools})(?=\s|$|\n)"
+    # Pattern 1: Opening fences - word char OR punctuation followed by ``` followed by a common tool name
+    # Preceded by: word char (letter, digit, underscore) or sentence-ending punctuation
+    # Note: Backtick removed from character class to avoid breaking quad-backtick fences like "````save"
+    opening_pattern = rf"(?<!^)(?<!\n)(?<=[\w.!?])(```+)({common_tools})(?=\s|$|\n)"
 
     # Replace with newline + the backticks + the tool name
     markdown = re.sub(opening_pattern, r"\n\1\2", markdown)
-
-    # Pattern 2: Closing fences with text after them
-    # Match lines that start with ``` and have text after that is NOT a common tool/language name
-    # This handles cases like "```Then" but not "```python"
-    # Negative lookahead to exclude common tools
-    closing_pattern = rf"^(`{{3,}})(?!{common_tools}\b)([a-zA-Z_][a-zA-Z0-9_]*)$"
-
-    # Replace with the backticks + newline + the following text
-    markdown = re.sub(closing_pattern, r"\1\n\2", markdown, flags=re.MULTILINE)
 
     return markdown
 

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -1130,8 +1130,15 @@ def test_kimi_missing_newline_before_codeblock():
     assert len(blocks) == 1
     assert blocks[0].lang == "python"
 
-    # Multiple tool calls should all be extracted
-    markdown = "First```python\n1\n```Then```shell\necho 2\n```"
+    # Multiple codeblocks with text between them (blank line between closing and next opening)
+    markdown = "First```python\n1\n```\n\nThen\n```shell\necho 2\n```"
+    blocks = list(_extract_codeblocks(markdown))
+    assert len(blocks) == 2
+    assert blocks[0].lang == "python"
+    assert blocks[1].lang == "shell"
+
+    # Consecutive codeblocks with blank line between
+    markdown = "```python\n1\n```\n\n```shell\necho 2\n```"
     blocks = list(_extract_codeblocks(markdown))
     assert len(blocks) == 2
     assert blocks[0].lang == "python"


### PR DESCRIPTION
Fixes #1234 - adds preprocessing for Kimi K2.5 missing newlines before markdown code blocks
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds preprocessing to handle missing newlines before code blocks in Kimi K2.5 output, ensuring correct markdown parsing.
> 
>   - **Behavior**:
>     - Adds `_preprocess_kimi_markdown()` in `codeblock.py` to insert newlines before code blocks when missing in Kimi K2.5 output.
>     - Handles cases where code blocks are preceded by word characters or punctuation and followed by common tool names.
>     - Ensures nested code blocks and backticks in strings are not affected.
>   - **Tests**:
>     - Adds `test_kimi_missing_newline_before_codeblock()` and `test_kimi_fix_does_not_break_nested_blocks()` in `test_codeblock.py` to verify newline insertion and ensure nested blocks are unaffected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for a87fca2b09a9ec3ddbdfa655fca87e74cdd8481c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->