### PR TITLE
feat(llm): add missing OpenAI model metadata (GPT-4.1, o3, o4-mini)

### DIFF
--- a/gptme/llm/llm_openai_models.py
+++ b/gptme/llm/llm_openai_models.py
@@ -33,6 +33,31 @@ OPENAI_MODELS: dict[str, "_ModelDictMeta"] = {
         "supports_reasoning": True,
         "knowledge_cutoff": datetime(2024, 5, 31),
     },
+    # GPT-4.1
+    "gpt-4.1": {
+        "context": 1_047_576,
+        "max_output": 32_768,
+        "price_input": 2,
+        "price_output": 8,
+        "supports_vision": True,
+        "knowledge_cutoff": datetime(2025, 3, 1),
+    },
+    "gpt-4.1-mini": {
+        "context": 1_047_576,
+        "max_output": 32_768,
+        "price_input": 0.4,
+        "price_output": 1.6,
+        "supports_vision": True,
+        "knowledge_cutoff": datetime(2025, 3, 1),
+    },
+    "gpt-4.1-nano": {
+        "context": 1_047_576,
+        "max_output": 32_768,
+        "price_input": 0.1,
+        "price_output": 0.4,
+        "supports_vision": True,
+        "knowledge_cutoff": datetime(2025, 3, 1),
+    },
     # GPT-4o
     "gpt-4o": {
         "context": 128_000,
@@ -68,7 +93,39 @@ OPENAI_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_output": 0.6,
         "knowledge_cutoff": datetime(2023, 10, 1),
     },
-    # OpenAI o1-preview
+    # OpenAI o4-mini
+    "o4-mini": {
+        "context": 200_000,
+        "max_output": 100_000,
+        "price_input": 1.1,
+        "price_output": 4.4,
+        "supports_vision": True,
+        "supports_reasoning": True,
+    },
+    # OpenAI o3
+    "o3": {
+        "context": 200_000,
+        "max_output": 100_000,
+        "price_input": 2,
+        "price_output": 8,
+        "supports_vision": True,
+        "supports_reasoning": True,
+    },
+    "o3-mini": {
+        "context": 200_000,
+        "max_output": 100_000,
+        "price_input": 1.1,
+        "price_output": 4.4,
+        "supports_reasoning": True,
+    },
+    # OpenAI o1
+    "o1": {
+        "context": 200_000,
+        "max_output": 100_000,
+        "price_input": 15,
+        "price_output": 60,
+        "supports_reasoning": True,
+    },
     "o1-preview": {
         "context": 128_000,
         "price_input": 15,
@@ -81,7 +138,6 @@ OPENAI_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_output": 60,
         "supports_reasoning": True,
     },
-    # OpenAI o1-mini
     "o1-mini": {
         "context": 128_000,
         "price_input": 3,


### PR DESCRIPTION
## Summary

Add model metadata entries for recently released OpenAI models that were missing from the static model registry:

- **GPT-4.1 family**: `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano` — 1M context, 32k max output
- **o3 family**: `o3`, `o3-mini` — 200k context, 100k max output, reasoning models
- **o4-mini**: 200k context, 100k max output, reasoning model
- **o1** (non-preview): 200k context, 100k max output (previously only had o1-preview)

Pricing sourced from OpenAI API documentation. Without these entries, gptme can't properly track costs or enforce context limits when users select these models.

## Test plan

- [x] All 12 model tests pass
- [x] Lint passes (ruff)
- [ ] CI passes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add metadata for new OpenAI models (GPT-4.1, o3, o4-mini, o1) to `llm_openai_models.py` for cost tracking and context limit enforcement.
> 
>   - **Behavior**:
>     - Add metadata for `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano` with 1M context, 32k max output.
>     - Add metadata for `o3`, `o3-mini`, `o4-mini` with 200k context, 100k max output, supports reasoning.
>     - Add non-preview `o1` with 200k context, 100k max output.
>   - **Misc**:
>     - Pricing sourced from OpenAI API documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for e073ef2fa032236b02c82523161ad52fd80abc9c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->