### PR TITLE
fix(llm): correct gemini-2.5-pro max_output from 8192 to 65536

### DIFF
--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -337,7 +337,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
         },
         "gemini-2.5-pro": {
             "context": 1_048_576,
-            "max_output": 8192,
+            "max_output": 65_536,
             # NOTE: at >200k context price is 2x for input and 1.5x for output
             "price_input": 1.25,
             "price_output": 10,


### PR DESCRIPTION
## Summary

- Fix `gemini-2.5-pro` (GA) `max_output` from 8192 to 65,536 tokens

The GA `gemini-2.5-pro` model supports 65,536 output tokens ([Google docs](https://ai.google.dev/gemini-api/docs/models)), matching `gemini-2.5-flash` which already has the correct value. The 8,192 value was carried over from the preview model but the GA release increased the limit.

This was causing gptme to artificially cap Gemini 2.5 Pro responses at 8K tokens via the `max_tokens` API parameter.

## Test plan

- [x] Verified `get_model('gemini/gemini-2.5-pro').max_output == 65536`
- [ ] CI passes (lint, typecheck)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `max_output` for `gemini-2.5-pro` in `models.py` from 8192 to 65536 tokens to match GA release specifications.
> 
>   - **Behavior**:
>     - Fix `max_output` for `gemini-2.5-pro` in `models.py` from 8192 to 65536 tokens.
>     - Aligns with GA release specifications, preventing artificial capping at 8K tokens.
>   - **Testing**:
>     - Verified `get_model('gemini/gemini-2.5-pro').max_output == 65536`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 1f67bbb79a330cfa84569ae6f6e30210bc76500f. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->