### PR TITLE
feat(cli): add skills subcommands to gptme-util

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -567,7 +567,7 @@ def skills_list(show_all: bool, json_output: bool):
             desc = skill.metadata.description or skill.description or ""
             if len(desc) > 60:
                 desc = desc[:57] + "..."
-            click.echo(f"  {name:30s} {desc}")
+            click.echo(f"  {name or '':30s} {desc}")
     else:
         click.echo("No skills found.")
 

--- a/gptme/lessons/index.py
+++ b/gptme/lessons/index.py
@@ -371,8 +371,21 @@ class LessonIndex:
         results = []
 
         for lesson in self.lessons:
+            # Check skill name (metadata.name)
+            if lesson.metadata.name and query_lower in lesson.metadata.name.lower():
+                results.append(lesson)
+                continue
+
             # Check title
             if query_lower in lesson.title.lower():
+                results.append(lesson)
+                continue
+
+            # Check skill description (metadata.description)
+            if (
+                lesson.metadata.description
+                and query_lower in lesson.metadata.description.lower()
+            ):
                 results.append(lesson)
                 continue
 


### PR DESCRIPTION
## Summary

Adds `gptme-util skills` CLI group for inspecting skills and lessons from the terminal, without needing an active gptme session.

### Subcommands

- **`gptme-util skills list`** — List discovered skills (with `--all` for lessons too, `--json` for machine-readable output)
- **`gptme-util skills show <name>`** — Display full content of a skill or lesson by name
- **`gptme-util skills search <query>`** — Search skills and lessons by name, description, or keywords
- **`gptme-util skills dirs`** — Show which directories are searched for skills/lessons (useful for debugging "why isn't my skill loading?")

### Context

This addresses the **Phase 4.2 "Skills CLI commands"** item from #1170. The skills system (Phase 4.1) already has full parser, index, and matcher infrastructure — but skills could only be browsed via in-chat `/skills` commands during an active session. This PR exposes the same functionality through the standalone `gptme-util` CLI.

### Implementation

All subcommands reuse the existing `LessonIndex` class, which handles discovery across user, workspace, plugin, and config directories with mtime-based caching and symlink deduplication.

### Test plan

- [x] 10 new tests in `tests/test_util_cli_skills.py` covering all subcommands and edge cases
- [x] Existing `test_util_cli.py` tests still pass (14 total, 1 skipped)
- [x] mypy clean, ruff clean, pre-commit passes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `skills` CLI group to `gptme-util` for managing skills and lessons with commands for listing, showing, searching, and debugging.
> 
>   - **Behavior**:
>     - Adds `skills` CLI group to `gptme-util` in `util.py` for managing skills and lessons.
>     - Includes subcommands: `list`, `show`, `search`, and `dirs`.
>     - `list` command supports `--all` for lessons and `--json` for JSON output.
>     - `show` command displays full content of a skill or lesson by name.
>     - `search` command searches skills and lessons by name, description, or keywords.
>     - `dirs` command shows directories searched for skills/lessons.
>   - **Implementation**:
>     - Reuses `LessonIndex` class for skill discovery and management.
>     - Caches and deduplicates using mtime and symlinks.
>   - **Testing**:
>     - Adds `test_util_cli_skills.py` with 10 new tests covering all subcommands and edge cases.
>     - Ensures existing tests in `test_util_cli.py` pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 65dab28b893890f231b7ccccdd47c4cc8966bf83. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->