### PR TITLE
fix(webui): rename env vars to use VITE_GPTME_ prefix

### DIFF
--- a/webui/src/utils/connectionConfig.ts
+++ b/webui/src/utils/connectionConfig.ts
@@ -7,9 +7,9 @@ import {
 
 const DEFAULT_API_URL = 'http://127.0.0.1:5700';
 
-// Fleet operator URL for auth code exchange
-// Configure via VITE_FLEET_OPERATOR_URL environment variable
-const FLEET_OPERATOR_URL = import.meta.env.VITE_FLEET_OPERATOR_URL || 'https://fleet.gptme.ai';
+// Cloud service URL for auth code exchange (fleet.gptme.ai)
+// Configure via VITE_GPTME_CLOUD_BASE_URL environment variable
+const CLOUD_BASE_URL = import.meta.env.VITE_GPTME_CLOUD_BASE_URL || 'https://fleet.gptme.ai';
 
 export interface ConnectionConfig {
   baseUrl: string;
@@ -63,10 +63,10 @@ function getAuthCodeParams(hash?: string): { code: string } | null {
 
 /**
  * Get the exchange URL for auth code flow.
- * Derives from VITE_FLEET_OPERATOR_URL environment variable.
+ * Derives from VITE_GPTME_CLOUD_BASE_URL environment variable.
  */
 function getExchangeUrl(): string {
-  return `${FLEET_OPERATOR_URL}/api/v1/operator/auth/exchange`;
+  return `${CLOUD_BASE_URL}/api/v1/operator/auth/exchange`;
 }
 
 export function getConnectionConfigFromSources(hash?: string): ConnectionConfig {
@@ -120,7 +120,7 @@ export function getConnectionConfigFromSources(hash?: string): ConnectionConfig 
 
   // Fallback (should not happen since registry always has at least one server)
   return {
-    baseUrl: import.meta.env.VITE_API_URL || DEFAULT_API_URL,
+    baseUrl: import.meta.env.VITE_GPTME_API_URL || DEFAULT_API_URL,
     authToken: null,
     useAuthToken: false,
   };
@@ -177,7 +177,7 @@ export async function processConnectionFromHash(hash?: string): Promise<Connecti
  */
 export function getApiBaseUrl(): string {
   const server = getActiveServer();
-  return server?.baseUrl || import.meta.env.VITE_API_URL || DEFAULT_API_URL;
+  return server?.baseUrl || import.meta.env.VITE_GPTME_API_URL || DEFAULT_API_URL;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Rename `VITE_FLEET_OPERATOR_URL` → `VITE_GPTME_CLOUD_BASE_URL` (cloud/fleet service for auth exchange)
- Rename `VITE_API_URL` → `VITE_GPTME_API_URL` (user's gptme instance URL)

These are kept as **separate env vars** since they serve different purposes — the cloud URL is for auth code exchange with `fleet.gptme.ai`, while the API URL is for the user's local/remote gptme instance.

Supersedes #1218 (stale branch with conflicts). Implements the naming convention Erik requested: `VITE_GPTME_CLOUD_BASE_URL` for the cloud service.

Closes #1218
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Renames environment variables in `connectionConfig.ts` to use `VITE_GPTME_` prefix for clarity and consistency.
> 
>   - **Environment Variables**:
>     - Rename `VITE_FLEET_OPERATOR_URL` to `VITE_GPTME_CLOUD_BASE_URL` for cloud service auth exchange.
>     - Rename `VITE_API_URL` to `VITE_GPTME_API_URL` for user's gptme instance URL.
>   - **Functions**:
>     - Update `getExchangeUrl()` to use `VITE_GPTME_CLOUD_BASE_URL`.
>     - Update `getConnectionConfigFromSources()` and `getApiBaseUrl()` to use `VITE_GPTME_API_URL`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 2ec7bc3db372b4038f62c61bf3772ca7561688d2. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->