### PR TITLE
fix(llm): fix tools API detection for custom providers

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -1012,7 +1012,7 @@ def _spec2tool(spec: ToolSpec, model: ModelMeta) -> "ChatCompletionToolParam":
         "openrouter",
         "deepseek",
         "local",
-    ] or is_custom_provider(model.model):
+    ] or is_custom_provider(model.model.split("/")[0]):
         return {
             "type": "function",
             "function": {

--- a/tests/test_custom_providers.py
+++ b/tests/test_custom_providers.py
@@ -1,5 +1,7 @@
 """Tests for custom OpenAI-compatible providers configuration."""
 
+from unittest.mock import patch
+
 from gptme.config import Config, ProviderConfig, UserConfig
 
 
@@ -75,6 +77,51 @@ def test_backward_compatibility_local_provider():
     # The "local" provider should still work using OPENAI_BASE_URL
     # This is tested in the init function with the existing elif branch
     pass
+
+
+def test_custom_provider_supports_tools_api():
+    """Test that custom providers support the tools API.
+
+    Regression test for https://github.com/gptme/gptme/issues/1330
+    Custom providers (e.g. llama-server) are OpenAI-compatible and should
+    support the tools API, but the check was failing because it passed the
+    full model path (e.g. 'sanctuary/gpt-oss') to is_custom_provider()
+    instead of just the provider name ('sanctuary').
+    """
+    from gptme.llm.llm_openai import _spec2tool
+    from gptme.llm.models import ModelMeta
+    from gptme.tools.base import Parameter, ToolSpec
+
+    # Create a minimal tool spec
+    spec = ToolSpec(
+        name="test_tool",
+        desc="A test tool",
+        instructions="Use this tool for testing",
+        parameters=[
+            Parameter(
+                name="arg",
+                type="string",
+                description="A test argument",
+                required=True,
+            ),
+        ],
+    )
+
+    # Simulate a custom provider model (provider="unknown", model="sanctuary/gpt-oss")
+    model = ModelMeta(provider="unknown", model="sanctuary/gpt-oss", context=128_000)
+
+    # Mock is_custom_provider to return True for "sanctuary"
+    with patch("gptme.llm.llm_openai.is_custom_provider") as mock_icp:
+        mock_icp.return_value = True
+        result = _spec2tool(spec, model)
+
+    # Verify the provider name was extracted correctly (not the full model path)
+    mock_icp.assert_called_once_with("sanctuary")
+
+    # Verify we got a valid tool definition back
+    assert result["type"] == "function"
+    assert result["function"]["name"] == "test_tool"
+    assert "parameters" in result["function"]
 
 
 # Example configuration that would be in gptme.toml:


### PR DESCRIPTION
## Summary
- Fixed `_spec2tool()` passing full model path (e.g. `sanctuary/gpt-oss`) to `is_custom_provider()` instead of just the provider name (`sanctuary`)
- Added regression test verifying custom providers are recognized for tools API

## Context
When a user configures a custom OpenAI-compatible provider (like llama-server) in `config.toml` and uses `--tool-format tool`, they get "Provider doesn't support tools API" even though the provider supports it.

**Root cause**: `get_model()` stores custom providers with `provider="unknown"` and `model="provider-name/model-name"`. The tool support check called `is_custom_provider(model.model)` which passed the full path — but `is_custom_provider()` expects just the provider name.

**Fix**: Extract provider prefix with `.split("/")[0]` before the check.

Fixes #1330

## Test plan
- [ ] New test `test_custom_provider_supports_tools_api` passes
- [ ] Existing custom provider tests still pass (5/5)
- [ ] CI green
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `_spec2tool()` to correctly detect custom providers for tools API and add regression test.
> 
>   - **Behavior**:
>     - Fix `_spec2tool()` in `llm_openai.py` to pass only provider name to `is_custom_provider()`.
>     - Handles custom providers correctly for tools API.
>   - **Testing**:
>     - Add `test_custom_provider_supports_tools_api` in `test_custom_providers.py` to verify custom provider tool support.
>     - Mock `is_custom_provider` to ensure correct provider name extraction.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for e773f6a6a42e5f32438df83f21c59b1588e255c0. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->