### PR TITLE
test(util): add unit tests for tokens, cost_display, and export modules

### DIFF
--- a/tests/test_cost_display.py
+++ b/tests/test_cost_display.py
@@ -1,0 +1,267 @@
+"""Tests for util/cost_display.py — cost aggregation and display."""
+
+from gptme.message import Message
+from gptme.util.cost_display import (
+    CostData,
+    RequestCosts,
+    TotalCosts,
+    gather_conversation_costs,
+)
+
+
+def test_gather_conversation_costs_empty():
+    """No messages returns None."""
+    result = gather_conversation_costs([])
+    assert result is None
+
+
+def test_gather_conversation_costs_no_metadata():
+    """Messages without metadata return None."""
+    msgs = [
+        Message(role="user", content="hello"),
+        Message(role="assistant", content="hi there"),
+    ]
+    result = gather_conversation_costs(msgs)
+    assert result is None
+
+
+def test_gather_conversation_costs_zero_metadata():
+    """Messages with zero-value metadata return None."""
+    msgs = [
+        Message(
+            role="assistant",
+            content="hi",
+            metadata={
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_creation_tokens": 0,
+                "cost": 0.0,
+            },
+        ),
+    ]
+    result = gather_conversation_costs(msgs)
+    assert result is None
+
+
+def test_gather_conversation_costs_single_request():
+    """Single assistant message with metadata returns correct totals."""
+    msgs = [
+        Message(role="user", content="hello"),
+        Message(
+            role="assistant",
+            content="hi there",
+            metadata={
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_read_tokens": 20,
+                "cache_creation_tokens": 10,
+                "cost": 0.005,
+            },
+        ),
+    ]
+    result = gather_conversation_costs(msgs)
+    assert result is not None
+    assert isinstance(result, CostData)
+    assert result.source == "conversation"
+    assert result.total.input_tokens == 100
+    assert result.total.output_tokens == 50
+    assert result.total.cache_read_tokens == 20
+    assert result.total.cache_creation_tokens == 10
+    assert result.total.cost == 0.005
+    assert result.total.request_count == 1
+
+
+def test_gather_conversation_costs_multiple_requests():
+    """Multiple assistant messages aggregate correctly."""
+    msgs = [
+        Message(role="user", content="hello"),
+        Message(
+            role="assistant",
+            content="hi",
+            metadata={
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cost": 0.005,
+            },
+        ),
+        Message(role="user", content="how are you?"),
+        Message(
+            role="assistant",
+            content="fine",
+            metadata={
+                "input_tokens": 200,
+                "output_tokens": 80,
+                "cost": 0.010,
+            },
+        ),
+    ]
+    result = gather_conversation_costs(msgs)
+    assert result is not None
+    assert result.total.input_tokens == 300
+    assert result.total.output_tokens == 130
+    assert result.total.cost == 0.015
+    assert result.total.request_count == 2
+
+
+def test_gather_conversation_costs_last_request():
+    """Last assistant metadata is used for last_request field."""
+    msgs = [
+        Message(
+            role="assistant",
+            content="first",
+            metadata={"input_tokens": 100, "output_tokens": 50, "cost": 0.005},
+        ),
+        Message(
+            role="assistant",
+            content="second",
+            metadata={"input_tokens": 200, "output_tokens": 80, "cost": 0.010},
+        ),
+    ]
+    result = gather_conversation_costs(msgs)
+    assert result is not None
+    assert result.last_request is not None
+    assert isinstance(result.last_request, RequestCosts)
+    assert result.last_request.input_tokens == 200
+    assert result.last_request.output_tokens == 80
+    assert result.last_request.cost == 0.010
+
+
+def test_gather_conversation_costs_cache_hit_rate():
+    """Cache hit rate is calculated correctly."""
+    msgs = [
+        Message(
+            role="assistant",
+            content="cached response",
+            metadata={
+                "input_tokens": 50,
+                "output_tokens": 30,
+                "cache_read_tokens": 150,
+                "cache_creation_tokens": 0,
+                "cost": 0.003,
+            },
+        ),
+    ]
+    result = gather_conversation_costs(msgs)
+    assert result is not None
+    # cache_hit_rate = cache_read / (input + cache_read + cache_creation)
+    # = 150 / (50 + 150 + 0) = 0.75
+    assert result.total.cache_hit_rate == 0.75
+
+
+def test_gather_conversation_costs_user_metadata_counted():
+    """User messages with metadata contribute to totals but not request_count."""
+    msgs = [
+        Message(
+            role="user",
+            content="hello",
+            metadata={"input_tokens": 50, "output_tokens": 0, "cost": 0.001},
+        ),
+        Message(
+            role="assistant",
+            content="hi",
+            metadata={"input_tokens": 100, "output_tokens": 30, "cost": 0.005},
+        ),
+    ]
+    result = gather_conversation_costs(msgs)
+    assert result is not None
+    # Both messages' tokens are summed
+    assert result.total.input_tokens == 150
+    assert result.total.output_tokens == 30
+    assert result.total.cost == 0.006
+    # But only assistant messages count as requests
+    assert result.total.request_count == 1
+
+
+def test_gather_conversation_costs_partial_metadata():
+    """Messages with partial metadata (missing keys) use defaults."""
+    msgs = [
+        Message(
+            role="assistant",
+            content="response",
+            metadata={"input_tokens": 100, "output_tokens": 50},
+            # No cache_read_tokens, cache_creation_tokens, or cost
+        ),
+    ]
+    result = gather_conversation_costs(msgs)
+    assert result is not None
+    assert result.total.input_tokens == 100
+    assert result.total.output_tokens == 50
+    assert result.total.cache_read_tokens == 0
+    assert result.total.cache_creation_tokens == 0
+    assert result.total.cost == 0.0
+
+
+def test_request_costs_dataclass():
+    """RequestCosts dataclass instantiation works."""
+    rc = RequestCosts(
+        input_tokens=100,
+        output_tokens=50,
+        cache_read_tokens=20,
+        cache_creation_tokens=10,
+        cost=0.005,
+    )
+    assert rc.input_tokens == 100
+    assert rc.output_tokens == 50
+    assert rc.cost == 0.005
+
+
+def test_total_costs_dataclass():
+    """TotalCosts dataclass instantiation works."""
+    tc = TotalCosts(
+        input_tokens=1000,
+        output_tokens=500,
+        cache_read_tokens=200,
+        cache_creation_tokens=100,
+        cost=0.05,
+        cache_hit_rate=0.15,
+        request_count=5,
+    )
+    assert tc.input_tokens == 1000
+    assert tc.request_count == 5
+    assert tc.cache_hit_rate == 0.15
+
+
+def test_cost_data_dataclass():
+    """CostData dataclass instantiation works."""
+    cd = CostData(
+        last_request=None,
+        total=TotalCosts(
+            input_tokens=0,
+            output_tokens=0,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+            cost=0.0,
+            cache_hit_rate=0.0,
+            request_count=0,
+        ),
+        source="conversation",
+    )
+    assert cd.source == "conversation"
+    assert cd.last_request is None
+
+
+def test_gather_conversation_costs_no_last_request_when_zero():
+    """last_request is None when last metadata has all zeros."""
+    msgs = [
+        Message(
+            role="assistant",
+            content="first",
+            metadata={"input_tokens": 100, "output_tokens": 50, "cost": 0.005},
+        ),
+        Message(
+            role="assistant",
+            content="second",
+            metadata={
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_creation_tokens": 0,
+                "cost": 0.0,
+            },
+        ),
+    ]
+    result = gather_conversation_costs(msgs)
+    assert result is not None
+    # Last metadata has all zeros, so last_request should be None
+    assert result.last_request is None

--- a/tests/test_util_export.py
+++ b/tests/test_util_export.py
@@ -1,0 +1,67 @@
+"""Tests for util/export.py — replace_or_fail utility."""
+
+import pytest
+
+from gptme.util.export import replace_or_fail
+
+
+def test_replace_or_fail_basic():
+    """Successful replacement returns modified string."""
+    result = replace_or_fail("<title>old</title>", "old", "new")
+    assert result == "<title>new</title>"
+
+
+def test_replace_or_fail_no_match():
+    """Raises ValueError when old string not found."""
+    with pytest.raises(ValueError, match="Failed to replace"):
+        replace_or_fail("hello world", "missing", "replacement")
+
+
+def test_replace_or_fail_custom_desc():
+    """Error message includes custom description."""
+    with pytest.raises(ValueError, match="the title tag"):
+        replace_or_fail("hello", "missing", "new", desc="the title tag")
+
+
+def test_replace_or_fail_default_desc():
+    """Error message shows old string repr when no desc given."""
+    with pytest.raises(ValueError, match="'missing'"):
+        replace_or_fail("hello", "missing", "new")
+
+
+def test_replace_or_fail_multiple_occurrences():
+    """Replaces all occurrences (str.replace behavior)."""
+    result = replace_or_fail("aaa", "a", "b")
+    assert result == "bbb"
+
+
+def test_replace_or_fail_empty_old_string():
+    """Empty old string always matches (str.replace behavior)."""
+    result = replace_or_fail("hello", "", "X")
+    # str.replace with empty string inserts between every char
+    assert result == "XhXeXlXlXoX"
+
+
+def test_replace_or_fail_empty_new_string():
+    """Replacing with empty string (deletion) works."""
+    result = replace_or_fail("hello world", " world", "")
+    assert result == "hello"
+
+
+def test_replace_or_fail_html_content():
+    """Works with realistic HTML content."""
+    html = '<link rel="stylesheet" href="/static/style.css">'
+    css = "body { color: red; }"
+    result = replace_or_fail(
+        html,
+        '<link rel="stylesheet" href="/static/style.css">',
+        f"<style>{css}</style>",
+        "stylesheet link",
+    )
+    assert result == "<style>body { color: red; }</style>"
+
+
+def test_replace_or_fail_preserves_surrounding():
+    """Content before and after the match is preserved."""
+    result = replace_or_fail("before TARGET after", "TARGET", "REPLACED")
+    assert result == "before REPLACED after"

--- a/tests/test_util_tokens.py
+++ b/tests/test_util_tokens.py
@@ -1,0 +1,159 @@
+"""Tests for util/tokens.py — token counting, caching, and tokenizer selection."""
+
+import hashlib
+
+import pytest
+
+
+def test_hash_content_deterministic():
+    """_hash_content returns consistent SHA-256 hex digest."""
+    from gptme.util.tokens import _hash_content
+
+    result = _hash_content("hello world")
+    expected = hashlib.sha256(b"hello world").hexdigest()
+    assert result == expected
+
+
+def test_hash_content_different_inputs():
+    """Different inputs produce different hashes."""
+    from gptme.util.tokens import _hash_content
+
+    assert _hash_content("hello") != _hash_content("world")
+    assert _hash_content("") != _hash_content(" ")
+
+
+def test_hash_content_empty_string():
+    """Empty string produces valid hash."""
+    from gptme.util.tokens import _hash_content
+
+    result = _hash_content("")
+    assert len(result) == 64  # SHA-256 hex digest length
+    assert result == hashlib.sha256(b"").hexdigest()
+
+
+def test_hash_content_unicode():
+    """Unicode content is handled correctly."""
+    from gptme.util.tokens import _hash_content
+
+    result = _hash_content("こんにちは世界")
+    expected = hashlib.sha256("こんにちは世界".encode()).hexdigest()
+    assert result == expected
+
+
+def test_get_tokenizer_gpt4o():
+    """gpt-4o models use o200k_base encoding."""
+    from gptme.util.tokens import get_tokenizer
+
+    enc = get_tokenizer("gpt-4o")
+    assert enc.name == "o200k_base"
+
+    # Variants should also match
+    enc2 = get_tokenizer("gpt-4o-mini")
+    assert enc2.name == "o200k_base"
+
+
+def test_get_tokenizer_unknown_model():
+    """Unknown models fall back to cl100k_base."""
+    from gptme.util.tokens import get_tokenizer
+
+    enc = get_tokenizer("totally-unknown-model-xyz")
+    assert enc.name == "cl100k_base"
+
+
+def test_get_tokenizer_known_model():
+    """Known OpenAI models get their proper tokenizer."""
+    from gptme.util.tokens import get_tokenizer
+
+    enc = get_tokenizer("gpt-4")
+    assert enc.name == "cl100k_base"
+
+
+def test_len_tokens_string():
+    """len_tokens works on plain strings."""
+    from gptme.util.tokens import len_tokens
+
+    count = len_tokens("hello world", model="gpt-4")
+    assert isinstance(count, int)
+    assert count > 0
+    assert count < 10  # "hello world" is 2-3 tokens
+
+
+def test_len_tokens_empty_string():
+    """Empty string returns 0 tokens."""
+    from gptme.util.tokens import len_tokens
+
+    count = len_tokens("", model="gpt-4")
+    assert count == 0
+
+
+def test_len_tokens_message():
+    """len_tokens works on Message objects."""
+    from gptme.message import Message
+    from gptme.util.tokens import len_tokens
+
+    msg = Message(role="user", content="hello world")
+    count = len_tokens(msg, model="gpt-4")
+    assert isinstance(count, int)
+    assert count > 0
+
+
+def test_len_tokens_message_list():
+    """len_tokens sums tokens across a list of messages."""
+    from gptme.message import Message
+    from gptme.util.tokens import len_tokens
+
+    msgs = [
+        Message(role="user", content="hello"),
+        Message(role="assistant", content="world"),
+    ]
+    total = len_tokens(msgs, model="gpt-4")
+    individual = sum(len_tokens(m, model="gpt-4") for m in msgs)
+    assert total == individual
+
+
+def test_len_tokens_empty_list():
+    """Empty list returns 0 tokens."""
+    from gptme.util.tokens import len_tokens
+
+    count = len_tokens([], model="gpt-4")
+    assert count == 0
+
+
+def test_len_tokens_caching():
+    """Repeated calls with same content use cache."""
+    from gptme.util.tokens import _token_cache, len_tokens
+
+    content = "test caching behavior unique string 12345"
+    model = "gpt-4"
+
+    # Clear any existing cache entry
+    from gptme.util.tokens import _hash_content
+
+    cache_key = (_hash_content(content), model)
+    _token_cache.pop(cache_key, None)
+
+    # First call computes and caches
+    count1 = len_tokens(content, model=model)
+    assert cache_key in _token_cache
+
+    # Second call returns same result (from cache)
+    count2 = len_tokens(content, model=model)
+    assert count1 == count2
+
+
+def test_len_tokens_long_content():
+    """Token counting works on longer content."""
+    from gptme.util.tokens import len_tokens
+
+    # A paragraph of text
+    content = "The quick brown fox jumps over the lazy dog. " * 50
+    count = len_tokens(content, model="gpt-4")
+    assert count > 100  # Should be many tokens
+
+
+def test_len_tokens_invalid_type():
+    """Non-string, non-Message, non-list raises AssertionError."""
+    from gptme.util.tokens import len_tokens
+
+    with pytest.raises(AssertionError):
+        len_tokens(42, model="gpt-4")  # type: ignore


### PR DESCRIPTION
## Summary

- Add 15 unit tests for `gptme/util/tokens.py` — tokenizer selection, token counting, caching, edge cases
- Add 13 unit tests for `gptme/util/cost_display.py` — conversation cost aggregation from message metadata  
- Add 9 unit tests for `gptme/util/export.py` — `replace_or_fail` string replacement utility

**37 tests total**, all pure unit tests with no mocking or external dependencies.

These three utility modules had zero test coverage previously. The tests cover:
- Hash content determinism and Unicode handling
- gpt-4o tokenizer routing and unknown model fallback to cl100k_base
- Token counting for strings, Messages, and lists with caching verification
- Cost aggregation across multiple messages with cache hit rate calculation
- Partial metadata handling with safe defaults
- `replace_or_fail` error reporting and HTML content processing

## Test plan

- [x] All 37 tests pass locally
- [x] Ruff lint and format clean
- [ ] CI passes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add 37 unit tests for `tokens.py`, `cost_display.py`, and `export.py` to improve test coverage and handle various edge cases.
> 
>   - **Tests for `tokens.py`**:
>     - Add 15 unit tests for token counting, caching, and tokenizer selection.
>     - Test cases include deterministic hashing, Unicode handling, and caching verification.
>     - Ensure correct tokenizer selection for known and unknown models.
>   - **Tests for `cost_display.py`**:
>     - Add 13 unit tests for conversation cost aggregation from message metadata.
>     - Handle cases with no metadata, zero-value metadata, and partial metadata.
>     - Verify cache hit rate calculation and user message metadata contribution.
>   - **Tests for `export.py`**:
>     - Add 9 unit tests for `replace_or_fail` utility.
>     - Test string replacement, error reporting, and handling of multiple occurrences.
>     - Ensure functionality with realistic HTML content and empty strings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for a7cf35e16f95706b251cfc7361004aed647c16af. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->