### PR TITLE
fix(logmanager): check all messages for modifications, not just first 3

### DIFF
--- a/gptme/logmanager.py
+++ b/gptme/logmanager.py
@@ -770,7 +770,7 @@ def delete_conversation(conv_id: str) -> bool:
 
 
 def check_for_modifications(log: Log) -> bool:
-    """Check if there are any file modifications in last 3 assistant messages since last user message."""
+    """Check if there are any file modifications in assistant messages since last user message."""
     messages_since_user = []
     found_user_message = False
 
@@ -786,17 +786,11 @@ def check_for_modifications(log: Log) -> bool:
     if not found_user_message:
         return False
 
-    # FIXME: this is hacky and unreliable
-
-    has_modifications = any(
+    return any(
         tu.tool in ["save", "patch", "append", "morph"]
-        for m in messages_since_user[:3]
+        for m in messages_since_user
         for tu in ToolUse.iter_from_content(m.content)
     )
-    # logger.debug(
-    #     f"Found {len(messages_since_user)} messages since user ({found_user_message=}, {has_modifications=})"
-    # )
-    return has_modifications
 
 
 def _gen_read_jsonl(path: PathLike) -> Generator[Message, None, None]:


### PR DESCRIPTION
## Summary

`check_for_modifications()` was only scanning the first 3 assistant messages after the last user message for file-modifying tool uses (`save`/`patch`/`append`/`morph`). This caused autocommit and precommit hooks to silently skip when agents made 4+ tool calls in a single response.

**Fix**: Remove the `[:3]` slice so all assistant messages since the last user prompt are checked.

**Tests**: Added 5 test cases:
- Basic tool use detection
- No tool use returns False
- **Regression test**: Modifications beyond the 3rd message are detected (would fail with old code)
- No user message returns False
- System messages are properly skipped

Closes the FIXME at `logmanager.py:789`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `check_for_modifications()` in `logmanager.py` to check all assistant messages for modifications and add comprehensive tests.
> 
>   - **Behavior**:
>     - Fix `check_for_modifications()` in `logmanager.py` to check all assistant messages for file modifications, not just the first 3.
>     - Handles cases with no user message and skips system messages.
>   - **Tests**:
>     - Add test cases in `test_logmanager.py` for tool use detection, no tool use, modifications beyond the third message, no user message, and skipping system messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for d05fa713c8e91bf64252e4be9a9da5ddfcf7cb8e. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->