### PR TITLE
fix(tests): use tmp_path to prevent parallel test interference

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -220,168 +220,150 @@ def test_get_config():
     assert config
 
 
-def test_env_vars_loaded_in_correct_priority(monkeypatch):
-    temp_dir = tempfile.gettempdir()
-    temp_user_config = os.path.join(temp_dir, "config.toml")
-    temp_project_config = os.path.join(temp_dir, "gptme.toml")
+def test_env_vars_loaded_in_correct_priority(tmp_path, monkeypatch):
+    temp_user_config = tmp_path / "config.toml"
+    temp_project_config = tmp_path / "gptme.toml"
 
-    try:
-        # Create a temporary user config file with env vars and check that they are loaded
-        with open(temp_user_config, "w") as temp_file:
-            temp_file.write(default_user_config)
-            temp_file.write('TEST_KEY = "file_test_key"\nANOTHER_KEY = "file_value"')
-            temp_file.flush()
-        config = Config(user=load_user_config(temp_user_config))
-        assert config.get_env("TEST_KEY") == "file_test_key"
-        assert config.get_env("ANOTHER_KEY") == "file_value"
+    # Create a temporary user config file with env vars and check that they are loaded
+    temp_user_config.write_text(
+        default_user_config + 'TEST_KEY = "file_test_key"\nANOTHER_KEY = "file_value"'
+    )
+    config = Config(user=load_user_config(str(temp_user_config)))
+    assert config.get_env("TEST_KEY") == "file_test_key"
+    assert config.get_env("ANOTHER_KEY") == "file_value"
 
-        # Check that the env vars are overridden by the project config
-        project_config = """[env]\nTEST_KEY = \"project_test_key\"\nANOTHER_KEY = \"project_value\""""
-        with open(temp_project_config, "w") as temp_file:
-            temp_file.write(project_config)
-            temp_file.flush()
-        config = Config.from_workspace(Path(temp_dir))
-        config = replace(config, user=load_user_config(temp_user_config))
-        assert config.get_env("TEST_KEY") == "project_test_key"
-        assert config.get_env("ANOTHER_KEY") == "project_value"
+    # Check that the env vars are overridden by the project config
+    project_config = (
+        '[env]\nTEST_KEY = "project_test_key"\nANOTHER_KEY = "project_value"'
+    )
+    temp_project_config.write_text(project_config)
+    config = Config.from_workspace(tmp_path)
+    config = replace(config, user=load_user_config(str(temp_user_config)))
+    assert config.get_env("TEST_KEY") == "project_test_key"
+    assert config.get_env("ANOTHER_KEY") == "project_value"
 
-        # Check that the env vars are overridden by the environment
-        monkeypatch.setenv("ANOTHER_KEY", "env_value")
-        monkeypatch.setenv("TEST_KEY", "env_test_key")
-        assert config.get_env("TEST_KEY") == "env_test_key"
-        assert config.get_env("ANOTHER_KEY") == "env_value"
-
-    finally:
-        # Delete the temporary files
-        if os.path.exists(temp_user_config):
-            os.remove(temp_user_config)
-        if os.path.exists(temp_project_config):
-            os.remove(temp_project_config)
+    # Check that the env vars are overridden by the environment
+    monkeypatch.setenv("ANOTHER_KEY", "env_value")
+    monkeypatch.setenv("TEST_KEY", "env_test_key")
+    assert config.get_env("TEST_KEY") == "env_test_key"
+    assert config.get_env("ANOTHER_KEY") == "env_value"
 
 
-def test_mcp_config_loaded_in_correct_priority():
-    temp_dir = tempfile.gettempdir()
-    temp_user_config = os.path.join(temp_dir, "config.toml")
-    temp_project_config = os.path.join(temp_dir, "gptme.toml")
+def test_mcp_config_loaded_in_correct_priority(tmp_path):
+    temp_user_config = tmp_path / "config.toml"
+    temp_project_config = tmp_path / "gptme.toml"
 
-    try:
-        # Create a temporary user config file with MCP config
-        with open(temp_user_config, "w") as temp_file:
-            temp_file.write(default_user_config)
-            temp_file.write("\n" + default_mcp_config)
-            temp_file.write("\n" + test_mcp_server_1_enabled)
-            temp_file.write("\n" + test_mcp_server_2_enabled)
-            temp_file.flush()
-        config = Config(user=load_user_config(temp_user_config))
-        assert config.mcp.enabled is True
-        assert config.mcp.auto_start is True
-        assert len(config.mcp.servers) == 2
-        my_server = next(s for s in config.mcp.servers if s.name == "my-server")
-        assert my_server.name == "my-server"
-        assert my_server.enabled is True
-        assert my_server.command == "server-command"
-        assert my_server.args == ["--arg1", "--arg2"]
-        assert my_server.env == {"API_KEY": "your-key"}
-        my_server_2 = next(s for s in config.mcp.servers if s.name == "my-server-2")
-        assert my_server_2.name == "my-server-2"
-        assert my_server_2.enabled is True
-        assert my_server_2.command == "server-command-2"
-        assert my_server_2.args == ["--arg2", "--arg3"]
-        assert my_server_2.env == {"API_KEY": "your-key-2"}
+    # Create a temporary user config file with MCP config
+    temp_user_config.write_text(
+        default_user_config
+        + "\n"
+        + default_mcp_config
+        + "\n"
+        + test_mcp_server_1_enabled
+        + "\n"
+        + test_mcp_server_2_enabled
+    )
+    config = Config(user=load_user_config(str(temp_user_config)))
+    assert config.mcp.enabled is True
+    assert config.mcp.auto_start is True
+    assert len(config.mcp.servers) == 2
+    my_server = next(s for s in config.mcp.servers if s.name == "my-server")
+    assert my_server.name == "my-server"
+    assert my_server.enabled is True
+    assert my_server.command == "server-command"
+    assert my_server.args == ["--arg1", "--arg2"]
+    assert my_server.env == {"API_KEY": "your-key"}
+    my_server_2 = next(s for s in config.mcp.servers if s.name == "my-server-2")
+    assert my_server_2.name == "my-server-2"
+    assert my_server_2.enabled is True
+    assert my_server_2.command == "server-command-2"
+    assert my_server_2.args == ["--arg2", "--arg3"]
+    assert my_server_2.env == {"API_KEY": "your-key-2"}
 
-        # Check that the MCP config is overridden by the project config
-        project_config = """[mcp]\nenabled = false\nauto_start = false"""
-        with open(temp_project_config, "w") as temp_file:
-            temp_file.write(project_config)
-            temp_file.write("\n" + test_mcp_server_1_disabled)
-            temp_file.write("\n" + test_mcp_server_3)
-            temp_file.flush()
-        config = Config.from_workspace(Path(temp_dir))
-        config = replace(config, user=load_user_config(temp_user_config))
+    # Check that the MCP config is overridden by the project config
+    project_config = "[mcp]\nenabled = false\nauto_start = false"
+    temp_project_config.write_text(
+        project_config + "\n" + test_mcp_server_1_disabled + "\n" + test_mcp_server_3
+    )
+    config = Config.from_workspace(tmp_path)
+    config = replace(config, user=load_user_config(str(temp_user_config)))
 
-        # Check that the MCP config is overridden by the project config
-        assert config.mcp.enabled is False
-        assert config.mcp.auto_start is False
+    # Check that the MCP config is overridden by the project config
+    assert config.mcp.enabled is False
+    assert config.mcp.auto_start is False
 
-        # Check that the MCP servers are merged from the user and project configs
-        # Should have 3 servers:
-        # - my-server (enabled in user config, disabled in project config)
-        # - my-server-2 (added in user config, not in project config)
-        # - my-server-3 (added in project config, not in user config)
-        assert len(config.mcp.servers) == 3
-        my_server = next(s for s in config.mcp.servers if s.name == "my-server")
-        assert my_server.name == "my-server"
-        assert my_server.enabled is False
-        my_server_2 = next(s for s in config.mcp.servers if s.name == "my-server-2")
-        assert my_server_2.name == "my-server-2"
-        assert my_server_2.enabled is True
-        assert my_server_2.command == "server-command-2"
-        assert my_server_2.args == ["--arg2", "--arg3"]
-        assert my_server_2.env == {"API_KEY": "your-key-2"}
-        my_server_3 = next(s for s in config.mcp.servers if s.name == "my-server-3")
-        assert my_server_3.name == "my-server-3"
-        assert my_server_3.enabled is True
-        assert my_server_3.command == "server-command-3"
-        assert my_server_3.args == ["--arg3", "--arg4"]
-        assert my_server_3.env == {"API_KEY": "your-key-3"}
+    # Check that the MCP servers are merged from the user and project configs
+    # Should have 3 servers:
+    # - my-server (enabled in user config, disabled in project config)
+    # - my-server-2 (added in user config, not in project config)
+    # - my-server-3 (added in project config, not in user config)
+    assert len(config.mcp.servers) == 3
+    my_server = next(s for s in config.mcp.servers if s.name == "my-server")
+    assert my_server.name == "my-server"
+    assert my_server.enabled is False
+    my_server_2 = next(s for s in config.mcp.servers if s.name == "my-server-2")
+    assert my_server_2.name == "my-server-2"
+    assert my_server_2.enabled is True
+    assert my_server_2.command == "server-command-2"
+    assert my_server_2.args == ["--arg2", "--arg3"]
+    assert my_server_2.env == {"API_KEY": "your-key-2"}
+    my_server_3 = next(s for s in config.mcp.servers if s.name == "my-server-3")
+    assert my_server_3.name == "my-server-3"
+    assert my_server_3.enabled is True
+    assert my_server_3.command == "server-command-3"
+    assert my_server_3.args == ["--arg3", "--arg4"]
+    assert my_server_3.env == {"API_KEY": "your-key-3"}
 
-        # Load chat config
-        chat_config_toml_str = """
-            [chat]
-            model = "gpt-4o"
-            tools = ["tool1", "tool2"]
-            tool_format = "markdown"
-            stream = true
-            interactive = true
+    # Load chat config
+    chat_config_toml_str = """
+        [chat]
+        model = "gpt-4o"
+        tools = ["tool1", "tool2"]
+        tool_format = "markdown"
+        stream = true
+        interactive = true
 
-            [mcp]
-            enabled = true
-            auto_start = true
+        [mcp]
+        enabled = true
+        auto_start = true
 
-        """
-        chat_config_toml_str += test_mcp_server_2_disabled + "\n\n" + test_mcp_server_4
-        chat_config_dict = tomlkit.loads(chat_config_toml_str)
-        chat_config = ChatConfig.from_dict(chat_config_dict.unwrap())
-        assert chat_config.mcp is not None
-        assert chat_config.mcp.enabled is True
-        assert chat_config.mcp.auto_start is True
-        assert len(chat_config.mcp.servers) == 2
+    """
+    chat_config_toml_str += test_mcp_server_2_disabled + "\n\n" + test_mcp_server_4
+    chat_config_dict = tomlkit.loads(chat_config_toml_str)
+    chat_config = ChatConfig.from_dict(chat_config_dict.unwrap())
+    assert chat_config.mcp is not None
+    assert chat_config.mcp.enabled is True
+    assert chat_config.mcp.auto_start is True
+    assert len(chat_config.mcp.servers) == 2
 
-        # Check that the MCP config is merged from the chat config, project config, and the user config
-        # Should have 4 servers:
-        # - my-server (enabled in user config, disabled in project config)
-        # - my-server-2 (added in user config, not in project config, disabled in chat config)
-        # - my-server-3 (added in project config, not in user config)
-        # - my-server-4 (added in chat config, not in user config or project config)
-        config.chat = chat_config
-        assert config.mcp.enabled is True
-        assert config.mcp.auto_start is True
-        assert len(config.mcp.servers) == 4
-        my_server = next(s for s in config.mcp.servers if s.name == "my-server")
-        assert my_server.name == "my-server"
-        assert my_server.enabled is False
-        my_server_2 = next(s for s in config.mcp.servers if s.name == "my-server-2")
-        assert my_server_2.name == "my-server-2"
-        assert my_server_2.enabled is False
-        my_server_3 = next(s for s in config.mcp.servers if s.name == "my-server-3")
-        assert my_server_3.name == "my-server-3"
-        assert my_server_3.enabled is True
-        assert my_server_3.command == "server-command-3"
-        assert my_server_3.args == ["--arg3", "--arg4"]
-        assert my_server_3.env == {"API_KEY": "your-key-3"}
-        my_server_4 = next(s for s in config.mcp.servers if s.name == "my-server-4")
-        assert my_server_4.name == "my-server-4"
-        assert my_server_4.enabled is True
-        assert my_server_4.command == "server-command-4"
-        assert my_server_4.args == ["--arg4", "--arg5"]
-        assert my_server_4.env == {"API_KEY": "your-key-4"}
-
-    finally:
-        # Delete the temporary files
-        if os.path.exists(temp_user_config):
-            os.remove(temp_user_config)
-        if os.path.exists(temp_project_config):
-            os.remove(temp_project_config)
+    # Check that the MCP config is merged from the chat config, project config, and the user config
+    # Should have 4 servers:
+    # - my-server (enabled in user config, disabled in project config)
+    # - my-server-2 (added in user config, not in project config, disabled in chat config)
+    # - my-server-3 (added in project config, not in user config)
+    # - my-server-4 (added in chat config, not in user config or project config)
+    config.chat = chat_config
+    assert config.mcp.enabled is True
+    assert config.mcp.auto_start is True
+    assert len(config.mcp.servers) == 4
+    my_server = next(s for s in config.mcp.servers if s.name == "my-server")
+    assert my_server.name == "my-server"
+    assert my_server.enabled is False
+    my_server_2 = next(s for s in config.mcp.servers if s.name == "my-server-2")
+    assert my_server_2.name == "my-server-2"
+    assert my_server_2.enabled is False
+    my_server_3 = next(s for s in config.mcp.servers if s.name == "my-server-3")
+    assert my_server_3.name == "my-server-3"
+    assert my_server_3.enabled is True
+    assert my_server_3.command == "server-command-3"
+    assert my_server_3.args == ["--arg3", "--arg4"]
+    assert my_server_3.env == {"API_KEY": "your-key-3"}
+    my_server_4 = next(s for s in config.mcp.servers if s.name == "my-server-4")
+    assert my_server_4.name == "my-server-4"
+    assert my_server_4.enabled is True
+    assert my_server_4.command == "server-command-4"
+    assert my_server_4.args == ["--arg4", "--arg5"]
+    assert my_server_4.env == {"API_KEY": "your-key-4"}
 
 
 def test_mcp_config_loaded_from_toml():


### PR DESCRIPTION
## Summary

Fix flaky config priority tests that fail under pytest-xdist parallel execution.

**Root cause**: `test_env_vars_loaded_in_correct_priority` and `test_mcp_config_loaded_in_correct_priority` both wrote to hardcoded paths in `/tmp` (`config.toml`, `gptme.toml`). Under `-n 16` parallel execution, workers stomp on each other's files.

**Symptoms on master** (since #1370 shifted xdist scheduling):
- `assert 2 == 3` in MCP test (another worker overwrote `gptme.toml`)
- `assert None == 'project_test_key'` in env test (another worker deleted `config.toml`)

**Fix**: Replace `tempfile.gettempdir()` with pytest's `tmp_path` fixture, which provides unique directories per test. Removes manual `try/finally` cleanup (tmp_path auto-cleans).

## Test plan

- [x] Both tests pass locally
- [x] ruff-format applied
- [ ] CI passes (this should fix the current master CI failure)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix flaky tests in `tests/test_config.py` by using `tmp_path` for unique directories, preventing parallel execution conflicts.
> 
>   - **Behavior**:
>     - Fixes flaky tests `test_env_vars_loaded_in_correct_priority` and `test_mcp_config_loaded_in_correct_priority` in `tests/test_config.py` by using `tmp_path` for unique temporary directories.
>     - Replaces `tempfile.gettempdir()` with `tmp_path` to prevent file conflicts during parallel test execution.
>     - Removes manual `try/finally` cleanup as `tmp_path` auto-cleans.
>   - **Tests**:
>     - Both tests now pass locally and are expected to pass in CI with parallel execution enabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 73bc937dc17670ebf64aa0224d5d75f2b526aeac. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->