### PR TITLE
fix(tests): skip server API tests when flask is not installed

### DIFF
--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -1,11 +1,14 @@
 """Tests for URI support in Message.files."""
 
+from importlib.util import find_spec
 from pathlib import Path
 
 import pytest
 
 from gptme.message import Message
 from gptme.util.uri import URI, is_uri, parse_file_reference
+
+_has_flask = find_spec("flask") is not None
 
 
 class TestURI:
@@ -183,6 +186,7 @@ class TestMessageWithURI:
         assert all(isinstance(f, Path) for f in msg.files)
 
 
+@pytest.mark.skipif(not _has_flask, reason="flask not installed (server extra)")
 class TestAbsToRelWorkspace:
     """Test _abs_to_rel_workspace handles URIs correctly."""
 


### PR DESCRIPTION
## Summary
- `TestAbsToRelWorkspace` tests in `test_uri.py` import from `gptme.server.api` which requires `flask` (an optional `server` extra dependency)
- When flask is not installed, these tests fail with `ModuleNotFoundError` instead of being skipped
- Added `pytest.mark.skipif` to skip the class when flask is unavailable

## Test plan
- [x] Verified: 20 tests pass, 4 skip when flask is not installed
- [x] Tests would still run when flask IS installed (server extra)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `pytest.mark.skipif` to skip `TestAbsToRelWorkspace` tests in `test_uri.py` when `flask` is not installed.
> 
>   - **Tests**:
>     - Add `pytest.mark.skipif` to `TestAbsToRelWorkspace` in `test_uri.py` to skip tests if `flask` is not installed.
>     - Checks for `flask` availability using `importlib.util.find_spec`.
>   - **Verification**:
>     - Confirmed 20 tests pass and 4 are skipped when `flask` is not installed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 0a690c1eef1db084064d832f1b0226fa21357608. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->