### PR TITLE
style: fix E402 import ordering in codeblock.py and plugins

### DIFF
--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Generator
 from dataclasses import dataclass, field
 from xml.etree import ElementTree
@@ -31,8 +32,6 @@ class Codeblock:
     @classmethod
     @trace_function(name="codeblock.from_markdown", attributes={"component": "parser"})
     def from_markdown(cls, content: str) -> "Codeblock":
-        import re
-
         stripped = content.strip()
         fence_len = 0
 
@@ -79,9 +78,6 @@ class Codeblock:
         per conversation, creating ~97% of all trace spans (see Issue #199).
         """
         return list(_extract_codeblocks(markdown, streaming=streaming))
-
-
-import re
 
 
 def _extract_codeblocks(

--- a/gptme/plugins/__init__.py
+++ b/gptme/plugins/__init__.py
@@ -19,11 +19,11 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
-
 # Use the global console from gptme.util (redirected to stderr in ACP mode)
 # instead of creating a separate instance that would default to stdout.
 from gptme.util import console
+
+logger = logging.getLogger(__name__)
 
 # Cache for discovered plugins to avoid repeated discovery
 _plugin_cache: dict[tuple[Path, ...], list[Plugin]] = {}


### PR DESCRIPTION
## Summary

- `codeblock.py`: Move `import re` to top of file and remove duplicate inline import inside `from_markdown()`. The module-level `import re` was placed between a class definition and a standalone function, triggering E402.
- `plugins/__init__.py`: Move `from gptme.util import console` above `logger = logging.getLogger()` so it's grouped with the other imports.

Both are pure style/import-ordering fixes with no behavior change. All tests pass (40 codeblock tests + 17 plugin tests).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix import ordering in `codeblock.py` and `plugins/__init__.py` for PEP 8 compliance, with no behavior changes.
> 
>   - **Import Ordering**:
>     - `codeblock.py`: Move `import re` to the top and remove duplicate inline import in `from_markdown()`.
>     - `plugins/__init__.py`: Move `from gptme.util import console` above `logger = logging.getLogger()` to group with other imports.
>   - **Tests**:
>     - All tests pass: 40 codeblock tests and 17 plugin tests.
>   - **Misc**:
>     - Pure style/import-ordering fixes with no behavior change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 9b072bba461246c3c2d3c736d81c4e6d3efa2e62. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->