### PR TITLE
chore: remove 6 unused type: ignore comments

### DIFF
--- a/gptme/acp/__main__.py
+++ b/gptme/acp/__main__.py
@@ -42,18 +42,18 @@ class _WritePipeProtocol(asyncio.BaseProtocol):
         self._drain_waiter: asyncio.Future[None] | None = None
         self._connection_lost = False
 
-    def pause_writing(self) -> None:  # type: ignore[override]
+    def pause_writing(self) -> None:
         self._paused = True
         if self._drain_waiter is None:
             self._drain_waiter = self._loop.create_future()
 
-    def resume_writing(self) -> None:  # type: ignore[override]
+    def resume_writing(self) -> None:
         self._paused = False
         if self._drain_waiter is not None and not self._drain_waiter.done():
             self._drain_waiter.set_result(None)
         self._drain_waiter = None
 
-    def connection_lost(self, exc: Exception | None) -> None:  # type: ignore[override]
+    def connection_lost(self, exc: Exception | None) -> None:
         self._connection_lost = True
         if self._drain_waiter is not None and not self._drain_waiter.done():
             if exc is None:

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -74,7 +74,7 @@ class CommaSeparatedChoice(click.ParamType):
 
     def get_metavar(
         self, param: click.Parameter, ctx: click.Context | None = None
-    ) -> str | None:  # type: ignore[override]
+    ) -> str | None:
         if self._metavar:
             return self._metavar
         return "[" + "|".join(self.choices) + "]"

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -108,7 +108,7 @@ def init_model(
 
     # set up API_KEY and API_BASE, needs to be done before loading history to avoid saving API_KEY
     if model_name is None:
-        model_name = get_recommended_model(provider)  # type: ignore[arg-type]
+        model_name = get_recommended_model(provider)
     model_full = f"{provider}/{model_name}"
     console.log(f"Using model: [green]{model_full}[/green]")
     init_llm(provider)

--- a/gptme/lessons/matcher_enhanced.py
+++ b/gptme/lessons/matcher_enhanced.py
@@ -79,7 +79,7 @@ class EnhancedLessonMatcher(LessonMatcher):
         selector = self._get_selector()
         selected_items = selector.select(
             query=context.message,
-            candidates=lesson_items,  # type: ignore[arg-type]
+            candidates=lesson_items,
             max_results=max_results,
         )
 


### PR DESCRIPTION
## Summary
- Removed 6 unused `type: ignore` comments identified by `mypy --warn-unused-ignores`
- Files: `init.py`, `cli/main.py`, `acp/__main__.py` (3), `lessons/matcher_enhanced.py`
- Kept all `import-not-found` ignores in `acp/` files since `acp` is an optional dependency

## Details

| File | Removed Ignore | Reason |
|------|---------------|--------|
| `gptme/init.py:111` | `[arg-type]` | Type now matches |
| `gptme/cli/main.py:77` | `[override]` | Signature now compatible |
| `gptme/acp/__main__.py:45,50,56` | `[override]` | `asyncio.BaseProtocol` method signatures now match |
| `gptme/lessons/matcher_enhanced.py:82` | `[arg-type]` | Type now matches |

## Test plan
- [ ] CI typecheck passes (mypy without `--warn-unused-ignores`)
- [ ] Verify no regressions in lint or test jobs
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove 6 unused `type: ignore` comments from various files, improving type clarity.
> 
>   - **Behavior**:
>     - Removed 6 unused `type: ignore` comments identified by `mypy --warn-unused-ignores`.
>     - Retained `import-not-found` ignores in `acp/` files for optional dependency.
>   - **Files**:
>     - `init.py`: Removed `[arg-type]` ignore at line 111.
>     - `cli/main.py`: Removed `[override]` ignore at line 77.
>     - `acp/__main__.py`: Removed `[override]` ignores at lines 45, 50, 56.
>     - `lessons/matcher_enhanced.py`: Removed `[arg-type]` ignore at line 82.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 26c8bd9670cb0cd03b0f2e274d222afe317153c3. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->