### PR TITLE
chore: update deprecated model references and remove stale noqa

### DIFF
--- a/gptme/commands/export.py
+++ b/gptme/commands/export.py
@@ -116,7 +116,7 @@ def _replay_tool(log, tool_name: str) -> None:
     count = 0
 
     for msg in log:
-        for tooluse in ToolUse.iter_from_content(msg.content):  # noqa: F821 - ToolUse imported above
+        for tooluse in ToolUse.iter_from_content(msg.content):
             if tooluse.tool == tool_name and tooluse.content:
                 count += 1
                 # Execute the tool operation

--- a/gptme/hooks/form_autodetect.py
+++ b/gptme/hooks/form_autodetect.py
@@ -96,7 +96,7 @@ def _parse_options_with_llm(content: str) -> dict | None:
     fast_models = [
         "anthropic/claude-haiku-4-5",  # ~0.25s response
         "openai/gpt-4o-mini",  # ~0.3s response
-        "anthropic/claude-3-haiku-20240307",  # fallback
+        "anthropic/claude-3-5-haiku-20241022",  # fallback
     ]
 
     # Try to find an available fast model

--- a/gptme/llm/validate.py
+++ b/gptme/llm/validate.py
@@ -110,7 +110,7 @@ def _validate_anthropic(api_key: str, timeout: int) -> tuple[bool, str]:
             "content-type": "application/json",
         },
         json={
-            "model": "claude-3-haiku-20240307",
+            "model": "claude-haiku-4-5",
             "max_tokens": 1,
             "messages": [],  # Empty messages will fail validation but key is checked first
         },


### PR DESCRIPTION
## Summary
- Update two references to deprecated `claude-3-haiku-20240307` model
- Remove stale `noqa: F821` comment where `ToolUse` is properly imported

## Changes
- **`gptme/hooks/form_autodetect.py`**: Updated fallback model in `fast_models` list from `claude-3-haiku-20240307` → `claude-3-5-haiku-20241022`
- **`gptme/llm/validate.py`**: Updated model in API key validation request from `claude-3-haiku-20240307` → `claude-haiku-4-5`
- **`gptme/commands/export.py`**: Removed `# noqa: F821 - ToolUse imported above` — `ToolUse` is imported on line 108, so the suppression is unnecessary

## Test plan
- [ ] mypy passes on all 3 modified files (verified locally)
- [ ] CI passes (no behavioral changes — model names only used for fast inference and key validation)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update deprecated model references in `form_autodetect.py` and `validate.py`, and remove stale `noqa` comment in `export.py`.
> 
>   - **Model Updates**:
>     - `gptme/hooks/form_autodetect.py`: Change fallback model in `fast_models` from `claude-3-haiku-20240307` to `claude-3-5-haiku-20241022`.
>     - `gptme/llm/validate.py`: Update model in API key validation from `claude-3-haiku-20240307` to `claude-haiku-4-5`.
>   - **Code Cleanup**:
>     - `gptme/commands/export.py`: Remove unnecessary `# noqa: F821` comment for `ToolUse` import.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 72d789f4f0da4c0e97a3c49505c32d7c0ead1f9c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->