### PR TITLE
fix(config): use logger instead of console for config messages

### DIFF
--- a/gptme/config.py
+++ b/gptme/config.py
@@ -22,7 +22,7 @@ from typing_extensions import Self
 from .context.config import ContextConfig
 from .context.selector.config import ContextSelectorConfig
 from .tools import get_toolchain
-from .util import console, path_with_tilde
+from .util import path_with_tilde
 
 if TYPE_CHECKING:
     from .tools.base import ToolFormat
@@ -360,12 +360,14 @@ def load_user_config(path: str | None = None) -> UserConfig:
         config = _merge_config_data(config, local_config)
 
     # Log config paths (only once per config file)
+    # Use logger instead of console to avoid polluting stdout
+    # (console.log writes to stdout, breaking JSON output in doctor --json, ACP, etc.)
     if config_file not in _user_config_logged:
         _user_config_logged.add(config_file)
         msg = f"Using user configuration from {path_with_tilde(config_file)}"
         if has_local:
             msg += " with local overrides"
-        console.log(msg)
+        logger.info(msg)
 
     # Note: prompt and env are optional - defaults are used if missing
 
@@ -449,7 +451,7 @@ def _load_config_doc(path: str | None = None) -> tomlkit.TOMLDocument:
         toml = tomlkit.dumps(_strip_none(asdict(default_config)))
         with open(path, "w") as config_file:
             config_file.write(toml)
-        console.log(f"Created config file at {path}")
+        logger.info(f"Created config file at {path}")
         doc = tomlkit.loads(toml)
         return doc
     else:
@@ -588,9 +590,9 @@ def get_project_config(
     # Log only on first non-quiet access per workspace
     if not quiet and workspace not in _config_logged_workspaces:
         _config_logged_workspaces.add(workspace)
-        console.log(f"Using project configuration at {path_with_tilde(config_path)}")
+        logger.info(f"Using project configuration at {path_with_tilde(config_path)}")
         if local_config_path:
-            console.log(
+            logger.info(
                 f"Using local configuration from {path_with_tilde(local_config_path)}"
             )
 


### PR DESCRIPTION
## Summary
- Replace `console.log()` with `logger.info()` in `config.py` for all config loading messages
- Removes unused `console` import from config.py
- Fixes `gptme doctor --json` producing invalid JSON due to Rich console messages on stdout

## Problem
The Rich `console.log()` writes to stdout by default. When `gptme doctor --json` runs, config loading triggers `console.log("Using user configuration from ...")` which appears before the JSON output, making it unparseable.

This caused the `test_cli_json_output` test to be flaky — it fails whenever config is loaded during the test (depends on test ordering and caching).

## Fix
Config loading messages are informational and belong in the logger (which defaults to stderr via `RichHandler`), not in the stdout-writing console. Changed all 3 `console.log()` calls in config.py to `logger.info()`.

## Test plan
- [x] `pytest tests/test_doctor.py` — all 25 tests pass (including previously flaky `test_cli_json_output`)
- [x] `ruff check` clean
- [x] Verified `gptme doctor --json` produces valid JSON output
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `console.log()` with `logger.info()` in `config.py` to fix JSON output issues in `gptme doctor --json` and removes an unused import.
> 
>   - **Behavior**:
>     - Replace `console.log()` with `logger.info()` in `load_user_config()`, `_load_config_doc()`, and `get_project_config()` in `config.py` to prevent stdout pollution.
>     - Fixes invalid JSON output in `gptme doctor --json` by ensuring config messages do not appear in stdout.
>   - **Imports**:
>     - Removes unused `console` import from `config.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for dd167b65c040fdf20df29ffadc67fccde6e90514. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->