### PR TITLE
fix(acp): set default model ContextVar in prompt() handler

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from ..init import init
+from ..llm.models import set_default_model
 from ..logmanager import LogManager
 from ..message import Message
 from ..prompts import get_prompt
@@ -523,6 +524,12 @@ class GptmeAgent:
         try:
             # Import chat step
             from ..chat import step as chat_step
+
+            # Ensure model ContextVar is set in this task's context.
+            # Each ACP RPC call runs in a fresh asyncio task that doesn't inherit
+            # the ContextVar set by initialize(). Setting it here ensures both
+            # this task and the executor thread (via copy_context below) see it.
+            set_default_model(self._model)
 
             # Run gptme chat step in executor to not block event loop
             loop = asyncio.get_running_loop()


### PR DESCRIPTION
## Problem

After the fix in #1293, the `assert model is not None, "No model loaded"` error still occurred on the second ACP call (reported in #1290).

**Root cause**: Each ACP RPC call runs in a fresh asyncio Task. Python's `ContextVar` values set in one Task are **not** automatically visible to sibling Tasks — only child Tasks inherit from their parent. So when `initialize()` calls `init()` → `set_default_model()`, that ContextVar update is only visible within the `initialize` task's context tree, not to the `prompt()` task created by the ACP framework for the next call.

The `copy_context()` fix in #1293 correctly propagated the context from the `prompt()` task to its executor thread — but the `prompt()` task itself didn't have the model ContextVar set in the first place.

## Fix

Call `set_default_model(self._model)` at the start of `prompt()`, before `copy_context()` and `run_in_executor()`. This sets the ContextVar in the `prompt()` task's context, which is then correctly propagated to the executor thread.

## Testing

All 29 existing ACP agent tests pass. The fix addresses the specific scenario in #1290 where the model appeared to load (logged as "Using model: ...") but subsequent `get_default_model()` calls returned `None`.

Closes #1290
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `ContextVar` issue in `prompt()` in `agent.py` by setting `set_default_model(self._model)` at the start to ensure availability in task context.
> 
>   - **Behavior**:
>     - Fixes `ContextVar` issue in `prompt()` in `agent.py` by setting `set_default_model(self._model)` at the start of the function.
>     - Ensures `ContextVar` is available in the `prompt()` task and propagated to the executor thread.
>   - **Testing**:
>     - All 29 existing ACP agent tests pass.
>     - Specifically addresses issue #1290 where `get_default_model()` returned `None` after model appeared to load.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for ef066c2e8e53e74f76e66819798ff28adb1f8261. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->