### PR TITLE
refactor: move inline lynx tests to proper test file

### DIFF
--- a/gptme/tools/_browser_lynx.py
+++ b/gptme/tools/_browser_lynx.py
@@ -51,16 +51,3 @@ def search(query: str, engine: str = "duckduckgo") -> str:
     elif engine == "duckduckgo":
         return read_url(f"https://lite.duckduckgo.com/lite/?q={query}")
     raise ValueError(f"Unknown search engine: {engine}")
-
-
-def test_read_url():
-    content = read_url("https://gptme.org/")
-    assert "Getting Started" in content
-    content = read_url("https://github.com/gptme/gptme/issues/205")
-    assert "lynx-backed browser tool" in content
-
-
-def test_search():
-    # result = search("Python", "google")
-    result = search("Erik Bjäreholt", "duckduckgo")
-    assert "erik.bjareholt.com" in result

--- a/tests/test_browser_lynx.py
+++ b/tests/test_browser_lynx.py
@@ -1,8 +1,12 @@
-"""Tests for lynx browser backend security."""
+"""Tests for lynx browser backend."""
+
+import shutil
 
 import pytest
 
-from gptme.tools._browser_lynx import _validate_url_scheme
+from gptme.tools._browser_lynx import _validate_url_scheme, read_url, search
+
+lynx_available = shutil.which("lynx") is not None
 
 
 def test_url_scheme_validation():
@@ -21,3 +25,21 @@ def test_url_scheme_validation():
 
     with pytest.raises(ValueError, match="not allowed"):
         _validate_url_scheme("javascript:alert(1)")
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not lynx_available, reason="lynx not installed")
+def test_read_url():
+    """Test reading URLs with lynx backend."""
+    content = read_url("https://gptme.org/")
+    assert "Getting Started" in content
+    content = read_url("https://github.com/gptme/gptme/issues/205")
+    assert "lynx-backed browser tool" in content
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not lynx_available, reason="lynx not installed")
+def test_search():
+    """Test search with lynx backend."""
+    result = search("Erik Bjäreholt", "duckduckgo")
+    assert "erik.bjareholt.com" in result


### PR DESCRIPTION
## Summary

Moves `test_read_url()` and `test_search()` from production code (`_browser_lynx.py`) to the existing test file (`tests/test_browser_lynx.py`).

**Why:** Test functions in production modules are picked up by pytest but they make network calls (to gptme.org, GitHub, DuckDuckGo), have no markers, and are invisible to coverage tools. Moving them to the test suite gives proper `@slow` markers and `skipif(not lynx_available)` guards.

**Changes:**
- `_browser_lynx.py`: Remove 2 inline test functions (13 lines)
- `test_browser_lynx.py`: Add 2 test functions with `@slow` + lynx skip markers (24 lines)

## Test plan

- [x] All 3 lynx tests pass locally (1 existing + 2 moved)
- [x] `_browser_lynx.py` imports clean
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move inline tests from `_browser_lynx.py` to `test_browser_lynx.py` with appropriate markers.
> 
>   - **Tests**:
>     - Move `test_read_url()` and `test_search()` from `_browser_lynx.py` to `test_browser_lynx.py`.
>     - Add `@slow` and `skipif(not lynx_available)` markers to the moved tests in `test_browser_lynx.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for e51bb714b1aa19b84e47ebf51582470fd135e660. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->