### PR TITLE
feat(webui): add show hidden messages setting, move initial system to settings

### DIFF
--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -3,13 +3,13 @@ import { useRef, useEffect } from 'react';
 import { ChatMessage } from './ChatMessage';
 import { ChatInput, type ChatOptions } from './ChatInput';
 import { useConversation } from '@/hooks/useConversation';
-import { Checkbox } from './ui/checkbox';
-import { Label } from './ui/label';
+
 import { InlineToolConfirmation } from './InlineToolConfirmation';
 import { InlineToolExecution } from './InlineToolExecution';
-import { For, Memo, useObservable, useObserveEffect } from '@legendapp/state/react';
+import { For, useObservable, useObserveEffect } from '@legendapp/state/react';
 import { getObservableIndex } from '@legendapp/state';
 import { useApi } from '@/contexts/ApiContext';
+import { useSettings } from '@/contexts/SettingsContext';
 import { useModels } from '@/hooks/useModels';
 
 interface Props {
@@ -79,15 +79,8 @@ export const ConversationContent: FC<Props> = ({ conversationId, isReadOnly }) =
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversationId]);
 
-  const showInitialSystem$ = useObservable<boolean>(false);
-
-  const hasInitialSystemMessages$ = useObservable(() => {
-    const log = conversation$.get()?.data.log;
-    if (!log || log.length === 0) {
-      return false;
-    }
-    return log[0].role === 'system';
-  });
+  // Import settings from global context
+  const { settings } = useSettings();
 
   // Create a ref for the scroll container
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -175,29 +168,6 @@ export const ConversationContent: FC<Props> = ({ conversationId, isReadOnly }) =
           }
         }}
       >
-        <Memo>
-          {() =>
-            hasInitialSystemMessages$.get() && (
-              <div className="flex w-full items-center bg-accent/50">
-                <div className="mx-auto flex max-w-3xl flex-1 items-center gap-2 p-4">
-                  <Checkbox
-                    id="showInitialSystem"
-                    checked={showInitialSystem$.get()}
-                    onCheckedChange={(checked) => {
-                      showInitialSystem$.set(checked === true);
-                    }}
-                  />
-                  <Label
-                    htmlFor="showInitialSystem"
-                    className="cursor-pointer text-sm text-muted-foreground hover:text-foreground"
-                  >
-                    Show initial system messages
-                  </Label>
-                </div>
-              </div>
-            )
-          }
-        </Memo>
         <For each={conversation$.data.log}>
           {(msg$) => {
             const index = getObservableIndex(msg$);
@@ -206,12 +176,12 @@ export const ConversationContent: FC<Props> = ({ conversationId, isReadOnly }) =
             const isInitialSystem =
               msg$.role.get() === 'system' &&
               (firstNonSystemIndex === -1 || index < firstNonSystemIndex);
-            if (isInitialSystem && !showInitialSystem$.get()) {
+            if (isInitialSystem && !settings.showInitialSystem) {
               return <div key={`${index}-${msg$.timestamp.get()}`} />;
             }
 
             // Hide messages with hide=true (e.g., auto-included lessons)
-            if (msg$.hide?.get()) {
+            if (msg$.hide?.get() && !settings.showHiddenMessages) {
               return <div key={`${index}-${msg$.timestamp.get()}`} />;
             }
 

--- a/webui/src/components/SettingsModal.tsx
+++ b/webui/src/components/SettingsModal.tsx
@@ -149,6 +149,44 @@ export const SettingsModal = forwardRef<HTMLButtonElement, SettingsModalProps>(
                   onCheckedChange={(checked) => updateSettings({ blocksDefaultOpen: checked })}
                 />
               </div>
+
+              <Separator />
+
+              <div className="space-y-4">
+                <h4 className="text-sm font-medium">Developer Options</h4>
+
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="hidden-toggle" className="text-sm">
+                      Show hidden messages
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Display messages marked as hidden (e.g., lessons, context)
+                    </p>
+                  </div>
+                  <Switch
+                    id="hidden-toggle"
+                    checked={settings.showHiddenMessages}
+                    onCheckedChange={(checked) => updateSettings({ showHiddenMessages: checked })}
+                  />
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="initial-system-toggle" className="text-sm">
+                      Show initial system messages
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Display the initial system prompt at the start of conversations
+                    </p>
+                  </div>
+                  <Switch
+                    id="initial-system-toggle"
+                    checked={settings.showInitialSystem}
+                    onCheckedChange={(checked) => updateSettings({ showInitialSystem: checked })}
+                  />
+                </div>
+              </div>
             </div>
           );
 

--- a/webui/src/contexts/SettingsContext.tsx
+++ b/webui/src/contexts/SettingsContext.tsx
@@ -3,6 +3,8 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 export interface Settings {
   chimeEnabled: boolean;
   blocksDefaultOpen: boolean;
+  showHiddenMessages: boolean;
+  showInitialSystem: boolean;
 }
 
 interface SettingsContextType {
@@ -14,6 +16,8 @@ interface SettingsContextType {
 const defaultSettings: Settings = {
   chimeEnabled: true,
   blocksDefaultOpen: true,
+  showHiddenMessages: false,
+  showInitialSystem: false,
 };
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);


### PR DESCRIPTION
Adds developer-focused settings for controlling message visibility in the web UI.

## Changes

- **Added "Show hidden messages" setting**: Displays messages marked as hidden (e.g., auto-included lessons, context)
- **Moved "Show initial system messages"**: From inline checkbox in conversation header to Settings > Content > Developer Options
- Both settings are persisted in localStorage

## Screenshots

Settings are now in the "Content" section under "Developer Options":
- Show hidden messages (default: off)
- Show initial system messages (default: off)

This improves the UI by reducing clutter in the conversation view while making these developer-focused options accessible in a dedicated section.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add developer settings for message visibility in web UI, moving initial system message control to settings and persisting in localStorage.
> 
>   - **Settings**:
>     - Add `showHiddenMessages` and `showInitialSystem` to `Settings` in `SettingsContext.tsx`.
>     - Persist settings in `localStorage` in `SettingsProvider`.
>   - **UI Changes**:
>     - Add "Show hidden messages" and "Show initial system messages" toggles to `SettingsModal.tsx` under "Content > Developer Options".
>     - Remove inline checkbox for "Show initial system messages" from `ConversationContent.tsx`.
>   - **Behavior**:
>     - Use `settings.showHiddenMessages` and `settings.showInitialSystem` in `ConversationContent.tsx` to control message visibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for cc30b263c1470ae1bc491a629d1e80e5b8e739fa. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->