### PR TITLE
test(acp): add per-session model override tests

### DIFF
--- a/gptme/tools/autocommit.py
+++ b/gptme/tools/autocommit.py
@@ -148,7 +148,6 @@ def autocommit_on_message_complete(
 
 
 # Tool specification
-# TODO: should probably be disabled by default, or at least in non-interactive modes
 tool = ToolSpec(
     name="autocommit",
     desc="Automatic hints to commit changes after message processing",


### PR DESCRIPTION
## Summary

Adds test coverage for the per-session model override feature introduced in #1360. The `TestPerSessionModel` class covers 8 test cases:

- `set_session_model` correctly stores, overwrites, and isolates models across sessions
- Effective model resolution: per-session override > global default > None
- Session cleanup properly removes per-session model
- `@provider` routing suffix (e.g. `model@together`) preserved in storage

Also removes a stale TODO comment in `autocommit.py` — the feature is already disabled by default (requires explicit `GPTME_AUTOCOMMIT=true`).

## Test plan

- [x] All 34 tests pass (8 skipped — existing ACP-not-installed guards)
- [x] ruff-format clean
- [x] mypy clean
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds tests for per-session model overrides in `GptmeAgent` and removes a stale comment in `autocommit.py`.
> 
>   - **Tests**:
>     - Adds `TestPerSessionModel` class in `test_acp_agent.py` with 8 test cases for per-session model overrides in `GptmeAgent`.
>     - Tests include storing, overwriting, and isolating models across sessions, effective model resolution, session cleanup, and handling of `@provider` routing suffix.
>   - **Misc**:
>     - Removes stale TODO comment in `autocommit.py` regarding default autocommit behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 84b7b16b13049aaa9af10b11e6da360c87cfc656. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->