### PR TITLE
fix: replace assert with proper validation in server and shell

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -168,9 +168,8 @@ class SessionManager:
         """Remove a session."""
         if session_id in cls._sessions:
             conversation_id = cls._sessions[session_id].conversation_id
-            assert (
-                conversation_id is not None
-            ), "Server sessions must have conversation_id"
+            if conversation_id is None:
+                raise ValueError("Server sessions must have conversation_id")
 
             # Trigger SESSION_END hook when removing the last session for a conversation
             is_last_session = (
@@ -220,9 +219,8 @@ class SessionManager:
 def _append_and_notify(manager: LogManager, session: ConversationSession, msg: Message):
     """Append a message and notify clients."""
     manager.append(msg)
-    assert (
-        session.conversation_id is not None
-    ), "Server sessions must have conversation_id"
+    if session.conversation_id is None:
+        raise ValueError("Server sessions must have conversation_id")
     SessionManager.add_event(
         session.conversation_id,
         {

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -783,8 +783,12 @@ class ShellSession:
                             # if command is cd and successful, we need to change the directory
                             if command.startswith("cd ") and return_code == 0:
                                 ex, pwd, _ = self._run("pwd", output=False)
-                                assert ex == 0
-                                os.chdir(pwd.strip())
+                                if ex != 0:
+                                    logger.warning(
+                                        "pwd failed after cd, cannot update working directory"
+                                    )
+                                else:
+                                    os.chdir(pwd.strip())
 
                             # Issue #408: Drain any remaining stderr before returning
                             # This prevents stderr from leaking to the next command


### PR DESCRIPTION
## Summary

Python's `-O` flag disables `assert` statements, making them unsuitable for input validation in production code. This PR converts 3 assert-based validations to proper exception handling:

- **`server/api_v2_sessions.py`** (2 locations): `assert conversation_id is not None` → `if conversation_id is None: raise ValueError(...)`. These validate server session state — silently passing on `-O` could cause `NoneType` errors downstream.

- **`tools/shell.py`**: `assert ex == 0` after `pwd` → graceful warning log + skip `os.chdir()`. If `pwd` somehow fails after a `cd`, the shell session continues instead of crashing (or silently proceeding with stale cwd on `-O`).

## Test plan

- [x] All 14 server tests pass
- [x] All 52 shell tests pass  
- [x] mypy clean on both files
- [x] ruff-format clean
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `assert` statements with exception handling in `server/api_v2_sessions.py` and `tools/shell.py` for robust input validation.
> 
>   - **Behavior**:
>     - Replace `assert conversation_id is not None` with `if conversation_id is None: raise ValueError(...)` in `remove_session()` and `_append_and_notify()` in `server/api_v2_sessions.py`.
>     - Replace `assert ex == 0` with a warning log and skip `os.chdir()` in `_run_pipe()` in `tools/shell.py`.
>   - **Testing**:
>     - All 14 server tests pass.
>     - All 52 shell tests pass.
>     - `mypy` and `ruff-format` checks are clean.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 652a59bc08b8703e92137657aec63bcd702387f4. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->