### PR TITLE
refactor(llm): replace duplicate model entries with MODEL_ALIASES

### DIFF
--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -650,7 +650,7 @@ def _find_base_model_properties(
     if provider in MODEL_ALIASES and model_name in MODEL_ALIASES[provider]:
         canonical = MODEL_ALIASES[provider][model_name]
         if canonical in provider_models:
-            logger.debug(f"Resolved alias {model_name} -> {canonical}")
+            logger.info(f"Resolved alias {model_name} -> {canonical}")
             return provider_models[canonical]
 
     # Try stripping date suffix (e.g., -20250929) to find base model


### PR DESCRIPTION
## Summary

Follow-up to #1347 per Erik's review feedback. Replaces the duplicated metadata entries with a proper `MODEL_ALIASES` dict that maps short alias names to their canonical model IDs.

**Before (#1347)**: 3 duplicate entries (27 lines of repeated metadata)
**After**: `MODEL_ALIASES` dict (10 lines) + resolution in `_find_base_model_properties` (6 lines)

Adding a new alias is now a one-liner in the dict instead of copying an entire metadata block.

```python
MODEL_ALIASES: dict[str, dict[str, str]] = {
    "anthropic": {
        "claude-opus-4-1": "claude-opus-4-1-20250805",
        "claude-opus-4-0": "claude-opus-4-20250514",
        "claude-sonnet-4-0": "claude-sonnet-4-20250514",
    },
}
```

Resolution happens in `_find_base_model_properties` (after exact match fails, before date suffix stripping), so the lookup chain is:
1. Exact match in MODELS dict
2. Alias resolution via MODEL_ALIASES
3. Date suffix stripping (existing)
4. Provider-specific fallback (existing)

## Test plan

- [x] All 12 `test_llm_models.py` tests pass
- [x] mypy clean on `models.py`
- [x] Manual verification: all 3 aliases resolve to correct metadata
- [x] Canonical names and latest models still work
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `models.py` to use `MODEL_ALIASES` for alias resolution, reducing duplicate metadata entries and simplifying alias management.
> 
>   - **Behavior**:
>     - Introduces `MODEL_ALIASES` in `models.py` to map short alias names to canonical model IDs, reducing duplicate metadata entries.
>     - Updates `_find_base_model_properties` to resolve aliases before stripping date suffixes.
>   - **Tests**:
>     - All tests in `test_llm_models.py` pass.
>     - Manual verification confirms correct alias resolution.
>   - **Misc**:
>     - Removes duplicate model metadata entries for aliases in `models.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 0fb6684a883653ecd8d189d63d69d22e6254bf5e. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->