### PR TITLE
fix(hooks): remove unnecessary type: ignore and fix imports

### DIFF
--- a/gptme/hooks/confirm.py
+++ b/gptme/hooks/confirm.py
@@ -15,7 +15,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, cast
 
 if TYPE_CHECKING:
     from ..tools.base import ToolUse
@@ -211,8 +211,6 @@ def get_confirmation(
             return ConfirmationResult.skip("No confirmation hook registered")
 
     # Try hooks in priority order, falling through if a hook returns None
-    from typing import cast
-
     for hook in enabled_hooks:
         try:
             logger.debug(f"Calling confirmation hook '{hook.name}'")

--- a/gptme/hooks/elicitation.py
+++ b/gptme/hooks/elicitation.py
@@ -55,7 +55,7 @@ MCP Elicitation:
 import getpass
 import logging
 from dataclasses import dataclass
-from typing import Literal, Protocol
+from typing import Literal, Protocol, cast
 
 logger = logging.getLogger(__name__)
 
@@ -398,8 +398,6 @@ def elicit(request: ElicitationRequest) -> ElicitationResponse:
     hooks = [h for h in get_hooks(HookType.ELICIT) if h.enabled]
     for hook in hooks:
         try:
-            from typing import cast
-
             hook_func = cast(ElicitationHook, hook.func)
             result = hook_func(request)
             if result is not None:
@@ -431,7 +429,7 @@ def register_cli_elicitation_hook() -> None:
     register_hook(
         name="cli_elicit",
         hook_type=HookType.ELICIT,
-        func=cli_hook,  # type: ignore[arg-type]
+        func=cli_hook,
         priority=0,
         enabled=True,
     )

--- a/gptme/hooks/tests/test_elicitation.py
+++ b/gptme/hooks/tests/test_elicitation.py
@@ -95,7 +95,7 @@ class TestElicitFunction:
         register_hook(
             name="test_elicit",
             hook_type=HookType.ELICIT,
-            func=my_hook,  # type: ignore[arg-type]
+            func=my_hook,
         )
 
         req = ElicitationRequest(type="text", prompt="What is your name?")
@@ -118,13 +118,13 @@ class TestElicitFunction:
         register_hook(
             name="first",
             hook_type=HookType.ELICIT,
-            func=first_hook,  # type: ignore[arg-type]
+            func=first_hook,
             priority=10,
         )
         register_hook(
             name="second",
             hook_type=HookType.ELICIT,
-            func=second_hook,  # type: ignore[arg-type]
+            func=second_hook,
             priority=0,
         )
 
@@ -163,7 +163,7 @@ class TestElicitFunction:
         register_hook(
             name="cancel_hook",
             hook_type=HookType.ELICIT,
-            func=cancelling_hook,  # type: ignore[arg-type]
+            func=cancelling_hook,
         )
 
         req = ElicitationRequest(type="text", prompt="Gonna cancel?")


### PR DESCRIPTION
## Summary

- Remove 5 unnecessary `# type: ignore[arg-type]` comments from elicitation hook registrations. These were added before `ElicitationHook` was included in the `HookFunc` union and the `register_hook` overload for `HookType.ELICIT` was added — they're no longer needed.
- Move `from typing import cast` from function bodies to top-level imports in `elicitation.py` and `confirm.py`.

All 76 hooks tests pass. No behavior changes.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unnecessary type ignores and optimize imports in `elicitation.py` and `confirm.py`.
> 
>   - **Type Ignore Removal**:
>     - Removed `# type: ignore[arg-type]` from `cli_hook`, `my_hook`, `first_hook`, `second_hook`, and `cancelling_hook` in `elicitation.py` and `test_elicitation.py`.
>   - **Imports**:
>     - Moved `from typing import cast` to top-level imports in `confirm.py` and `elicitation.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for f192f0f20b6a2301763ae1ce1c1a47339167401b. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->