### PR TITLE
fix(llm): add GPT-5.3-Codex and Codex-Spark to subscription models

### DIFF
--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -141,6 +141,8 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_reasoning": True,
         }
         for model in [
+            "gpt-5.3-codex",
+            "gpt-5.3-codex-spark",
             "gpt-5.2",
             "gpt-5.2-codex",
             "gpt-5.1-codex-max",


### PR DESCRIPTION
## Summary

- Add `gpt-5.3-codex` and `gpt-5.3-codex-spark` to the `openai-subscription` provider
- GPT-5.3-Codex released Feb 5, 2026 — most capable agentic coding model, available through Codex app/CLI/IDE for ChatGPT Plus/Pro subscribers
- GPT-5.3-Codex-Spark released Feb 13, 2026 — ultra-fast research preview (1000+ tok/sec on Cerebras), ChatGPT Pro only

## Context

These models are currently available through the ChatGPT subscription (Codex product) but not yet through the standard OpenAI API. The `openai-subscription` provider is the correct place for them.

## Test plan

- [x] Verified model entries are syntactically correct
- [ ] CI passes (model metadata only, no logic changes)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `gpt-5.3-codex` and `gpt-5.3-codex-spark` to `openai-subscription` in `models.py`.
> 
>   - **Models**:
>     - Add `gpt-5.3-codex` and `gpt-5.3-codex-spark` to `openai-subscription` in `models.py`.
>     - Both models share the same specifications as existing models in the subscription.
>   - **Misc**:
>     - No logic changes, only model metadata updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for e68e21fa9b3605b8e58cb3dbbc8d1b7eb8282ad0. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->