### PR TITLE
fix(logmanager): handle malformed JSON lines gracefully in JSONL reader

### DIFF
--- a/gptme/logmanager.py
+++ b/gptme/logmanager.py
@@ -806,7 +806,14 @@ def _gen_read_jsonl(path: PathLike) -> Generator[Message, None, None]:
 
     with open(path) as file:
         for line in file.readlines():
-            json_data = json.loads(line)
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                json_data = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning(f"Skipping malformed JSON line in {path}")
+                continue
             files = [parse_file_reference(f) for f in json_data.pop("files", [])]
             file_hashes = json_data.pop("file_hashes", {})
             if "timestamp" in json_data:


### PR DESCRIPTION
## Summary
- Skip malformed or empty JSON lines in `_gen_read_jsonl()` with a warning instead of crashing
- Fixes flaky `test_chats` failures caused by concurrent file access producing partially-written JSONL lines

## Root Cause
`_gen_read_jsonl()` calls `json.loads(line)` without error handling. When a JSONL file is read concurrently (e.g. `search_chats()` using `lock=False`), a partially-written line like `{"role": "assistant", "content": "truncated stri` triggers `JSONDecodeError`.

## Changes
- `gptme/logmanager.py`: Added `try/except JSONDecodeError` around `json.loads()`, strips whitespace, skips empty lines
- `tests/test_logmanager.py`: New `test_read_jsonl_malformed` test covering malformed lines, empty lines, and valid recovery

## Test plan
- [x] All 9 logmanager tests pass
- [x] New test verifies malformed lines are skipped and valid messages are preserved
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes JSONL reader to skip malformed or empty lines gracefully, preventing crashes during concurrent file access.
> 
>   - **Behavior**:
>     - `_gen_read_jsonl()` in `logmanager.py` now skips malformed or empty JSON lines with a warning instead of crashing.
>     - Fixes flaky `test_chats` failures due to concurrent file access causing partially-written JSONL lines.
>   - **Error Handling**:
>     - Added `try/except JSONDecodeError` around `json.loads()` in `_gen_read_jsonl()`.
>     - Strips whitespace and skips empty lines in `_gen_read_jsonl()`.
>   - **Testing**:
>     - New `test_read_jsonl_malformed` in `test_logmanager.py` to cover malformed lines, empty lines, and valid recovery.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for ebafd642f5f434b054e07e2b644156579559aaaa. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->