### PR TITLE
chore: remove stale TODO comments

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -1785,8 +1785,6 @@ def _find_max_heredoc_pos(node, current_max: int = 0) -> int:
 
 
 def split_commands(script: str) -> list[str]:
-    # TODO: write proper tests
-
     # Preprocess script to handle quoted heredoc delimiters that bashlex can't parse
     processed_script = _preprocess_quoted_heredocs(script)
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -8,8 +8,7 @@ from gptme.eval.main import main
 
 
 def _detect_model():
-    # detect which model is configured
-    # TODO: isn't there already a get_default_model() helper?
+    # detect which model is configured (manual since init() hasn't run in tests)
     config = get_config()
     if model := config.get_env("MODEL"):
         return model


### PR DESCRIPTION
## Summary

- Remove `# TODO: write proper tests` from `split_commands()` in shell.py — comprehensive tests already exist in `test_tools_shell.py` and `test_tools_shell_multiline.py` (54 tests covering multiline commands, heredocs, loops, etc.)
- Remove stale `# TODO: isn't there already a get_default_model() helper?` from `test_eval.py` — yes the helper exists, but it requires `init()` to have run, so the manual config-based detection is correct for the test context

## Test plan

- [x] All 54 shell tool tests pass locally
- [ ] CI checks pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove stale TODO comments from `split_commands()` in `shell.py` and `test_eval.py`.
> 
>   - **Comments**:
>     - Remove `# TODO: write proper tests` from `split_commands()` in `shell.py` as tests exist in `test_tools_shell.py` and `test_tools_shell_multiline.py`.
>     - Remove `# TODO: isn't there already a get_default_model() helper?` from `test_eval.py` since manual detection is correct for the test context.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for fdc6ccc051076c1c2b038c182733e6722286b752. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->