### PR TITLE
feat: auto-trigger LLM resume when rule-based compaction stalls

### DIFF
--- a/tests/test_auto_compact.py
+++ b/tests/test_auto_compact.py
@@ -574,10 +574,10 @@ def test_should_auto_compact_respects_minimum_savings():
     result = should_auto_compact(messages, limit=100)  # Low limit to trigger check
 
     # With minimal savings potential (no reasoning, no tool results, no long messages),
-    # should return "resume" (not "rule_based") even though we're "over limit"
+    # should return "summarize" (not "rule_based") even though we're "over limit"
     assert (
-        result == "resume"
-    ), "should_auto_compact should return 'resume' when rule-based savings are below threshold"
+        result == "summarize"
+    ), "should_auto_compact should return 'summarize' when rule-based savings are below threshold"
 
 
 def test_should_auto_compact_triggers_with_high_savings():
@@ -819,12 +819,12 @@ def test_load_context_files_truncates_long_files(tmp_path):
     assert "truncated" in loaded[0][1].lower()
 
 
-def test_should_auto_compact_returns_resume_when_over_limit_low_savings():
-    """Test that should_auto_compact returns 'resume' when over limit but rule-based savings are too low."""
+def test_should_auto_compact_returns_summarize_when_over_limit_low_savings():
+    """Test that should_auto_compact returns 'summarize' when over limit but rule-based savings are too low."""
     # Many short user messages: over a low limit but nothing to rule-based compact
     messages = [Message("user", f"Short message {i}") for i in range(100)]
     result = should_auto_compact(messages, limit=100)
-    assert result == "resume"
+    assert result == "summarize"
 
 
 def test_resume_via_llm_with_mocked_reply():


### PR DESCRIPTION
## Summary

- When `autocompact_hook` detects the conversation is over-limit but rule-based compaction would save <10%, it now automatically triggers LLM-powered resume instead of just logging a suggestion
- `should_auto_compact()` returns a `CompactAction` literal (`"none"`, `"rule_based"`, `"resume"`) instead of `bool`
- Extracted `_resume_via_llm()` from `_compact_resume()` so the hook can reuse the core LLM resume logic with `use_view_branch=True`

## Test plan

- [x] All 42 existing + new tests pass (`pytest tests/test_auto_compact.py -x`)
- [x] All compact-related tests pass (`pytest tests/ -k compact`)
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [ ] CI passes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Auto-trigger LLM resume when rule-based compaction stalls, updating `should_auto_compact` to return `CompactAction` and extracting `_resume_via_llm` for reuse.
> 
>   - **Behavior**:
>     - `autocompact_hook` now triggers LLM-powered resume if rule-based compaction saves <10%.
>     - `should_auto_compact()` returns `CompactAction` (`"none"`, `"rule_based"`, `"resume"`) instead of `bool`.
>     - Extracts `_resume_via_llm()` from `_compact_resume()` for reuse with `use_view_branch=True`.
>   - **Tests**:
>     - Update tests in `test_auto_compact.py` to check for `CompactAction` return values.
>     - Add tests for `_resume_via_llm` with mocked LLM responses.
>   - **Misc**:
>     - Minor logging changes in `autocompact.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 1580512ac0eb82631bd01cdfa550fd366f41c6ed. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->