### PR TITLE
fix(message): drop timestamp from Message equality, add consistent __hash__

### DIFF
--- a/gptme/message.py
+++ b/gptme/message.py
@@ -112,14 +112,12 @@ class Message:
         return f"<Message role={self.role} content={content}>"
 
     def __eq__(self, other):
-        # FIXME: really include timestamp?
         if not isinstance(other, Message):
             return False
-        return (
-            self.role == other.role
-            and self.content == other.content
-            and self.timestamp == other.timestamp
-        )
+        return self.role == other.role and self.content == other.content
+
+    def __hash__(self):
+        return hash((self.role, self.content))
 
     def len_tokens(self, model: str) -> int:
         return len_tokens(self, model=model)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -307,6 +307,45 @@ def test_to_xml_handles_quotes_in_role():
     assert 'Test content with "quotes"' in xml_str
 
 
+def test_message_equality_ignores_timestamp():
+    """Test that Message equality is based on role and content, not timestamp."""
+    msg1 = Message("user", "Hello", timestamp=datetime(2025, 1, 1, tzinfo=timezone.utc))
+    msg2 = Message("user", "Hello", timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    msg3 = Message("user", "World", timestamp=datetime(2025, 1, 1, tzinfo=timezone.utc))
+    msg4 = Message(
+        "assistant", "Hello", timestamp=datetime(2025, 1, 1, tzinfo=timezone.utc)
+    )
+
+    # Same role + content = equal, regardless of timestamp
+    assert msg1 == msg2
+
+    # Different content = not equal
+    assert msg1 != msg3
+
+    # Different role = not equal
+    assert msg1 != msg4
+
+    # Not equal to non-Message
+    assert msg1 != "not a message"
+
+
+def test_message_hash_consistent_with_equality():
+    """Test that Message hash is consistent with equality (equal objects hash the same)."""
+    msg1 = Message("user", "Hello", timestamp=datetime(2025, 1, 1, tzinfo=timezone.utc))
+    msg2 = Message("user", "Hello", timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    msg3 = Message("user", "World")
+
+    # Equal messages must have equal hashes
+    assert hash(msg1) == hash(msg2)
+
+    # Different messages should (likely) have different hashes
+    assert hash(msg1) != hash(msg3)
+
+    # Messages work correctly in sets
+    s = {msg1, msg2, msg3}
+    assert len(s) == 2  # msg1 and msg2 are equal, so only 2 unique
+
+
 def test_toml_preserves_whitespace():
     """Test that from_toml preserves leading/trailing whitespace in content.
 


### PR DESCRIPTION
## Summary

- Drops timestamp from `Message.__eq__` — two messages with the same role and content are semantically equal regardless of when they were created
- Adds `__hash__` based on `(role, content)` to satisfy the hash/equality contract
- Resolves the `FIXME: really include timestamp?` comment that's been there since the custom `__eq__` was written

## Motivation

The previous `__eq__` included timestamp, making two identical messages unequal if created at different times. This is rarely the intended behavior — equality should be about semantic content, not metadata.

Additionally, the custom `__eq__` was inconsistent with the inherited identity-based `__hash__`, violating Python's hash/equality contract. This would cause incorrect behavior if Messages were ever used in sets or as dict keys (equal messages could appear as duplicates).

## Test plan

- [x] New `test_message_equality_ignores_timestamp` — verifies same role+content are equal regardless of timestamp
- [x] New `test_message_hash_consistent_with_equality` — verifies hash consistency and correct set behavior
- [x] All 16 existing message tests pass
- [x] Full fast test suite passes locally
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modifies `Message` class to ignore timestamp in equality checks and adds consistent `__hash__` implementation, with tests verifying the changes.
> 
>   - **Behavior**:
>     - Drops timestamp from `Message.__eq__` in `message.py`, making equality based on `role` and `content` only.
>     - Adds `__hash__` to `Message` based on `(role, content)` to ensure hash/equality consistency.
>   - **Tests**:
>     - Adds `test_message_equality_ignores_timestamp` in `test_message.py` to verify equality without timestamp.
>     - Adds `test_message_hash_consistent_with_equality` in `test_message.py` to verify hash consistency and set behavior.
>     - Confirms all 16 existing message tests pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 00b590194a65375456d3d7d202bd49816624da73. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->