### PR TITLE
chore: remove dead TYPE_CHECKING blocks with empty pass bodies

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -11,7 +11,7 @@ import contextvars
 import logging
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from uuid import uuid4
 
 from ..config import get_project_config
@@ -30,9 +30,6 @@ from .types import (
     ToolCallStatus,
     gptme_tool_to_acp_kind,
 )
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 

--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -4,7 +4,6 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import datetime
 from typing import (
-    TYPE_CHECKING,
     Literal,
     TypedDict,
     cast,
@@ -14,9 +13,6 @@ from typing import (
 from typing_extensions import NotRequired
 
 from .llm_openai_models import OPENAI_MODELS
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 

--- a/gptme/util/cost_tracker.py
+++ b/gptme/util/cost_tracker.py
@@ -8,10 +8,6 @@ See Issue #935 for design context.
 
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    pass
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Remove 3 empty `if TYPE_CHECKING: pass` blocks and their unused `TYPE_CHECKING` imports
- Files: `gptme/llm/models.py`, `gptme/util/cost_tracker.py`, `gptme/acp/agent.py`
- All three blocks imported `TYPE_CHECKING` but never used it for any type-only imports

## Test plan
- [x] mypy passes on all 3 changed files
- [x] Smoke-tested model loading and cost tracker import
- [ ] Full CI passes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unused `TYPE_CHECKING` blocks and imports from three files.
> 
>   - **Removals**:
>     - Remove `if TYPE_CHECKING: pass` blocks and `TYPE_CHECKING` imports from `gptme/llm/models.py`, `gptme/util/cost_tracker.py`, `gptme/acp/agent.py`.
>     - All removed blocks imported `TYPE_CHECKING` but did not use it for type-only imports.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 90e83f1ec2b36b79be538c484f5ff99ae06ff87c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->