### PR TITLE
fix(tree): remove tree command dependency, fall back to git ls-files

### DIFF
--- a/gptme/util/tree.py
+++ b/gptme/util/tree.py
@@ -23,6 +23,7 @@ def get_tree_output(workspace: Path, method: TreeMethod = "git") -> str | None:
         return None
 
     # Check if in a git repository
+    in_git_repo = False
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--is-inside-work-tree"],
@@ -31,24 +32,28 @@ def get_tree_output(workspace: Path, method: TreeMethod = "git") -> str | None:
             text=True,
             timeout=1,
         )
-        if result.returncode != 0:
-            logger.debug("Not in a git repository, skipping tree output")
-            return None
+        in_git_repo = result.returncode == 0
     except Exception as e:
-        logger.warning(f"Error checking git repository: {e}")
-        return None
+        logger.debug(f"Error checking git repository: {e}")
 
-    methods: dict[TreeMethod, str] = {
-        "git": "git ls-files --exclude-standard",  # use with git ls-files -o --exclude-standard for unstaged files
-        "tree": "tree -fi --gitignore .",  # is -fi more effective? probably
+    # git and tree --gitignore require a git repo; ls works anywhere
+    git_methods: dict[TreeMethod, str] = {
+        "git": "git ls-files --exclude-standard",
+        "tree": "tree -fi --gitignore .",
+    }
+    non_git_methods: dict[TreeMethod, str] = {
         "ls": "ls -R .",
     }
+    methods: dict[TreeMethod, str] = (
+        {**git_methods, **non_git_methods} if in_git_repo else dict(non_git_methods)
+    )
 
-    # Preferred method order
-    method_order: list[TreeMethod] = ["git", "tree", "ls"]
+    # Preferred method order (only include available methods)
+    _all_methods: list[TreeMethod] = ["git", "tree", "ls"]
+    method_order: list[TreeMethod] = [m for m in _all_methods if m in methods]
 
-    # Start with the requested method, then try others
-    if method in method_order:
+    # Start with the requested method (if available), then try others
+    if method in methods:
         methods_to_try = [method] + [m for m in method_order if m != method]
     else:
         methods_to_try = method_order


### PR DESCRIPTION
## Summary

- Remove early `shutil.which('tree')` check that blocked all fallback methods when `tree` wasn't installed
- Change default method from `tree` to `git` since `git ls-files` works in any git repo without external dependencies
- Methods now try in order and gracefully fall back when one fails (tree → git → ls)

**Before**: `GPTME_CONTEXT_TREE=true` did nothing unless the `tree` command was installed, even though `git ls-files` was listed as a fallback.

**After**: Falls back automatically to `git ls-files` (or `ls -R`) when `tree` isn't available.

## Test plan

- [x] All 8 tree tests pass (including new fallback test)
- [x] mypy clean
- [ ] CI green
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `tree` command dependency in `get_tree_output()` and change default to `git`, with automatic fallback to other methods.
> 
>   - **Behavior**:
>     - Remove `shutil.which('tree')` check in `get_tree_output()` in `tree.py`, allowing fallback to other methods.
>     - Change default method in `get_tree_output()` from `tree` to `git`.
>     - Implement fallback order: `git`, `tree`, `ls` in `get_tree_output()`.
>   - **Tests**:
>     - Update `test_tree.py` to reflect new fallback behavior and default method.
>     - Add `test_get_tree_output_fallback_when_tree_missing()` to verify fallback to `git` when `tree` fails.
>     - Modify existing tests to remove `shutil.which` mocking and check for correct command execution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 8719da72c33acfee67b5f10246e51a711a05cda5. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->