### PR TITLE
fix(eval): prevent recursive SIGTERM handler loop

### DIFF
--- a/gptme/eval/run.py
+++ b/gptme/eval/run.py
@@ -416,6 +416,10 @@ def act_process(
 
     # handle SIGTERM
     def sigterm_handler(*_):
+        # Reset to default handler first to prevent recursive SIGTERM loop:
+        # _graceful_killpg sends SIGTERM to our own process group, which would
+        # re-trigger this handler without this reset.
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
         error_handler(KeyboardInterrupt("SIGTERM received"))
 
     signal.signal(signal.SIGTERM, sigterm_handler)


### PR DESCRIPTION
## Summary
- Fixes infinite recursion in the eval runner's SIGTERM handler
- The handler called `_graceful_killpg()` which sends SIGTERM to the own process group, re-triggering the handler until stack overflow
- Fix: reset to `SIG_DFL` before handling, so the self-sent SIGTERM uses default behavior instead of recursing

This caused the massive log spam of repeated `sigterm_handler → error_handler → _graceful_killpg → os.killpg(SIGTERM)` stack frames in CI.

**Note:** The actual CI test failures are from an expired/invalid OpenAI API key (401 errors). The SIGTERM recursion was a secondary issue triggered during cleanup of those failures.

## Test plan
- [x] Code review — single-line fix with clear reasoning
- [ ] CI: verify no more recursive SIGTERM stack traces on timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes infinite recursion in `sigterm_handler` in `gptme/eval/run.py` by resetting to `SIG_DFL` to prevent re-triggering.
> 
>   - **Behavior**:
>     - Fixes infinite recursion in `sigterm_handler` in `gptme/eval/run.py` by resetting to `SIG_DFL` before handling.
>     - Prevents re-triggering of handler by self-sent SIGTERM signals, avoiding stack overflow.
>   - **Testing**:
>     - Code review confirms single-line fix with clear reasoning.
>     - CI to verify absence of recursive SIGTERM stack traces on timeout.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for a4d6fa3d1ad68439ca0e7d5dad4eb9840806ae52. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->