### PR TITLE
fix(chat): improve thread safety and None guard in auto-naming

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import os
 import sys
@@ -352,12 +353,18 @@ def _process_message_conversation(
                 # Start naming in background thread (daemon so it doesn't block exit)
                 # Get current model dynamically (model param may be None)
                 current_model = get_default_model()
-                thread = threading.Thread(
-                    target=_auto_name_thread,
-                    args=(chat_config, manager.log.messages.copy(), current_model),
-                    daemon=True,
-                )
-                thread.start()
+                if current_model:
+                    # deepcopy to prevent shared state with main thread
+                    thread = threading.Thread(
+                        target=_auto_name_thread,
+                        args=(
+                            chat_config,
+                            copy.deepcopy(manager.log.messages),
+                            current_model.full,
+                        ),
+                        daemon=True,
+                    )
+                    thread.start()
 
         # Check if there are any runnable tools left
         last_content = next(


### PR DESCRIPTION
## Summary

Applies the thread safety improvements from #1088 (by @loftybuilder), without the `logger.exception` change that @ErikBjare requested be kept as `logger.warning`.

**Changes:**
- Use `copy.deepcopy()` instead of `.copy()` when passing messages to the background auto-naming thread — prevents shared mutable state that could cause data races
- Add `if current_model:` guard before starting the thread — prevents `AttributeError` when no default model is configured
- Pass `current_model.full` (str) instead of the `ModelMeta` object — matches the expected `model_name: str` parameter type

**Not included:**
- `logger.exception()` change (reverted to `logger.warning(f"...")` per @ErikBjare's feedback on #1088)

Closes #1088 (supersedes it with the cleaner version).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves thread safety and adds a `None` guard in `gptme/chat.py` for auto-naming, ensuring correct parameter types and consistent logging.
> 
>   - **Thread Safety**:
>     - Use `copy.deepcopy()` instead of `.copy()` in `gptme/chat.py` to prevent shared mutable state in `_auto_name_thread()`.
>   - **None Guard**:
>     - Add `if current_model:` guard in `gptme/chat.py` to prevent `AttributeError` when no default model is configured.
>   - **Parameter Type**:
>     - Pass `current_model.full` (str) instead of `ModelMeta` object to `_auto_name_thread()` in `gptme/chat.py`.
>   - **Logging**:
>     - Revert `logger.exception()` to `logger.warning()` as per feedback.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for ca6c1cb22fdf84ba82d68fac483c2150a7263739. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->