### PR TITLE
fix(dirs): move readline history from config dir to data dir

### DIFF
--- a/gptme/dirs.py
+++ b/gptme/dirs.py
@@ -137,8 +137,11 @@ def _migrate_readline_history():
     old_path = get_config_dir() / "history"
     new_path = get_data_dir() / "history"
     if old_path.exists() and not new_path.exists():
-        logger.info(f"Migrating readline history: {old_path} -> {new_path}")
-        shutil.move(str(old_path), str(new_path))
+        try:
+            logger.info(f"Migrating readline history: {old_path} -> {new_path}")
+            shutil.move(str(old_path), str(new_path))
+        except Exception as e:
+            logger.warning(f"Failed to migrate readline history: {e}")
 
 
 def _init_paths():


### PR DESCRIPTION
## Summary

- Moves `get_readline_history_file()` path from config dir to data dir, matching `get_pt_history_file()` which is already in the data dir
- Adds automatic migration: on startup, if the old config-dir history file exists and the new data-dir path doesn't, it's moved transparently
- History files are data, not configuration — this follows XDG conventions

Resolves the TODO on `dirs.py:13`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Moves readline history file from config dir to data dir and adds migration for existing files in `dirs.py`.
> 
>   - **Behavior**:
>     - Moves `get_readline_history_file()` path from config dir to data dir in `dirs.py`.
>     - Adds `_migrate_readline_history()` to move existing history file from config dir to data dir if needed.
>   - **Misc**:
>     - Resolves TODO in `dirs.py:13`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 503e72d61bc28bab267a55651d7e11fbf5fc0e7e. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->