### PR TITLE
fix(types): add mypy overrides for optional deps (dspy, playwright)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,6 +231,14 @@ ignore_missing_imports = true
 module = "flask.*"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "dspy.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "playwright.*"
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",


### PR DESCRIPTION
## Summary
- Add mypy override sections for `dspy.*` and `playwright.*` optional dependencies
- Follows existing pattern used for `opentelemetry`, `langchain`, `numpy`, `scipy`, `sounddevice`, `flask`
- Makes `make typecheck` pass cleanly (was showing 10 `import-not-found` errors)

These are optional extras that aren't installed in the standard dev environment, so mypy correctly can't find them. The override sections tell mypy to ignore missing imports for these specific modules.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add mypy overrides for `dspy` and `playwright` to ignore missing imports, ensuring `make typecheck` passes cleanly.
> 
>   - **Mypy Overrides**:
>     - Add mypy override for `dspy.*` to ignore missing imports.
>     - Add mypy override for `playwright.*` to ignore missing imports.
>   - **Consistency**:
>     - Follows existing pattern for optional dependencies like `opentelemetry`, `numpy`, `scipy`, etc.
>   - **Build**:
>     - Ensures `make typecheck` passes without `import-not-found` errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for e02124267effc1d5e4295ab0ab30248c422d8a45. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->