### PR TITLE
chore: remove dead browser tests and fix shell.py type safety

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -478,8 +478,10 @@ class ShellSession:
             universal_newlines=True,
             start_new_session=True,  # Create new process group for proper signal handling
         )
-        self.stdout_fd = self.process.stdout.fileno()  # type: ignore[union-attr]
-        self.stderr_fd = self.process.stderr.fileno()  # type: ignore[union-attr]
+        assert self.process.stdout is not None
+        assert self.process.stderr is not None
+        self.stdout_fd = self.process.stdout.fileno()
+        self.stderr_fd = self.process.stderr.fileno()
         self.delimiter = "END_OF_COMMAND_OUTPUT"
         self.start_marker = "START_OF_COMMAND_OUTPUT"
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -7,22 +7,6 @@ playwright = pytest.importorskip("playwright")
 from gptme.tools.browser import read_url, search  # fmt: skip
 
 
-# FIXME: Broken? ~~Seems to work, for now~~ edit: not anymore
-@pytest.mark.skip
-@pytest.mark.slow
-def test_search_ddg():
-    results = search("test", "duckduckgo")
-    assert "1." in results, f"{results=}"
-
-
-# FIXME: Broken, sometimes hits CAPTCHA
-@pytest.mark.skip
-@pytest.mark.slow
-def test_search_google():
-    results = search("test", "google")
-    assert "1." in results, f"{results=}"
-
-
 @pytest.mark.slow
 def test_read_url_with_links():
     s = read_url("https://superuserlabs.org")
@@ -32,13 +16,6 @@ def test_read_url_with_links():
 
     # check that link to activitywatch is present
     assert "https://activitywatch.net/" in s
-
-
-@pytest.mark.slow
-def test_read_url_arxiv_html():
-    # TODO: test that we can read it in a reasonable amount of tokens
-    # url = "https://arxiv.org/html/2410.12361v2"
-    pass
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary

- Remove 3 dead/broken browser tests that were permanently skipped
- Fix 2 `type: ignore[union-attr]` suppressions in shell.py with proper asserts

## Changes

**tests/test_browser.py:**
- Remove `test_search_ddg` — permanently skipped, broken due to DuckDuckGo blocking automated requests
- Remove `test_search_google` — permanently skipped, broken due to CAPTCHAs
- Remove `test_read_url_arxiv_html` — empty placeholder (just `pass`)
- All remaining tests are functional and exercised in CI

**gptme/tools/shell.py:**
- Replace `type: ignore[union-attr]` on `process.stdout.fileno()` and `process.stderr.fileno()` with explicit `assert` guards
- These are always non-None since `Popen` is called with `stdout=PIPE, stderr=PIPE`, but mypy can't prove it statically
- Assert pattern is idiomatic and provides a clear runtime error message if the invariant ever breaks

## Test plan
- [ ] CI passes (lint, typecheck, tests)
- [ ] No behavior changes — only removes dead code and improves type safety
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove dead browser tests and improve type safety in `shell.py` by replacing type ignores with assertions.
> 
>   - **Tests**:
>     - Remove `test_search_ddg`, `test_search_google`, and `test_read_url_arxiv_html` from `test_browser.py` as they were permanently skipped or placeholders.
>   - **Type Safety**:
>     - Replace `type: ignore[union-attr]` with `assert` statements for `process.stdout.fileno()` and `process.stderr.fileno()` in `shell.py` to ensure non-None values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for b9229559e3e13100f2915976d21f95d867c4ee9b. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->