### PR TITLE
fix(tests): remove stale xfail from test_shell_file

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -228,8 +228,6 @@ def test_shell(args: list[str], runner: CliRunner):
     assert result.exit_code == 0
 
 
-# Flaky in CI
-@pytest.mark.xfail(strict=False)
 def test_shell_file(args: list[str], runner: CliRunner):
     # test running the shell tool with a filename
     # make sure we don't accidentally expand the filename and include it in the shell command


### PR DESCRIPTION
## Summary
- Remove stale `@pytest.mark.xfail(strict=False)` from `test_shell_file` — the test now passes consistently
- The xfail was added with comment "Flaky in CI" but the underlying issue appears to be fixed

## Test plan
- [x] `test_shell_file` passes without xfail mark
- [x] Full test suite passes (1401 tests, 0 xpassed — clean)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove stale `@pytest.mark.xfail` from `test_shell_file` in `tests/test_cli.py` as the test now passes consistently.
> 
>   - **Tests**:
>     - Remove stale `@pytest.mark.xfail(strict=False)` from `test_shell_file` in `tests/test_cli.py` as the test now passes consistently.
>     - The xfail was originally added due to flakiness in CI, which is no longer an issue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 36a344b1ae0e9b24a09946969124a6d7a8b3f93f. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->