### PR TITLE
fix(agent): fix service management and add proper tests

### DIFF
--- a/gptme/agent/service.py
+++ b/gptme/agent/service.py
@@ -338,7 +338,7 @@ def parse_schedule(schedule: str) -> dict:
         return {"StartCalendarInterval": [{"Hour": hour, "Minute": minute}]}
 
     # Day of week: Mon/Tue/Wed/Thu/Fri/Sat/Sun HH:MM or *:MM
-    day_map = {"mon": 1, "tue": 2, "wed": 3, "thu": 4, "fri": 5, "sat": 6, "sun": 7}
+    day_map = {"mon": 1, "tue": 2, "wed": 3, "thu": 4, "fri": 5, "sat": 6, "sun": 0}
     m = re.match(r"^(\w+)\s+\*:(\d+)$", schedule, re.IGNORECASE)
     if m and m.group(1).lower() in day_map:
         weekday = day_map[m.group(1).lower()]
@@ -526,11 +526,9 @@ class LaunchdManager(ServiceManager):
         if not plist_path.exists():
             return None
 
-        loaded = self._is_loaded(name)
-        if not loaded:
-            return ServiceStatus(name=name, running=False, enabled=False)
-
         result = self._run_launchctl("list", self._label(name))
+        if result.returncode != 0:
+            return ServiceStatus(name=name, running=False, enabled=False)
         pid = None
         exit_code = None
 


### PR DESCRIPTION
## Summary
- Fix launchd (macOS) service management: use `plistlib` for safe XML generation, fix `run` to ensure plist is loaded first, make `start`/`stop` idempotent
- Fix systemd (Linux) `start`/`stop` to also `enable`/`disable` the timer (so state survives reboots)
- Rewrite schedule parsing with proper support for hourly, daily, and weekly patterns (was only handling interval pattern `*:00/N`, everything else silently fell through to hardcoded 2-hour default)
- Add 39 new tests covering the actual service lifecycle (install, start, stop, run, status, uninstall, schedule conversion, plist generation) — up from 33 to 72 total

## Test plan
- [x] All 72 tests pass locally (`pytest tests/test_agent.py`)
- [ ] CI passes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes service management for macOS and Linux, improves schedule parsing, and adds extensive tests.
> 
>   - **Service Management Fixes**:
>     - `LaunchdManager` in `service.py`: Use `plistlib` for XML generation, ensure plist is loaded before `run`, make `start`/`stop` idempotent.
>     - `SystemdManager` in `service.py`: `start`/`stop` now also `enable`/`disable` timers to persist state across reboots.
>   - **Schedule Parsing**:
>     - `parse_schedule()` in `service.py`: Rewritten to support hourly, daily, and weekly patterns, fixing previous limitation to `*:00/N` intervals.
>   - **Testing**:
>     - Added 39 new tests in `test_agent.py` for service lifecycle, schedule conversion, and plist generation, increasing total from 33 to 72.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 4f6d9056195c342eee16d8507fdcb8a8c227652c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->