### PR TITLE
fix(webui): use .get() for agent avatar observable check

### DIFF
--- a/webui/src/components/ConversationContent.tsx
+++ b/webui/src/components/ConversationContent.tsx
@@ -229,7 +229,9 @@ export const ConversationContent: FC<Props> = ({ conversationId, serverId, isRea
 
             // Construct agent avatar URL if agent has avatar configured
             // Normalize baseUrl by removing trailing slashes to avoid double slashes
-            const agentAvatarUrl = conversation$.data.agent?.avatar
+            // NOTE: must use .get() to read the actual value from the observable,
+            // otherwise the Legend State proxy is always truthy
+            const agentAvatarUrl = conversation$.data.agent?.avatar?.get()
               ? `${connectionConfig.baseUrl.replace(/\/+$/, '')}/api/v2/conversations/${conversationId}/agent/avatar`
               : undefined;
 


### PR DESCRIPTION
## Summary
- `conversation$.data.agent?.avatar` always evaluates to truthy because Legend State returns proxy objects (not raw values) for observable property access
- This caused the avatar URL to be constructed for **every** conversation, resulting in spurious 404 requests to `/agent/avatar` for non-agent conversations
- Fix: use `.get()` to read the actual value from the observable before the truthiness check

Companion to #1250 — the chain type fix was the primary blocker for avatar display (hidden messages broke chain calculation, making assistant messages get `middle`/`end` type → avatar never rendered). This PR fixes the secondary issue of incorrect observable value reading.

## Test plan
- [ ] Open a Bob conversation — avatar should display on assistant messages
- [ ] Open a non-agent conversation — no avatar endpoint requests in Network tab (previously showed 404s)
- [ ] Verify the bot icon fallback still works when no agent is configured
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes avatar URL construction in `ConversationContent.tsx` by using `.get()` to read observable values, preventing unnecessary 404 requests.
> 
>   - **Behavior**:
>     - Fixes avatar URL construction in `ConversationContent.tsx` by using `.get()` to read `conversation$.data.agent?.avatar`.
>     - Prevents 404 requests to `/agent/avatar` for non-agent conversations.
>   - **Test Plan**:
>     - Verify avatar displays for agent conversations and no 404s for non-agent conversations.
>     - Ensure bot icon fallback works when no agent is configured.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for bb19d5d6466cb76840e7f092f82f371b916dce92. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->