### PR TITLE
fix(acp): surface init errors as agent messages instead of killing connection

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -410,9 +410,6 @@ class GptmeAgent:
                     tool_allowlist=None,
                     tool_format="markdown",
                 )
-                self._initialized = True
-                # Store tools for re-setting in other handler contexts
-                self._tools = get_tools()
             except Exception as e:
                 # Store the error instead of raising — raising would kill the
                 # ACP connection and leave the editor showing "Loading..." with


### PR DESCRIPTION
## Summary

Fixes #1315 — When gptme initialization fails in ACP mode (e.g. no API key configured), the editor now shows a clear error message instead of hanging on "Loading...".

**Before**: `initialize()` raised `RuntimeError` → ACP connection died → Zed showed "Loading..." forever with no explanation.

**After**: Init errors are stored and surfaced as visible agent messages when the user sends their first prompt. The ACP connection stays alive.

### Changes

- Store init errors in `_init_error` instead of raising `RuntimeError`
- Surface the error as an agent message in `prompt()` with clear instructions
- Widen exception catch from `(KeyError, ValueError)` to `Exception` to handle all init failure modes (import errors, permission issues, network errors, etc.)

### Testing

- Verified syntax and linting (ruff, mypy all pass)
- No existing ACP test suite to run; the fix is straightforward error handling
- The change is additive — successful init paths are unchanged
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Store initialization errors in `_init_error` and surface them as agent messages in `prompt()` to prevent ACP connection termination.
> 
>   - **Behavior**:
>     - Store initialization errors in `_init_error` instead of raising `RuntimeError` in `initialize()`.
>     - Surface errors as agent messages in `prompt()` when the user sends their first prompt.
>     - Widen exception catch in `initialize()` from `(KeyError, ValueError)` to `Exception` to handle all failure modes.
>   - **Testing**:
>     - Verified syntax and linting (ruff, mypy all pass).
>     - No existing ACP test suite; changes are straightforward error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 4d967c4bf34bc15b5a440f1736e0026047b0d469. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->