### PR TITLE
docs: update stale xai model example (grok-beta → grok-4)

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -24,7 +24,7 @@ To select a provider and model, run ``gptme`` with the ``-m``/``--model`` flag s
     gptme "hello" -m deepseek/deepseek-reasoner
     gptme "hello" -m gemini/gemini-2.5-flash
     gptme "hello" -m groq/llama-3.3-70b-versatile
-    gptme "hello" -m xai/grok-beta
+    gptme "hello" -m xai/grok-4
     gptme "hello" -m local/llama3.2:1b
 
 You can list the models known to gptme using ``gptme '/models' - '/exit'``


### PR DESCRIPTION
## Summary

- Update `xai/grok-beta` → `xai/grok-4` in providers.rst example
- `grok-beta` is no longer in the model metadata (replaced by grok-4 family)
- Aligns docs with the current recommended model (`get_recommended_model()` returns `grok-4` for xAI)

## Test plan

- [x] Docs-only change, no code affected
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `xai/grok-beta` to `xai/grok-4` in `providers.rst` to reflect current model recommendations.
> 
>   - **Documentation**:
>     - Update `xai/grok-beta` to `xai/grok-4` in `providers.rst` example.
>     - Aligns with current model metadata and `get_recommended_model()` output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 1a351e64e89cf12404f60b2c15ccddfca2c484da. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->