### PR TITLE
fix(acp): add session cleanup to prevent unbounded memory growth

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -688,18 +688,29 @@ class GptmeAgent:
         logger.warning(f"load_session not yet implemented: {session_id}")
         raise NotImplementedError("Session loading not yet implemented")
 
+    def _cleanup_session(self, session_id: str) -> None:
+        """Remove all per-session state for a given session.
+
+        Cleans up _session_models, _tool_calls, and _permission_policies
+        to prevent unbounded memory growth from accumulated sessions.
+        """
+        self._session_models.pop(session_id, None)
+        self._tool_calls.pop(session_id, None)
+        self._permission_policies.pop(session_id, None)
+        self._registry.remove(session_id)
+
     async def cancel(
         self,
         session_id: str,
         **kwargs: Any,
     ) -> None:
-        """Cancel an ongoing operation (Phase 2 feature).
+        """Cancel an ongoing operation and clean up session state.
 
         Args:
             session_id: Session to cancel
         """
-        # Phase 2: Implement cancellation
-        logger.warning(f"cancel not yet implemented: {session_id}")
+        logger.info(f"Cancelling session {session_id}")
+        self._cleanup_session(session_id)
 
     async def list_sessions(
         self,


### PR DESCRIPTION
## Summary

- Add `_cleanup_session()` method that atomically purges all per-session state (`_session_models`, `_tool_calls`, `_permission_policies`) and removes the session from the registry
- Wire cleanup into `cancel()` so sessions are properly cleaned up when Zed closes a panel
- Previously, per-session state was never cleaned up, causing unbounded memory growth in long-running ACP servers

Identified by Greptile review on #1360.

## Test plan

- [x] 4 new tests: full cleanup, idempotency, isolation, cancel integration
- [x] All 33 existing ACP agent tests still pass (25 passed, 8 skipped — ACP not installed)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add session cleanup in `agent.py` to prevent unbounded memory growth by purging session data on cancellation.
> 
>   - **Behavior**:
>     - Add `_cleanup_session()` in `agent.py` to remove `_session_models`, `_tool_calls`, `_permission_policies`, and session from `_registry`.
>     - Integrate `_cleanup_session()` into `cancel()` to clean up sessions when a panel is closed.
>     - Fixes unbounded memory growth issue in long-running ACP servers.
>   - **Tests**:
>     - Add tests for `_cleanup_session()` and `cancel()` in `test_acp_agent.py` to ensure full cleanup, idempotency, and isolation.
>     - Verify that `cancel()` calls `_cleanup_session()` and removes all session data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for e538016906884dc6da113ddcd1367ffcfbb148cc. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->