### PR TITLE
fix: remove debug print statements from util and anthropic modules

### DIFF
--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -528,7 +528,7 @@ def stream(
                     # Note: Server-side tool use (e.g., web search) comes through as
                     # regular ToolUseBlock with specific tool names, not special types
                     else:
-                        print(f"Unknown block type: {block}")
+                        logger.warning("Unknown block type: %s", block)
                 case "content_block_delta":
                     chunk = cast(anthropic.types.RawContentBlockDeltaEvent, chunk)
                     delta = chunk.delta

--- a/gptme/util/__init__.py
+++ b/gptme/util/__init__.py
@@ -12,7 +12,6 @@ from functools import lru_cache
 from pathlib import Path
 from xml.sax.saxutils import escape as xml_escape
 
-from rich import print
 from rich.console import Console
 
 EMOJI_WARN = "⚠️"
@@ -55,7 +54,6 @@ def example_to_xml(s: str) -> str:
     """
     s = clean_example(s)
     orig = s
-    print(f"After clean_example: {s!r}")  # Debug print
 
     lines = s.split("\n")
     result = []
@@ -100,7 +98,6 @@ def example_to_xml(s: str) -> str:
         )
 
     s = "\n".join(result).strip()
-    print(f"Final result: {s!r}")  # Debug print
     assert s != orig, "Couldn't find place to put start of directive"
     return s
 


### PR DESCRIPTION
## Summary
- Remove two debug `print()` calls in `example_to_xml()` that output raw repr strings during normal tool-format conversion
- Remove now-unused `from rich import print` import (was only used by the debug prints)
- Replace bare `print()` with `logger.warning()` for unknown block types in the Anthropic streaming handler, consistent with the adjacent `TextBlock` warning pattern

## Test plan
- [x] All XML/example-related tests pass locally (17 passed)
- [x] Lint clean (ruff check + format)
- [ ] CI passes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove debug print statements from `example_to_xml()` and replace a print with logging in `stream()` for unknown block types.
> 
>   - **Behavior**:
>     - Remove debug `print()` calls in `example_to_xml()` in `util/__init__.py`.
>     - Replace `print()` with `logger.warning()` for unknown block types in `stream()` in `llm_anthropic.py`.
>   - **Imports**:
>     - Remove unused `from rich import print` import in `util/__init__.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 62ebcbf577c4912341a9add7d57aef6b88e57bb7. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->