### PR TITLE
fix(llm): mark claude-3-opus-latest as deprecated

### DIFF
--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -318,6 +318,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 15,
             "price_output": 75,
             "knowledge_cutoff": datetime(2023, 8, 1),
+            "deprecated": True,  # resolves to claude-3-opus-20240229 (deprecated)
         },
     },
     # https://ai.google.dev/gemini-api/docs/models


### PR DESCRIPTION
## Summary

- Mark `claude-3-opus-latest` as deprecated, consistent with `claude-3-opus-20240229` which it resolves to

The `-latest` alias resolves to `claude-3-opus-20240229` which is already marked `deprecated: True` (superseded by claude-opus-4+). Without this fix, `gptme models` lists `claude-3-opus-latest` as an active model, which could mislead users into selecting a deprecated model.

## Test plan

- [x] `mypy` passes
- [x] All 12 model tests pass (`tests/test_llm_models.py`)
- [ ] CI passes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Mark `claude-3-opus-latest` as deprecated in `models.py`, aligning with its resolved model `claude-3-opus-20240229`.
> 
>   - **Behavior**:
>     - Mark `claude-3-opus-latest` as deprecated in `models.py`, aligning with `claude-3-opus-20240229` which it resolves to.
>     - Prevents `gptme models` from listing `claude-3-opus-latest` as active, avoiding user confusion.
>   - **Testing**:
>     - `mypy` and all 12 model tests in `tests/test_llm_models.py` pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 32c1fa4d376423657e4725abe4277fc45a653feb. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->