### PR TITLE
fix(tools): add specific error codes to bare type-ignore and noqa comments

### DIFF
--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -71,8 +71,8 @@ try:
 except ImportError:
     has_pypdf = False
 
-has_playwright = lambda: importlib.util.find_spec("playwright") is not None  # noqa
-has_lynx = lambda: shutil.which("lynx")  # noqa
+has_playwright = lambda: importlib.util.find_spec("playwright") is not None  # noqa: E731
+has_lynx = lambda: shutil.which("lynx")  # noqa: E731
 browser: Literal["playwright", "lynx"] | None = (
     "playwright" if has_playwright() else ("lynx" if has_lynx() else None)
 )
@@ -280,7 +280,7 @@ try:
     has_perplexity = has_perplexity_key()
 except ImportError:
     has_perplexity = False
-    search_perplexity = None  # type: ignore
+    search_perplexity = None  # type: ignore[assignment]
 
 # noreorder
 if browser == "playwright":
@@ -493,9 +493,9 @@ def read_url(url: str, max_pages: int | None = None) -> str:
     # Otherwise use normal browser reading (max_pages ignored)
     assert browser
     if browser == "playwright":
-        return read_url_playwright(url)  # type: ignore
+        return read_url_playwright(url)
     elif browser == "lynx":
-        return read_url_lynx(url)  # type: ignore
+        return read_url_lynx(url)
 
 
 def search(query: str, engine: EngineType = "perplexity") -> str:
@@ -509,7 +509,7 @@ def search(query: str, engine: EngineType = "perplexity") -> str:
         )
     if engine == "perplexity":
         if has_perplexity:
-            return search_perplexity(query)  # type: ignore
+            return search_perplexity(query)
         else:
             return "Error: Perplexity search not available. Set PERPLEXITY_API_KEY or OPENROUTER_API_KEY environment variable or add it to ~/.config/gptme/config.toml"
     raise ValueError(f"Unknown search engine: {engine}")
@@ -518,9 +518,9 @@ def search(query: str, engine: EngineType = "perplexity") -> str:
 def search_playwright(query: str, engine: EngineType = "google") -> str:
     """Search for a query on a search engine using Playwright."""
     if engine == "google":
-        return search_google(query)  # type: ignore
+        return search_google(query)
     elif engine == "duckduckgo":
-        return search_duckduckgo(query)  # type: ignore
+        return search_duckduckgo(query)
     raise ValueError(f"Unknown search engine: {engine}")
 
 
@@ -528,7 +528,7 @@ def screenshot_url(url: str, path: Path | str | None = None) -> Path:
     """Take a screenshot of a webpage."""
     assert browser
     if browser == "playwright":
-        return screenshot_url_pw(url, path)  # type: ignore
+        return screenshot_url_pw(url, path)
     raise ValueError("Screenshot not supported with lynx backend")
 
 
@@ -536,7 +536,7 @@ def read_logs() -> str:
     """Read browser console logs from the last read URL."""
     assert browser
     if browser == "playwright":
-        return read_logs_playwright()  # type: ignore
+        return read_logs_playwright()
     raise ValueError("Browser logs not supported with lynx backend")
 
 

--- a/gptme/tools/precommit.py
+++ b/gptme/tools/precommit.py
@@ -58,7 +58,7 @@ def use_checks() -> bool:
     Any issues found are included in the context, helping catch and fix code quality
     issues before the user continues the conversation.
     """
-    flag: str = get_config().get_env("GPTME_CHECK", "")  # type: ignore
+    flag: str = get_config().get_env("GPTME_CHECK", "")  # type: ignore[assignment]
     explicit_enabled = flag.lower() in ("1", "true", "yes")
     explicit_disabled = flag.lower() in ("0", "false", "no")
     if explicit_disabled:
@@ -91,7 +91,7 @@ def run_checks_per_file() -> bool:
     Not always a good idea for multi-step/multi-file changes, so disabled by default.
     """
     # TODO: also support checking only modified files in the full run after step complete?
-    flag: str = get_config().get_env("GPTME_CHECK_PER_FILE", "false")  # type: ignore
+    flag: str = get_config().get_env("GPTME_CHECK_PER_FILE", "false")  # type: ignore[assignment]
     return flag.lower() in (
         "1",
         "true",

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -478,8 +478,8 @@ class ShellSession:
             universal_newlines=True,
             start_new_session=True,  # Create new process group for proper signal handling
         )
-        self.stdout_fd = self.process.stdout.fileno()  # type: ignore
-        self.stderr_fd = self.process.stderr.fileno()  # type: ignore
+        self.stdout_fd = self.process.stdout.fileno()  # type: ignore[union-attr]
+        self.stderr_fd = self.process.stderr.fileno()  # type: ignore[union-attr]
         self.delimiter = "END_OF_COMMAND_OUTPUT"
         self.start_marker = "START_OF_COMMAND_OUTPUT"
 


### PR DESCRIPTION
## Summary

- Adds specific error codes to bare `# type: ignore` and `# noqa` comments in tool files
- Removes 7 unused `# type: ignore` comments in browser.py that mypy flagged as unnecessary
- Follows the cleanup pattern from PR #1302

### Changes

**browser.py:**
- `# noqa` → `# noqa: E731` (lambda assignment)
- `# type: ignore` → `# type: ignore[assignment]` (None → Callable)
- Removed 7 unused `# type: ignore` comments (types are now correct)

**precommit.py:**
- `# type: ignore` → `# type: ignore[assignment]` (str | None → str)

**shell.py:**
- `# type: ignore` → `# type: ignore[union-attr]` (stdout/stderr could be None)

## Motivation

Bare ignore comments silence ALL warnings, potentially hiding real issues. Specific codes document the intent and ensure only the known issue is suppressed.

## Test plan

- [x] mypy passes with `--warn-unused-ignores` on all modified files
- [x] Pre-commit checks pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds specific error codes to `# type: ignore` and `# noqa` comments in `browser.py`, `precommit.py`, and `shell.py`, and removes unused ignores in `browser.py`.
> 
>   - **Behavior**:
>     - Adds specific error codes to `# type: ignore` and `# noqa` comments in `browser.py`, `precommit.py`, and `shell.py`.
>     - Removes 7 unused `# type: ignore` comments in `browser.py`.
>   - **browser.py**:
>     - `# noqa` → `# noqa: E731` for lambda assignments.
>     - `# type: ignore` → `# type: ignore[assignment]` for `None` to `Callable` assignments.
>     - Removes 7 unused `# type: ignore` comments.
>   - **precommit.py**:
>     - `# type: ignore` → `# type: ignore[assignment]` for `str | None` to `str` assignments.
>   - **shell.py**:
>     - `# type: ignore` → `# type: ignore[union-attr]` for `stdout/stderr` potentially being `None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for b3cbc09dd543eedf53243f8c0c73ca43a9f5b399. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->