### PR TITLE
fix(doctor): add missing provider docs for gemini, azure

### DIFF
--- a/gptme/llm/validate.py
+++ b/gptme/llm/validate.py
@@ -17,9 +17,10 @@ PROVIDER_DOCS: dict[str, str] = {
     "deepseek": "https://platform.deepseek.com/api_keys",
     "xai": "https://console.x.ai/",
     "azure": "https://portal.azure.com/#view/Microsoft_Azure_ProjectOxford/CognitiveServicesHub",
-    "openai-subscription": "https://chatgpt.com/",  # ChatGPT Plus/Pro subscription (not API keys)
     "nvidia": "https://build.nvidia.com/",
     "local": "https://gptme.org/docs/providers.html#local-models",
+    # NOTE: openai-subscription uses gptme-auth (OAuth), not API keys.
+    # It needs a separate onboarding path (see: gptme-auth login).
 }
 
 

--- a/tests/test_llm_validate.py
+++ b/tests/test_llm_validate.py
@@ -138,7 +138,6 @@ class TestProviderDocs:
             "deepseek",
             "xai",
             "azure",
-            "openai-subscription",
             "nvidia",
             "local",
         ]


### PR DESCRIPTION
## Summary

- Add "gemini" key to `PROVIDER_DOCS` (canonical provider name used by `PROVIDERS` list)
- Keep "google" as backward-compat alias
- Add Azure portal URL for Azure users
- Expand provider docs test to cover all providers

**Problem**: `gptme doctor` and `gptme setup` showed the unhelpful fallback text "provider docs" instead of the actual API key URL for Gemini and Azure users, because `PROVIDER_DOCS` used "google" (old name) while the canonical provider name is "gemini", and Azure had no entry at all.

## Test plan

- [x] `test_all_major_providers_have_docs` expanded and passing
- [x] All 13 validate tests passing
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add missing provider documentation for Gemini and Azure in `PROVIDER_DOCS` and update tests accordingly.
> 
>   - **Behavior**:
>     - Add `gemini` key to `PROVIDER_DOCS` in `validate.py` with Google API key URL.
>     - Add `azure` key to `PROVIDER_DOCS` with Azure portal URL.
>     - Retain `google` as an alias for `gemini`.
>   - **Tests**:
>     - Expand `test_all_major_providers_have_docs` in `test_llm_validate.py` to include `gemini` and `azure`.
>     - Ensure all 13 validation tests pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 3dd9cdc0070928decaa763478fefb7c44e3ccba7. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->