### PR TITLE
fix(tmux): handle list-sessions failure gracefully instead of asserting

### DIFF
--- a/gptme/tools/tmux.py
+++ b/gptme/tools/tmux.py
@@ -124,7 +124,11 @@ def get_sessions() -> list[str]:
         capture_output=True,
         text=True,
     )
-    assert output.returncode == 0
+    if output.returncode != 0:
+        logger.warning(
+            f"tmux list-sessions failed (rc={output.returncode}): {output.stderr.strip()}"
+        )
+        return []
     return [session.split(":")[0] for session in output.stdout.split("\n") if session]
 
 


### PR DESCRIPTION
## Summary
- Replaces bare `assert output.returncode == 0` in `get_sessions()` with graceful error handling
- Logs a warning and returns empty list on `tmux list-sessions` failure, matching the pattern used by `send_keys()` and `kill_session()` in the same file

## Problem
CI jobs across multiple PRs (#1312, #1316, and others) have been failing with:
```
gptme/tools/tmux.py:127: AssertionError
```
This happens when `tmux list-sessions` returns non-zero despite `tmux has` succeeding — a race condition in headless/CI environments where the tmux server isn't fully initialized between the two calls.

## Changes
- `gptme/tools/tmux.py`: Replace assert with warning log + empty list return

## Test plan
- [x] All 10 tmux tests pass locally
- [x] ruff clean
- [ ] CI passes (this fix should eliminate the flaky tmux failures)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces assert with graceful error handling in `get_sessions()` in `tmux.py` to fix CI race condition.
> 
>   - **Behavior**:
>     - Replaces `assert output.returncode == 0` with a warning log and empty list return in `get_sessions()` in `tmux.py`.
>     - Handles `tmux list-sessions` failure gracefully, similar to `send_keys()` and `kill_session()`.
>   - **Problem**:
>     - Fixes CI job failures due to race condition where `tmux list-sessions` fails despite `tmux has` succeeding.
>   - **Misc**:
>     - Logs warning with return code and error message on failure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 06fd157308fe76ab5377626d79029931305d988b. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->