### PR TITLE
fix(llm): strip @provider suffix in non-streaming chat path

### DIFF
--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -534,7 +534,7 @@ def chat(
         optional_kwargs["response_format"] = response_format
 
     response = client.chat.completions.create(
-        model=api_model,
+        model=api_model.split("@")[0],
         messages=messages_dicts,  # type: ignore[arg-type]
         extra_headers=extra_headers(provider),
         extra_body=extra_body(provider, model_meta),


### PR DESCRIPTION
## Summary

The streaming `stream()` function correctly strips the `@provider` suffix from OpenRouter model names (e.g. `openrouter/z-ai/glm-5@together` → `z-ai/glm-5`) before sending to the API. The non-streaming `chat()` function was missing this, causing 400 errors.

**Error from issue #1362**:
```
'z-ai/glm-5@together is not a valid model ID'
```

**Root cause**: The `@` syntax is gptme's convention for provider routing within OpenRouter. The `@together` part is handled in `extra_body()` which adds it as `body["provider"]["order"]` for proper routing. The model name itself must have the `@provider` suffix stripped before sending to the API. The streaming path already did this; the non-streaming path didn't.

**Fix**: One-line change — add `.split("@")[0]` to `model=api_model` in the non-streaming `chat()` function, matching the streaming path.

Reported in #1362 by @Andrei-Pozolotin.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes 400 error in `chat()` by stripping `@provider` suffix from model names in `llm_openai.py`.
> 
>   - **Behavior**:
>     - Fixes 400 error in `chat()` function in `llm_openai.py` by stripping `@provider` suffix from model names, similar to `stream()` function.
>     - Handles OpenRouter model names like `z-ai/glm-5@together` by sending `z-ai/glm-5` to the API.
>   - **Error Handling**:
>     - Addresses issue #1362 reported by @Andrei-Pozolotin.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for cdbd99f93e25279ac63c65f7c4e8ce51891284ff. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->