### PR TITLE
fix(eval): handle @ in OpenRouter model names when parsing tool format

### DIFF
--- a/gptme/eval/main.py
+++ b/gptme/eval/main.py
@@ -391,27 +391,18 @@ def main(
             model, fmt = model_spec.rsplit("@", 1)
             if fmt in get_args(ToolFormat):
                 model_configs.append((model, parse_format(fmt)))
-            else:
-                # @ is part of the model name (e.g. OpenRouter provider suffix
-                # like 'z-ai/glm-5@z-ai'), not a tool format specifier
-                model = model_spec
-                formats_list: list[ToolFormat] = (
-                    [cast(ToolFormat, tool_format)]
-                    if tool_format
-                    else ["markdown", "xml", "tool"]
-                )
-                for fmt_ in formats_list:
-                    model_configs.append((model, fmt_))
                 continue
-        else:
-            # If no format specified for model, use either provided default or test all formats
-            formats: list[ToolFormat] = (
-                [cast(ToolFormat, tool_format)]
-                if tool_format
-                else ["markdown", "xml", "tool"]
-            )
-            for fmt in formats:
-                model_configs.append((model_spec, fmt))
+            # @ is part of the model name (e.g. OpenRouter provider suffix
+            # like 'z-ai/glm-5@z-ai'), not a tool format specifier
+
+        # No format specified (or @ was part of model name): use provided default or test all formats
+        formats: list[ToolFormat] = (
+            [cast(ToolFormat, tool_format)]
+            if tool_format
+            else ["markdown", "xml", "tool"]
+        )
+        for fmt in formats:
+            model_configs.append((model_spec, fmt))
 
     results_files = []
     for f in eval_names_or_result_files:


### PR DESCRIPTION
## Summary
- The eval CLI uses `model@format` syntax to specify tool format (e.g. `model@xml`)
- OpenRouter models can contain `@` as a provider suffix (e.g. `z-ai/glm-5@z-ai`)
- This caused `ValueError: Invalid tool format: z-ai` when running eval with such models
- Fix: check if the `@`-separated suffix is a valid ToolFormat before treating it as a format specifier

## Test plan
- [x] Verified parsing logic handles both `model@xml` (valid format) and `model@z-ai` (provider suffix) correctly
- [x] mypy type check passes
- [x] Existing tests pass
- [ ] CI checks pass

Relates to #1256 which fixed the same `@` suffix issue in model lookup.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix parsing of model names with `@` in `gptme/eval/main.py` to distinguish between tool format and provider suffix.
> 
>   - **Behavior**:
>     - Fix parsing of model names with `@` in `gptme/eval/main.py` to distinguish between tool format and provider suffix.
>     - Check if `@`-separated suffix is a valid `ToolFormat` before treating it as a format specifier.
>   - **Test Plan**:
>     - Verified parsing logic for `model@xml` and `model@z-ai`.
>     - `mypy` type check and existing tests pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 3a69a5a45bcbdf1608b5063ef41518d21b8b7775. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->