### PR TITLE
fix(subagent): capture workspace before spawning planner threads

### DIFF
--- a/gptme/tools/subagent.py
+++ b/gptme/tools/subagent.py
@@ -511,19 +511,19 @@ def _run_planner(
         s = string.ascii_lowercase + string.digits
         return "".join(random.choice(s) for _ in range(n))
 
-    # Capture workspace before spawning threads to avoid FileNotFoundError
-    # if cwd is deleted (e.g., tmpdir cleanup in tests)
-    try:
-        workspace = Path.cwd()
-    except FileNotFoundError:
-        workspace = Path.home()
-
     threads = []
     for subtask in subtasks:
         executor_id = f"{agent_id}-{subtask['id']}"
         executor_prompt = f"Context: {prompt}\n\nSubtask: {subtask['description']}"
         name = f"subagent-{executor_id}"
         logdir = get_logdir(name + "-" + random_string(4))
+
+        # Capture workspace before spawning thread to avoid FileNotFoundError
+        # if cwd is deleted (e.g., tmpdir cleanup in tests)
+        try:
+            workspace = Path.cwd()
+        except FileNotFoundError:
+            workspace = logdir.parent
 
         def run_executor(prompt=executor_prompt, log_dir=logdir, ws=workspace):
             _create_subagent_thread(


### PR DESCRIPTION
## Summary
- `_run_planner()` called `Path.cwd()` inside thread closures, racing with the caller's directory lifecycle
- When tmpdir cleanup happens before the executor thread starts, `Path.cwd()` raises `FileNotFoundError`
- Fix: capture workspace in the main thread (with try/except guard matching the pattern already used in `subagent()`) and pass it into the closure via default arg

## Details

The bug surfaces as `PytestUnhandledThreadExceptionWarning` in 6 planner-mode tests when run with `-W error::pytest.PytestUnhandledThreadExceptionWarning`. Without that flag the tests pass silently while the threads crash.

The `subagent()` function (line ~632) already handles this correctly with a try/except — this brings `_run_planner()` into alignment.

## Test plan
- [x] `pytest tests/test_tools_subagent.py` — 34/34 pass
- [x] `pytest tests/test_tools_subagent.py -W error::pytest.PytestUnhandledThreadExceptionWarning` — 34/34 pass (previously 6 failures)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `FileNotFoundError` in `_run_planner()` by capturing workspace in the main thread, resolving unhandled thread exceptions in tests.
> 
>   - **Bug Fix**:
>     - Fixes `FileNotFoundError` in `_run_planner()` by capturing `workspace` in the main thread and passing it to thread closures.
>     - Aligns `_run_planner()` with `subagent()` by using a try/except to handle `FileNotFoundError`.
>   - **Testing**:
>     - Resolves `PytestUnhandledThreadExceptionWarning` in 6 tests when using `-W error::pytest.PytestUnhandledThreadExceptionWarning`.
>     - All tests in `tests/test_tools_subagent.py` pass with and without the warning flag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 8bb5dcf836908721ab7aafd21c4be45528ea6b89. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->