### PR TITLE
fix(tests): use correct field name in ACP test helper

### DIFF
--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -41,10 +41,11 @@ def _mock_permission_response(option_id: str | None = None, cancelled: bool = Fa
         )
 
         if cancelled:
-            outcome = DeniedOutcome(outcome="cancelled")
+            return RequestPermissionResponse(outcome=DeniedOutcome(outcome="cancelled"))
         else:
-            outcome = AllowedOutcome(outcome="selected", optionId=option_id or "")
-        return RequestPermissionResponse(outcome=outcome)
+            return RequestPermissionResponse(
+                outcome=AllowedOutcome(outcome="selected", option_id=option_id or "")
+            )
     except ImportError:
         pytest.skip("acp not installed")
 


### PR DESCRIPTION
## Summary
- Fix `optionId` → `option_id` in `_mock_permission_response` test helper
- The helper was using the JSON alias instead of the Python field name for `AllowedOutcome`
- Also restructured if/else to avoid mypy type narrowing issue

## Test plan
- [x] `mypy tests/test_acp_agent.py` passes (was failing before)
- [x] All 29 ACP agent tests pass (21 passed, 8 skipped)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes field name and restructures conditional block in `_mock_permission_response()` in `tests/test_acp_agent.py` to resolve `mypy` issues.
> 
>   - **Fixes**:
>     - Change `optionId` to `option_id` in `_mock_permission_response()` in `tests/test_acp_agent.py` to use the correct Python field name.
>   - **Code Structure**:
>     - Restructure `if/else` block in `_mock_permission_response()` to resolve a `mypy` type narrowing issue.
>   - **Testing**:
>     - `mypy tests/test_acp_agent.py` now passes.
>     - All 29 ACP agent tests pass (21 passed, 8 skipped).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 63528af2bc8b09ea63e008c93ee017a780ef7b9f. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->