### PR TITLE
chore: remove redundant assert and str() calls

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -123,7 +123,7 @@ def mcp_list():
                 )
                 click.echo(f"   Tools: {', '.join(tool_names)}{more}")
         except Exception as e:
-            click.echo(f"   Status: ❌ Connection failed: {str(e)}")
+            click.echo(f"   Status: ❌ Connection failed: {e}")
 
         click.echo()
 
@@ -161,7 +161,7 @@ def mcp_test(server_name: str):
             click.echo(f"   • {tool.name}: {tool.description or 'No description'}")
 
     except Exception as e:
-        click.echo(f"❌ Connection failed: {str(e)}")
+        click.echo(f"❌ Connection failed: {e}")
 
 
 @mcp.command("info")

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -231,7 +231,7 @@ def _handle_anthropic_transient_error(e, attempt, max_retries, base_delay):
         f"retrying in {delay}s (attempt {attempt + 1}/{max_retries})"
     )
     if status_code in [200, "200"]:
-        logger.warning(f"Status code was strangely 200. Error details: {str(e)}")
+        logger.warning(f"Status code was strangely 200. Error details: {e}")
     time.sleep(delay)
 
 

--- a/gptme/llm/utils.py
+++ b/gptme/llm/utils.py
@@ -170,7 +170,7 @@ def process_image_file(
     try:
         data_bytes = f.read_bytes()
     except Exception as e:
-        logger.error("Error reading file %s: %s", file_path, str(e))
+        logger.error("Error reading file %s: %s", file_path, e)
         content_parts.append(
             {
                 "type": "text",

--- a/gptme/tools/_browser_perplexity.py
+++ b/gptme/tools/_browser_perplexity.py
@@ -102,7 +102,7 @@ def search_perplexity(query: str) -> str:
         return msg.content
 
     except Exception as e:
-        return f"Error searching with Perplexity: {str(e)}"
+        return f"Error searching with Perplexity: {e}"
 
 
 def has_perplexity_key() -> bool:

--- a/gptme/tools/_browser_playwright.py
+++ b/gptme/tools/_browser_playwright.py
@@ -121,7 +121,7 @@ def _load_page(browser: Browser, url: str) -> str:
         # Wait for page to be fully loaded (includes network idle)
         page.wait_for_load_state("networkidle")
     except Exception as e:
-        page_errors.append(f"Navigation error: {str(e)}")
+        page_errors.append(f"Navigation error: {e}")
         # Don't re-raise, just capture the error
 
     # Store logs globally

--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -475,7 +475,7 @@ def _read_pdf_url(url: str, max_pages: int | None = None) -> str:
 
     except Exception as e:
         logger.error(f"Error reading PDF: {e}")
-        return f"Error reading PDF: {str(e)}"
+        return f"Error reading PDF: {e}"
 
 
 def read_url(url: str, max_pages: int | None = None) -> str:

--- a/gptme/tools/morph.py
+++ b/gptme/tools/morph.py
@@ -87,7 +87,7 @@ def preview_morph(content: str, path: Path | None) -> str | None:
         return "\n".join(diff_lines)
 
     except Exception as e:
-        return f"Preview failed: {str(e)}"
+        return f"Preview failed: {e}"
 
 
 def execute_morph(
@@ -132,7 +132,7 @@ def execute_morph(
             messages, "openrouter/morph/morph-v3-fast", tools=None
         )
     except Exception as e:
-        yield Message("system", f"Error: failed Morph API call: {str(e)}")
+        yield Message("system", f"Error: failed Morph API call: {e}")
         return
 
     edited_content = response.strip()
@@ -230,7 +230,7 @@ def execute_morph_impl(
             f"Morph failed: Permission denied when writing to `{path}`"
         ) from None
     except Exception as e:
-        raise ValueError(f"Morph failed: {str(e)}") from e
+        raise ValueError(f"Morph failed: {e}") from e
 
 
 tool = ToolSpec(

--- a/gptme/tools/tmux.py
+++ b/gptme/tools/tmux.py
@@ -106,7 +106,6 @@ def _run_tmux_command(cmd: list[str]) -> subprocess.CompletedProcess:
         capture_output=True,
         text=True,
     )
-    assert result.returncode == 0
     print(result.stdout, result.stderr)
     return result
 


### PR DESCRIPTION
## Summary
Three categories of cleanup:

### 1. Fix incorrect GPT-4.1 knowledge cutoff
The GPT-4.1 family (`gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`) had `knowledge_cutoff` set to `2025-03-01`, but [OpenAI's official documentation](https://openai.com/index/gpt-4-1/) states their cutoff is **June 2024**. Fixed all three entries.

### 2. Replace `print()` with `logger.warning()` in Anthropic streaming
A stray `print(f"Unknown block type: {block}")` in the Anthropic streaming handler was the only inconsistent logging call — all other unknown-type handling in the same function uses `logger.warning()`.

### 3. Remove dead code and redundant patterns
- Remove dead `assert result.returncode == 0` in `tmux.py` — unreachable because `subprocess.run(check=True)` already raises `CalledProcessError`
- Remove redundant `str(e)` in f-strings across 7 files — f-strings implicitly call `__str__()`

## Test plan
- [x] All 12 model metadata tests pass
- [x] All 10 tmux tool tests pass
- [x] mypy clean on all modified files
- [ ] CI passes