### PR TITLE
fix: detect vision support from OpenRouter modality correctly

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1135,7 +1135,16 @@ def openrouter_model_to_modelmeta(model_data: dict) -> ModelMeta:
     pricing = model_data.get("pricing", {})
     price_input = float(pricing.get("prompt", 0)) * 1_000_000
     price_output = float(pricing.get("completion", 0)) * 1_000_000
-    vision = "vision" in model_data.get("architecture", {}).get("modality", "")
+    # Check for vision support: look for "image" in input modalities
+    # OpenRouter uses modalities like "text+image->text" (not "vision")
+    architecture = model_data.get("architecture", {})
+    input_modalities = architecture.get("input_modalities", [])
+    vision = "image" in input_modalities
+    if not vision and not input_modalities:
+        # Fallback: parse input side of modality string (before "->")
+        modality = architecture.get("modality", "")
+        input_side = modality.split("->")[0] if "->" in modality else ""
+        vision = "image" in input_side
     reasoning = "reasoning" in model_data.get("supported_parameters", [])
     include_reasoning = "include_reasoning" in model_data.get(
         "supported_parameters", []


### PR DESCRIPTION
OpenRouter API returns modality as `text+image->text` and `input_modalities` as `["text", "image"]`, but we were checking for `"vision"` in the modality string which never matched.

Now checks for `"image"` in `input_modalities` (preferred) or modality string, fixing vision support detection for all OpenRouter models including Claude Opus 4.6.

**Before:** `supports_vision=False` for all dynamically-fetched OpenRouter models
**After:** `supports_vision=True` correctly detected from API metadata
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes vision support detection for OpenRouter models by checking for 'image' in input modalities in `openrouter_model_to_modelmeta()` in `gptme/llm/llm_openai.py`.
> 
>   - **Behavior**:
>     - Fixes vision support detection in `openrouter_model_to_modelmeta()` in `gptme/llm/llm_openai.py` by checking for `"image"` in `input_modalities` or modality string.
>     - Corrects `supports_vision` to `True` for models with `"image"` input, previously always `False`.
>   - **Misc**:
>     - Updates logic to handle OpenRouter API's modality format `"text+image->text"`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 5333dd062e3293740e02d5b6f15b15ca7e33e1d9. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->