### PR TITLE
fix(tests): register flaky and integration pytest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,6 +246,8 @@ markers = [
     "serial",
     "timeout: marks tests with timeout value in seconds",
     "requires_api: marks tests that require API access",
+    "flaky: marks tests as flaky (retried automatically)",
+    "integration: marks tests as integration tests requiring external services",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Summary
- Register `flaky` and `integration` pytest markers in `pyproject.toml` to eliminate 12 `PytestUnknownMarkWarning` warnings during test runs
- These marks are used in `test_cli.py` (`@pytest.mark.flaky`) and `test_execenv.py` (`@pytest.mark.integration`) but were never registered

## Test plan
- [x] No more `PytestUnknownMarkWarning` warnings in test output
- [x] Full test suite passes (1401 tests)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Register `flaky` and `integration` pytest markers in `pyproject.toml` to eliminate 12 warnings during test runs.
> 
>   - **Behavior**:
>     - Register `flaky` and `integration` pytest markers in `pyproject.toml` to eliminate 12 `PytestUnknownMarkWarning` warnings.
>     - These markers are used in `test_cli.py` and `test_execenv.py`.
>   - **Test Plan**:
>     - No more `PytestUnknownMarkWarning` warnings in test output.
>     - Full test suite passes (1401 tests).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for c4a63c4fb568d0baa1bec606ca3017b737e042e1. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->