### PR TITLE
refactor(commands): add auto_undo to command decorator

### DIFF
--- a/gptme/commands/export.py
+++ b/gptme/commands/export.py
@@ -18,7 +18,6 @@ def cmd_summarize(ctx: CommandContext) -> None:
     from ..logmanager import prepare_messages  # fmt: skip
     from ..message import print_msg  # fmt: skip
 
-    ctx.manager.undo(1, quiet=True)
     msgs = prepare_messages(ctx.manager.log.messages)
     msgs = [m for m in msgs if not m.hide]
     print_msg(llm.summarize(msgs))
@@ -50,9 +49,6 @@ def cmd_replay(ctx: CommandContext) -> None:
     """Replay the conversation or specific tool operations."""
     from ..message import print_msg  # fmt: skip
     from ..tools import ToolUse, execute_msg  # fmt: skip
-
-    ctx.manager.undo(1, quiet=True)
-    ctx.manager.write()
 
     # Check if replaying a specific tool
     if ctx.args and ctx.args[0].lower() not in ["last", "all"]:
@@ -164,8 +160,6 @@ def cmd_export(ctx: CommandContext) -> None:
     """Export conversation as HTML."""
     from ..util.export import export_chat_to_html  # fmt: skip
 
-    ctx.manager.undo(1, quiet=True)
-    ctx.manager.write()
     # Get output path from args or use default
     output_path = (
         Path(ctx.args[0])

--- a/gptme/commands/llm.py
+++ b/gptme/commands/llm.py
@@ -67,7 +67,6 @@ def cmd_model(ctx: CommandContext) -> None:
         set_default_model,
     )
 
-    ctx.manager.undo(1, quiet=True)
     if ctx.args:
         new_model = ctx.args[0]
         set_default_model(new_model)
@@ -97,7 +96,6 @@ def cmd_tools(ctx: CommandContext) -> None:
     from ..message import len_tokens  # fmt: skip
     from ..tools import get_tool_format, get_tools  # fmt: skip
 
-    ctx.manager.undo(1, quiet=True)
     print("Available tools:")
     for tool in get_tools():
         print(
@@ -115,8 +113,6 @@ def cmd_context(ctx: CommandContext) -> None:
     from ..tools import ToolUse  # fmt: skip
     from ..util import console  # fmt: skip
     from ..util.tokens import len_tokens  # fmt: skip
-
-    ctx.manager.undo(1, quiet=True)
 
     # Try to use the current model's tokenizer, fallback to gpt-4
     current_model = get_default_model()
@@ -187,8 +183,6 @@ def cmd_tokens(ctx: CommandContext) -> None:
         gather_conversation_costs,
         gather_session_costs,
     )
-
-    ctx.manager.undo(1, quiet=True)
 
     session = gather_session_costs()
     conversation = gather_conversation_costs(ctx.manager.log.messages)

--- a/gptme/commands/meta.py
+++ b/gptme/commands/meta.py
@@ -65,7 +65,7 @@ action_descriptions: dict[Actions, str] = {
 COMMANDS = list(action_descriptions.keys())
 
 
-@command("impersonate")
+@command("impersonate", auto_undo=False)
 def cmd_impersonate(ctx: CommandContext) -> Generator["Message", None, None]:
     """Impersonate the assistant."""
     from ..message import Message  # fmt: skip
@@ -82,8 +82,6 @@ def cmd_setup(ctx: CommandContext) -> None:
     """Setup gptme with completions, configuration, and project setup."""
     from ..cli.setup import setup
 
-    ctx.manager.undo(1, quiet=True)
-    ctx.manager.write()
     setup()
 
 
@@ -92,16 +90,12 @@ def cmd_doctor(ctx: CommandContext) -> None:
     """Run system diagnostics to check gptme health."""
     from ..cli.doctor import main as doctor_main
 
-    ctx.manager.undo(1, quiet=True)
-    ctx.manager.write()
     doctor_main()
 
 
 @command("help")
 def cmd_help(ctx: CommandContext) -> None:
     """Show help message."""
-    ctx.manager.undo(1, quiet=True)
-    ctx.manager.write()
     _help()
 
 
@@ -146,8 +140,6 @@ def cmd_plugin(ctx: CommandContext) -> None:
         discover_plugins,
         get_install_instructions,
     )
-
-    ctx.manager.undo(1, quiet=True)
 
     config = get_config()
 

--- a/gptme/commands/session.py
+++ b/gptme/commands/session.py
@@ -26,7 +26,6 @@ def _complete_log(partial: str, _prev_args: list[str]) -> list[tuple[str, str]]:
 @command("log", completer=_complete_log)
 def cmd_log(ctx: CommandContext) -> None:
     """Show the conversation log."""
-    ctx.manager.undo(1, quiet=True)
     ctx.manager.log.print(show_hidden="--hidden" in ctx.args)
 
 
@@ -41,8 +40,6 @@ def _complete_rename(partial: str, _prev_args: list[str]) -> list[tuple[str, str
 @command("rename", completer=_complete_rename)
 def cmd_rename(ctx: CommandContext) -> None:
     """Rename the conversation."""
-    ctx.manager.undo(1, quiet=True)
-    ctx.manager.write()
     # rename the conversation
     print("Renaming conversation")
     if ctx.args:
@@ -69,7 +66,6 @@ def _complete_fork(partial: str, _prev_args: list[str]) -> list[tuple[str, str]]
 @command("fork", completer=_complete_fork)
 def cmd_fork(ctx: CommandContext) -> None:
     """Fork the conversation."""
-    ctx.manager.undo(1, quiet=True)
     new_name = ctx.args[0] if ctx.args else input("New name: ")
     ctx.manager.fork(new_name)
     print(f"✅ Forked conversation to: {ctx.manager.logdir}")
@@ -108,8 +104,6 @@ def cmd_delete(ctx: CommandContext) -> None:
         /delete --force <id> - Delete without confirmation
     """
     from ..logmanager import delete_conversation, list_conversations  # fmt: skip
-
-    ctx.manager.undo(1, quiet=True)
 
     # Check for --force flag
     force = "--force" in ctx.args or "-f" in ctx.args
@@ -159,16 +153,13 @@ def cmd_delete(ctx: CommandContext) -> None:
 @command("edit")
 def cmd_edit(ctx: CommandContext) -> Generator["Message", None, None]:
     """Edit previous messages."""
-    # first undo the '/edit' command itself
-    ctx.manager.undo(1, quiet=True)
     yield from _edit(ctx.manager)
 
 
 @command("undo")
 def cmd_undo(ctx: CommandContext) -> None:
     """Undo the last action(s)."""
-    # undo the '/undo' command itself
-    ctx.manager.undo(1, quiet=True)
+    # auto_undo already removed the '/undo' command itself
     # if int, undo n messages
     n = int(ctx.args[0]) if ctx.args and ctx.args[0].isdigit() else 1
     ctx.manager.undo(n)
@@ -177,7 +168,6 @@ def cmd_undo(ctx: CommandContext) -> None:
 @command("clear", aliases=["cls"])
 def cmd_clear(ctx: CommandContext) -> None:
     """Clear the terminal screen."""
-    ctx.manager.undo(1, quiet=True)
     # ANSI escape code to clear screen and move cursor to home position
     print("\033[2J\033[H", end="")
 
@@ -186,9 +176,6 @@ def cmd_clear(ctx: CommandContext) -> None:
 def cmd_exit(ctx: CommandContext) -> None:
     """Exit the program."""
     from ..hooks import HookType, trigger_hook
-
-    ctx.manager.undo(1, quiet=True)
-    ctx.manager.write()
 
     # Trigger session end hooks before exiting
     logdir = ctx.manager.logdir
@@ -209,8 +196,6 @@ def cmd_restart(ctx: CommandContext) -> None:
     - Recovering from state issues
     """
     from ..tools.restart import _do_restart
-
-    ctx.manager.undo(1, quiet=True)
 
     response = input("Restart gptme? This will exit and restart the process. [y/N] ")
     confirmed = response.lower().strip() in ("y", "yes")


### PR DESCRIPTION
Adds `auto_undo` parameter to the `@command` decorator to centralize the undo logic.

## Changes

- Added `auto_undo=True` parameter to `@command` decorator (default behavior)
- Decorator now automatically calls `ctx.manager.undo(1, quiet=True)` before executing commands
- Removed explicit undo calls from all command handlers (reduces boilerplate)
- Commands that need to keep their messages visible (like `impersonate`) use `auto_undo=False`

## Before/After

**Before** - every command needed to manually undo:
```python
@command("help")
def cmd_help(ctx: CommandContext) -> None:
    ctx.manager.undo(1, quiet=True)  # manual undo
    # ... command logic
```

**After** - automatic, opt-out if needed:
```python
@command("help")  # auto_undo=True by default
def cmd_help(ctx: CommandContext) -> None:
    # ... command logic

@command("impersonate", auto_undo=False)  # opt-out for commands that yield messages
def cmd_impersonate(ctx: CommandContext) -> Generator:
    # ... yields messages that should be visible
```

This reduces code duplication and ensures consistent behavior across commands.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces `auto_undo` parameter in `@command` decorator to centralize undo logic, reducing boilerplate and ensuring consistent command behavior.
> 
>   - **Decorator Changes**:
>     - Added `auto_undo=True` parameter to `@command` decorator in `base.py`.
>     - Automatically calls `ctx.manager.undo(1, quiet=True)` before executing commands.
>   - **Command Handlers**:
>     - Removed explicit `ctx.manager.undo(1, quiet=True)` calls from command handlers in `export.py`, `llm.py`, `meta.py`, and `session.py`.
>     - `impersonate` command uses `auto_undo=False` to keep messages visible.
>   - **Behavior**:
>     - Reduces code duplication and ensures consistent behavior across commands.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 5fcbdab4bb3b73c7daf3e420be5eb5682c4fbcc2. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->