### PR TITLE
fix(browser): fix Google search consent banner bypass in lynx

### DIFF
--- a/gptme/tools/_browser_lynx.py
+++ b/gptme/tools/_browser_lynx.py
@@ -67,11 +67,14 @@ def read_url(url: str, cookies: dict | None = None) -> str:
 
 def search(query: str, engine: str = "duckduckgo") -> str:
     if engine == "google":
-        # TODO: we need to figure out a way to remove the consent banner to access google search results
-        #       otherwise google is not usable
+        # Use SOCS cookie (newer Google consent format) to bypass GDPR banner,
+        # and gl=us to avoid region-specific consent redirects.
         return read_url(
-            f"https://www.google.com/search?q={query}&hl=en",
-            cookies={"CONSENT+": "YES+42"},
+            f"https://www.google.com/search?q={query}&hl=en&gl=us",
+            cookies={
+                "SOCS": "CAISHAgBEhJnd3NfMjAyMzA4MTAtMF9SQzIaAmVuIAEaBgiA_LyaBg",
+                "CONSENT": "PENDING+987",
+            },
         )
     if engine == "duckduckgo":
         return read_url(f"https://lite.duckduckgo.com/lite/?q={query}")


### PR DESCRIPTION
## Summary

- Fix malformed Google consent cookie (`CONSENT+` → proper `SOCS` + `CONSENT` cookies)
- Add `gl=us` URL parameter to avoid GDPR consent redirects
- Add test verifying Google search passes correct consent cookies

The previous cookie had `+` in the name (`CONSENT+`), which is invalid. Google now primarily uses the `SOCS` cookie for GDPR consent. Both `SOCS` (newer format) and `CONSENT` (fallback) are now sent. The `gl=us` parameter prevents Google from redirecting to regional consent pages.

## Test plan

- [x] All 4 lynx browser tests pass (2 slow skipped)
- [x] New test verifies Google consent cookies and URL parameters
- [x] ruff clean, mypy clean
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix Google search consent handling in Lynx by updating cookies and adding a URL parameter, with a new test to verify changes.
> 
>   - **Behavior**:
>     - Fix malformed Google consent cookie in `search()` in `_browser_lynx.py` by replacing `CONSENT+` with `SOCS` and `CONSENT` cookies.
>     - Add `gl=us` parameter in Google search URL to prevent GDPR consent redirects.
>   - **Tests**:
>     - Add `test_search_google_consent_cookies()` in `test_browser_lynx.py` to verify correct consent cookies and URL parameters for Google search.
>     - Ensure all Lynx browser tests pass, with 2 marked as slow and skipped if Lynx is not installed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for b03e68db3d10582ec1e8e32623ba0a65783223d8. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->