### PR TITLE
fix(acp): resolve model from config instead of hardcoding Anthropic default

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from ..init import init
-from ..llm.models import set_default_model
+from ..llm.models import get_default_model, set_default_model
 from ..logmanager import LogManager
 from ..message import Message
 from ..prompts import get_prompt
@@ -83,7 +83,7 @@ class GptmeAgent:
         self._conn: Any = None
         self._registry = SessionRegistry()
         self._initialized = False
-        self._model: str = "anthropic/claude-sonnet-4-20250514"
+        self._model: str | None = None
         self._tools: list[Any] | None = None
         # Phase 2: Track active tool calls per session
         self._tool_calls: dict[str, dict[str, ToolCall]] = {}
@@ -416,6 +416,11 @@ class GptmeAgent:
                     "Ensure API keys are set in environment or config.toml."
                 ) from e
             self._initialized = True
+            # Capture the resolved model (from config/env/auto-detect)
+            # so subsequent handlers use the same model
+            resolved = get_default_model()
+            if resolved:
+                self._model = f"{resolved.provider}/{resolved.model}"
             # Store tools for re-setting in other handler contexts
             self._tools = get_tools()
 

--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -57,7 +57,7 @@ class TestGptmeAgentInit:
         agent = GptmeAgent()
         assert agent._conn is None
         assert agent._initialized is False
-        assert agent._model == "anthropic/claude-sonnet-4-20250514"
+        assert agent._model is None
         assert agent._tool_calls == {}
         assert agent._permission_policies == {}
 


### PR DESCRIPTION
## Summary
- Fixes the ACP agent hardcoding `anthropic/claude-sonnet-4-20250514` as default model, which ignores user configuration
- Now passes `None` to `init()`, which resolves through the standard chain: `config.toml` → env vars → auto-detect
- After initialization, captures the resolved model for use in subsequent ACP handlers (new_session, prompt, etc.)

## Problem
When users configure a non-Anthropic provider (e.g. OpenAI, local models) in `config.toml`, the ACP agent would ignore their configuration and always try to use `anthropic/claude-sonnet-4-20250514`. This caused silent failures in Zed where the UI showed "Loading..." instead of a helpful error message.

## Changes
- `gptme/acp/agent.py`: Changed `self._model` default from hardcoded Anthropic model to `None`, added `get_default_model()` import to capture resolved model after `init()`
- `tests/test_acp_agent.py`: Updated test to match new `None` default

## Test plan
- [x] All 82 ACP tests pass
- [x] mypy clean
- [x] ruff clean
- [ ] CI passes

Closes #1315
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix ACP agent to resolve model from configuration instead of hardcoding Anthropic default, ensuring user configurations are respected.
> 
>   - **Behavior**:
>     - In `gptme/acp/agent.py`, change `self._model` default from hardcoded `anthropic/claude-sonnet-4-20250514` to `None`.
>     - Use `get_default_model()` to resolve model after `init()`.
>   - **Tests**:
>     - Update `tests/test_acp_agent.py` to reflect new `None` default for `self._model`.
>   - **Misc**:
>     - Fixes issue where non-Anthropic models in `config.toml` were ignored, causing UI failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for d8f1c0eb8b72c2e5410399cc89d7525faf88c15c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->