### PR TITLE
fix(llm): add missing -latest model aliases for Anthropic

### DIFF
--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -243,6 +243,15 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_reasoning": True,
             "knowledge_cutoff": datetime(2024, 10, 1),
         },
+        "claude-3-7-sonnet-latest": {
+            "context": 200_000,
+            "max_output": 8192,
+            "price_input": 3,
+            "price_output": 15,
+            "supports_vision": True,
+            "supports_reasoning": True,
+            "knowledge_cutoff": datetime(2024, 10, 1),
+        },
         "claude-3-5-sonnet-20241022": {
             "context": 200_000,
             "max_output": 8192,
@@ -258,7 +267,23 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 15,
             "knowledge_cutoff": datetime(2024, 4, 1),
         },
+        "claude-3-5-sonnet-latest": {
+            "context": 200_000,
+            "max_output": 8192,
+            "price_input": 3,
+            "price_output": 15,
+            "supports_vision": True,
+            "knowledge_cutoff": datetime(2024, 4, 1),
+        },
         "claude-3-5-haiku-20241022": {
+            "context": 200_000,
+            "max_output": 8192,
+            "price_input": 1,
+            "price_output": 5,
+            "supports_vision": True,
+            "knowledge_cutoff": datetime(2024, 4, 1),
+        },
+        "claude-3-5-haiku-latest": {
             "context": 200_000,
             "max_output": 8192,
             "price_input": 1,
@@ -274,6 +299,13 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "knowledge_cutoff": datetime(2024, 4, 1),
         },
         "claude-3-opus-20240229": {
+            "context": 200_000,
+            "max_output": 4096,
+            "price_input": 15,
+            "price_output": 75,
+            "knowledge_cutoff": datetime(2023, 8, 1),
+        },
+        "claude-3-opus-latest": {
             "context": 200_000,
             "max_output": 4096,
             "price_input": 15,


### PR DESCRIPTION
## Summary

Adds the official Anthropic `-latest` model aliases to the model metadata dict:

- `claude-3-7-sonnet-latest` (same specs as `claude-3-7-sonnet-20250219`)
- `claude-3-5-sonnet-latest` (same specs as `claude-3-5-sonnet-20241022`)
- `claude-3-5-haiku-latest` (same specs as `claude-3-5-haiku-20241022`)
- `claude-3-opus-latest` (same specs as `claude-3-opus-20240229`)

## Why

Without these entries, using a `-latest` alias (which many users and docs reference) triggers the fallback path in `get_model()`, which logs a warning and returns generic metadata without pricing, vision, or reasoning capability info. The `_find_base_model_properties` helper only handles date suffixes like `-20250219`, not `-latest`.

These are the officially documented aliases per the Anthropic SDK (`anthropic.types.model.Model`).

Note: Claude 4.x models don't have `-latest` aliases — they use unversioned names (e.g. `claude-sonnet-4-6`) directly.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds missing `-latest` model aliases for Anthropic in `models.py` to prevent fallback behavior in `get_model()`.
> 
>   - **Behavior**:
>     - Adds `-latest` model aliases for Anthropic models in `models.py`.
>     - Prevents fallback path in `get_model()` for `-latest` aliases by providing specific metadata.
>   - **Models**:
>     - Adds `claude-3-7-sonnet-latest`, `claude-3-5-sonnet-latest`, `claude-3-5-haiku-latest`, and `claude-3-opus-latest` to `MODELS` dictionary.
>     - Each alias has the same specs as their respective dated versions.
>   - **Misc**:
>     - Clarifies that Claude 4.x models do not use `-latest` aliases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 74b51305fe5d6a55625449a9548a36d1d314c04b. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->