### PR TITLE
fix(models): handle @ suffix in OpenRouter model lookup for context length

### DIFF
--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -634,9 +634,22 @@ def get_model(model: str) -> ModelMeta:
             openrouter_models = _get_models_for_provider(
                 "openrouter", dynamic_fetch=True
             )
+            # Strip @ suffix for comparison (e.g., "z-ai/glm-5@z-ai" -> "z-ai/glm-5")
+            base_model = model.split("@")[0] if "@" in model else model
             for model_meta in openrouter_models:
-                if model_meta.model == model:
-                    return model_meta
+                if model_meta.model == model or model_meta.model == base_model:
+                    return ModelMeta(
+                        provider=model_meta.provider,
+                        model=model,  # Preserve original name with suffix
+                        context=model_meta.context,
+                        max_output=model_meta.max_output,
+                        supports_streaming=model_meta.supports_streaming,
+                        supports_vision=model_meta.supports_vision,
+                        supports_reasoning=model_meta.supports_reasoning,
+                        price_input=model_meta.price_input,
+                        price_output=model_meta.price_output,
+                        knowledge_cutoff=model_meta.knowledge_cutoff,
+                    )
         except Exception as e:
             logger.debug("Failed to fetch OpenRouter models for %s: %s", model, e)
 


### PR DESCRIPTION
## Problem

When using OpenRouter models with a subprovider suffix (like `z-ai/glm-5@z-ai`), the context length was incorrectly reported as 128k (fallback) instead of the actual ~200k context.

This happened because:
1. `model.model` stores `z-ai/glm-5@z-ai` (without provider prefix)
2. When `get_model()` is called with this string, it tries dynamic fetch from OpenRouter
3. OpenRouter returns `z-ai/glm-5` (without @ suffix)
4. The comparison fails, falling back to `context=128000`

## Fix

Strip the `@` suffix when comparing models in the dynamic OpenRouter fetch. This ensures models like GLM-5 (~200k context) are correctly identified.

## Test

```python
from gptme.llm.models import get_model

# Before fix: context=128000
# After fix: context=202752
m = get_model("z-ai/glm-5@z-ai")
print(f"context={m.context}")  # 202752
```

## Impact

- Fixes token awareness budget display
- Fixes reduce_log compaction limits
- Ensures correct context for all OpenRouter models with @ suffix
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes context length reporting for OpenRouter models with `@` suffix in `get_model()` by stripping suffix for comparison.
> 
>   - **Behavior**:
>     - Fixes context length reporting for OpenRouter models with `@` suffix in `get_model()` in `models.py`.
>     - Strips `@` suffix for comparison, ensuring correct context length is identified.
>   - **Impact**:
>     - Corrects token awareness budget display.
>     - Fixes reduce_log compaction limits.
>     - Ensures correct context for all OpenRouter models with `@` suffix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 54c69b9adf5c9e8e3048852b9b8e733a5fad81dd. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->