### PR TITLE
fix: add requires-python to project metadata

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7786,4 +7786,4 @@ youtube = ["youtube_transcript_api"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "4d7b93323727f21bc2b4fdecc4e4f8f3310ef1d3cc3e3588008ba1e379382a35"
+content-hash = "44faf79556ce1f5c3b0c34ec42f1049e52056e29e81e5d45a7d434c432e70139"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 readme = "README.md"
 license = "MIT"
+requires-python = ">=3.10"
 dynamic = ["dependencies"]  # "version"
 
 [project.urls]


### PR DESCRIPTION
## Summary
- Add `requires-python = ">=3.10"` to the `[project]` table in pyproject.toml
- Matches the existing `python = "^3.10"` constraint in `[tool.poetry.dependencies]`

## Problem
uv emits a warning on every invocation:
```
warning: No `requires-python` value found in the workspace. Defaulting to `>=3.12`.
```

The default of `>=3.12` is incorrect — gptme supports Python 3.10+. This warning is noisy and the wrong default could cause issues for tools that respect the `requires-python` field.

## Test plan
- [x] `uv run python3 -c "import gptme"` no longer shows the warning
- [x] poetry.lock updated to stay in sync
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `requires-python = ">=3.10"` to `pyproject.toml` to resolve `uv` warning and align with existing Python version constraint.
> 
>   - **Behavior**:
>     - Add `requires-python = ">=3.10"` to `[project]` in `pyproject.toml` to specify minimum Python version.
>     - Resolves warning from `uv` about missing `requires-python`, which defaulted to `>=3.12`.
>   - **Dependencies**:
>     - Aligns with existing `python = "^3.10"` constraint in `[tool.poetry.dependencies]`.
>   - **Testing**:
>     - Verified `uv run python3 -c "import gptme"` no longer shows the warning.
>     - Updated `poetry.lock` to stay in sync.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 550d4c2be065c8374839e151aad0f43d99d15277. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->