### PR TITLE
fix(tests): isolate server v2 test from user config

### DIFF
--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -102,6 +102,11 @@ def test_v2_create_conversation_default_system_prompt(
     monkeypatch.chdir(tmp_path)
     # Explicitly disable chat history for this test
     monkeypatch.setenv("GPTME_CHAT_HISTORY", "false")
+    # Isolate from user config (user-level prompt files can inject extra messages)
+    monkeypatch.setattr("gptme.config.config_path", str(tmp_path / "config.toml"))
+    from gptme.config import _config_var
+
+    _config_var.set(None)  # Force re-creation from isolated config path
 
     convname = f"test-server-v2-{random.randint(0, 1000000)}"
     response = client.put(


### PR DESCRIPTION
## Summary
- `test_v2_create_conversation_default_system_prompt` expects exactly 2 messages (system prompt + user message) but fails on developer machines where `~/.config/gptme/config.toml` has user-level prompt files configured
- User-configured files get injected as an extra "Selected files" system message, causing `assert len(data["log"]) == 2` to fail with 3 messages
- Fix isolates the test from user config by monkeypatching `config_path` and resetting the config ContextVar

## Test plan
- [x] `test_v2_create_conversation_default_system_prompt` passes with user config present
- [x] All 11 `test_server_v2.py` tests pass
- [x] Full test suite (1086 tests) passes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `test_v2_create_conversation_default_system_prompt` in `test_server_v2.py` to isolate from user config by monkeypatching `config_path` and resetting `_config_var`.
> 
>   - **Behavior**:
>     - Fixes `test_v2_create_conversation_default_system_prompt` in `test_server_v2.py` to isolate from user config by monkeypatching `config_path` and resetting `_config_var`.
>     - Ensures test expects exactly 2 messages (system prompt + user message) without interference from user-level prompt files.
>   - **Test Plan**:
>     - Confirms `test_v2_create_conversation_default_system_prompt` passes with user config present.
>     - All 11 tests in `test_server_v2.py` pass.
>     - Full test suite (1086 tests) passes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for c77bc591862816f84dbf773ca39a8fd89830a52c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->