### PR TITLE
fix(llm): update model metadata (xAI, Gemini 3, Anthropic)

### DIFF
--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -279,9 +279,26 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "knowledge_cutoff": datetime(2023, 8, 1),
         },
     },
-    # https://ai.google.dev/gemini-api/docs/models/gemini#gemini-1.5-flash
-    # https://ai.google.dev/pricing#1_5flash
+    # https://ai.google.dev/gemini-api/docs/models
+    # https://ai.google.dev/gemini-api/docs/pricing
     "gemini": {
+        "gemini-3.1-pro-preview": {
+            "context": 1_000_000,
+            "max_output": 64_000,
+            # NOTE: at >200k context price is 2x for input and 1.5x for output
+            "price_input": 2,
+            "price_output": 12,
+            "supports_vision": True,
+            "supports_reasoning": True,
+        },
+        "gemini-3-flash-preview": {
+            "context": 1_000_000,
+            "max_output": 64_000,
+            "price_input": 0.5,
+            "price_output": 3,
+            "supports_vision": True,
+            "supports_reasoning": True,
+        },
         "gemini-1.5-flash-latest": {
             "context": 1_048_576,
             "max_output": 8192,
@@ -314,7 +331,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
         },
         "gemini-2.5-pro-preview-05-06": {
             "context": 1_048_576,
-            "max_output": 8192,
+            "max_output": 65_536,
             # NOTE: at >200k context price is 2x for input and 1.5x for output
             "price_input": 1.25,
             "price_output": 10,


### PR DESCRIPTION
## Summary

Update model metadata across multiple providers:

### xAI
- Replace stale `grok-beta` and `grok-vision-beta` entries (no longer listed in [xAI docs](https://docs.x.ai/developers/models)) with current models: `grok-3`, `grok-3-mini`, `grok-2-vision-1212`

### Gemini
- Add `gemini-3.1-pro-preview` and `gemini-3-flash-preview` (new Google models)
- Fix `gemini-2.5-pro-preview-05-06` max_output: 8192 -> 65536 (matches GA model)

### Anthropic
- Add missing `knowledge_cutoff` to `claude-3-opus-20240229`

## Details

**xAI**: The grok-beta models were early beta releases superseded by the grok-2/3/4 family. Their metadata had guessed values (`# guess` comments). Replaced with current production models:

| Model | Context | Max Output | Price (in/out) |
|-------|---------|------------|----------------|
| grok-3 | 131K | 131K | $3/$15 |
| grok-3-mini | 131K | 131K | $0.30/$0.50 |
| grok-2-vision-1212 | 32K | 32K | $2/$10 |

**Gemini 3**: New preview models from Google ([pricing](https://ai.google.dev/gemini-api/docs/pricing)):

| Model | Context | Max Output | Price (in/out) |
|-------|---------|------------|----------------|
| gemini-3.1-pro-preview | 1M | 64K | $2/$12 |
| gemini-3-flash-preview | 1M | 64K | $0.50/$3 |

## Test plan

- [x] `tests/test_llm_models.py` — 25 tests pass
- [x] `tests/test_llm_validate.py` — passes
- [x] mypy typecheck clean