### PR TITLE
fix(llm): add missing Gemini model entries (3-pro-preview, 2.0-flash)

### DIFF
--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -291,6 +291,14 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_vision": True,
             "supports_reasoning": True,
         },
+        "gemini-3-pro-preview": {
+            "context": 1_000_000,
+            "max_output": 64_000,
+            "price_input": 2,
+            "price_output": 12,
+            "supports_vision": True,
+            "supports_reasoning": True,
+        },
         "gemini-3-flash-preview": {
             "context": 1_000_000,
             "max_output": 64_000,
@@ -298,6 +306,13 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 3,
             "supports_vision": True,
             "supports_reasoning": True,
+        },
+        "gemini-2.0-flash": {
+            "context": 1_048_576,
+            "max_output": 8192,
+            "price_input": 0.10,
+            "price_output": 0.40,
+            "supports_vision": True,
         },
         "gemini-1.5-flash-latest": {
             "context": 1_048_576,


### PR DESCRIPTION
## Summary

Adds two Gemini models missing from the static metadata:

- **gemini-3-pro-preview**: Google's reasoning model between 3-flash and 3.1-pro (1M context, 64k output, $2/$12 per Mtok, vision + reasoning)
- **gemini-2.0-flash**: widely-used base Flash model (1M context, 8k output, $0.10/$0.40 per Mtok, vision). The -lite and -thinking-exp variants were present but the base model was missing.

## Test plan

- [x] All 12 `test_llm_models.py` tests pass
- [x] mypy clean on `gptme/llm/models.py`
- [x] Model metadata loads correctly and shows expected values
- [ ] CI passes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add missing Gemini models `gemini-3-pro-preview` and `gemini-2.0-flash` to `gptme/llm/models.py`.
> 
>   - **Models**:
>     - Add `gemini-3-pro-preview` to `MODELS` in `models.py` with 1M context, 64k output, $2/$12 per Mtok, vision and reasoning support.
>     - Add `gemini-2.0-flash` to `MODELS` in `models.py` with 1M context, 8k output, $0.10/$0.40 per Mtok, vision support.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 1bba0293e2b6d47c61f10ffb999acef27696a80b. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->