### PR TITLE
fix(shell): don't use start_new_session in TTY path

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -576,7 +576,8 @@ class ShellSession:
             stdin=tty_stdin,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            start_new_session=True,
+            # Don't use start_new_session=True here - we need to inherit the
+            # controlling terminal so sudo can prompt for passwords
             cwd=os.getcwd(),
             env=session_env,
         )


### PR DESCRIPTION
## Summary

Follow-up fix for #1288 - the TTY path for sudo commands was still not working because `_run_with_tty()` used `start_new_session=True`.

## Root Cause

`start_new_session=True` creates a new session leader without a controlling terminal. Even though `/dev/tty` was opened as stdin, sudo checks for an actual controlling terminal (not just stdin availability), so it still failed with "a terminal is required to read the password".

## Fix

Remove `start_new_session=True` from `_run_with_tty()` so the subprocess inherits the parent's controlling terminal.

## Testing

Manually verified that `sudo echo "hello"` now prompts for password and executes successfully.

Fixes #1095
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `start_new_session=True` from `_run_with_tty()` in `shell.py` to fix sudo password prompt issue by inheriting the parent's controlling terminal.
> 
>   - **Behavior**:
>     - Removes `start_new_session=True` from `_run_with_tty()` in `shell.py` to allow subprocess to inherit parent's controlling terminal, fixing sudo password prompt issue.
>   - **Testing**:
>     - Manually verified `sudo echo "hello"` prompts for password and executes successfully.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 115e6c4f2f30a3dab95ea5c7d223ef7f27277563. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->