### PR TITLE
fix(llm): correct GPT-4.1 knowledge cutoff to June 2024

### DIFF
--- a/gptme/llm/llm_openai_models.py
+++ b/gptme/llm/llm_openai_models.py
@@ -43,7 +43,7 @@ OPENAI_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_input": 2,
         "price_output": 8,
         "supports_vision": True,
-        "knowledge_cutoff": datetime(2025, 3, 1),
+        "knowledge_cutoff": datetime(2024, 6, 1),
     },
     "gpt-4.1-mini": {
         "context": 1_047_576,
@@ -51,7 +51,7 @@ OPENAI_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_input": 0.4,
         "price_output": 1.6,
         "supports_vision": True,
-        "knowledge_cutoff": datetime(2025, 3, 1),
+        "knowledge_cutoff": datetime(2024, 6, 1),
     },
     "gpt-4.1-nano": {
         "context": 1_047_576,
@@ -59,7 +59,7 @@ OPENAI_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_input": 0.1,
         "price_output": 0.4,
         "supports_vision": True,
-        "knowledge_cutoff": datetime(2025, 3, 1),
+        "knowledge_cutoff": datetime(2024, 6, 1),
     },
     # GPT-4o
     "gpt-4o": {


### PR DESCRIPTION
## Summary

- Fix GPT-4.1 family knowledge cutoff: `2025-03-01` → `2024-06-01`
- Affects: `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`

The cutoff was incorrectly set to March 2025. Per [OpenAI's official documentation](https://openai.com/index/gpt-4-1/), the GPT-4.1 family has a knowledge cutoff of June 2024.

This fix was originally part of PR #1340 but was lost during squash merge (the additional commits were pushed after the initial CI passed and the PR was merged by the monitoring bot).

## Test plan

- [x] `tests/test_llm_models.py` — 12/12 passing
- [x] Verified against [OpenAI docs](https://openai.com/index/gpt-4-1/) and [community tracker](https://github.com/HaoooWang/llm-knowledge-cutoff-dates)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects GPT-4.1 models' knowledge cutoff date to June 2024 in `llm_openai_models.py`.
> 
>   - **Behavior**:
>     - Corrects `knowledge_cutoff` for `gpt-4.1`, `gpt-4.1-mini`, and `gpt-4.1-nano` in `llm_openai_models.py` from `2025-03-01` to `2024-06-01`.
>   - **Testing**:
>     - All tests in `tests/test_llm_models.py` pass (12/12).
>     - Verified against OpenAI documentation and community tracker.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 84898b79e4ce48aa662aec13eb38fb23523c23d0. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->