### PR TITLE
fix(webui): rename env vars to VITE_GPTME_ prefix convention

### DIFF
--- a/webui/src/utils/connectionConfig.ts
+++ b/webui/src/utils/connectionConfig.ts
@@ -8,8 +8,8 @@ import {
 const DEFAULT_API_URL = 'http://127.0.0.1:5700';
 
 // Fleet operator URL for auth code exchange
-// Configure via VITE_FLEET_OPERATOR_URL environment variable
-const FLEET_OPERATOR_URL = import.meta.env.VITE_FLEET_OPERATOR_URL || 'https://fleet.gptme.ai';
+// Configure via VITE_GPTME_CLOUD_BASE_URL environment variable
+const FLEET_OPERATOR_URL = import.meta.env.VITE_GPTME_CLOUD_BASE_URL || 'https://fleet.gptme.ai';
 
 export interface ConnectionConfig {
   baseUrl: string;
@@ -63,7 +63,7 @@ function getAuthCodeParams(hash?: string): { code: string } | null {
 
 /**
  * Get the exchange URL for auth code flow.
- * Derives from VITE_FLEET_OPERATOR_URL environment variable.
+ * Derives from VITE_GPTME_CLOUD_BASE_URL environment variable.
  */
 function getExchangeUrl(): string {
   return `${FLEET_OPERATOR_URL}/api/v1/operator/auth/exchange`;
@@ -120,7 +120,7 @@ export function getConnectionConfigFromSources(hash?: string): ConnectionConfig 
 
   // Fallback (should not happen since registry always has at least one server)
   return {
-    baseUrl: import.meta.env.VITE_API_URL || DEFAULT_API_URL,
+    baseUrl: import.meta.env.VITE_GPTME_API_URL || DEFAULT_API_URL,
     authToken: null,
     useAuthToken: false,
   };
@@ -177,7 +177,7 @@ export async function processConnectionFromHash(hash?: string): Promise<Connecti
  */
 export function getApiBaseUrl(): string {
   const server = getActiveServer();
-  return server?.baseUrl || import.meta.env.VITE_API_URL || DEFAULT_API_URL;
+  return server?.baseUrl || import.meta.env.VITE_GPTME_API_URL || DEFAULT_API_URL;
 }
 
 /**


### PR DESCRIPTION
Takes over from Miyou's PR #1218 per Erik's request.

## Changes

- `VITE_FLEET_OPERATOR_URL` → `VITE_GPTME_CLOUD_BASE_URL` (the fleet.gptme.ai cloud service URL for auth code exchange)
- `VITE_API_URL` → `VITE_GPTME_API_URL` (the user's local/remote gptme instance API URL)

## Why two separate env vars?

The original PR #1218 used a single `VITE_GPTME_FLEET_BASE_URL` for both the fleet operator URL and the instance base URL. This would break auth code exchange if a user set it to their instance URL — the auth code POST would go to the wrong server.

These two URLs serve different purposes:
- `VITE_GPTME_CLOUD_BASE_URL`: Points to `fleet.gptme.ai` (the gptme.ai cloud service that handles auth code exchange)
- `VITE_GPTME_API_URL`: Points to the user's gptme instance (e.g. `http://127.0.0.1:5700`)

Keeping them separate preserves correct behavior while following the `VITE_GPTME_` naming convention.

Closes #1218
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Renames environment variables in `connectionConfig.ts` to follow `VITE_GPTME_` prefix, affecting fleet operator and API URL configurations.
> 
>   - **Environment Variables**:
>     - Rename `VITE_FLEET_OPERATOR_URL` to `VITE_GPTME_CLOUD_BASE_URL` for fleet operator URL.
>     - Rename `VITE_API_URL` to `VITE_GPTME_API_URL` for user's gptme instance API URL.
>   - **Functions in `connectionConfig.ts`**:
>     - Update `FLEET_OPERATOR_URL` to use `VITE_GPTME_CLOUD_BASE_URL`.
>     - Update `getExchangeUrl()` to derive from `VITE_GPTME_CLOUD_BASE_URL`.
>     - Update `getConnectionConfigFromSources()` and `getApiBaseUrl()` to use `VITE_GPTME_API_URL`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 9828276a89b79f12b09dd28722090f24e4b14c23. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->