### PR TITLE
fix(logmanager): prevent data loss when writing on compacted view branch

### DIFF
--- a/gptme/logmanager.py
+++ b/gptme/logmanager.py
@@ -289,7 +289,10 @@ class LogManager:
     def log(self, value: Log | list[Message]) -> None:
         if isinstance(value, list):
             value = Log(value)
-        self._branches[self.current_branch] = value
+        if self.current_view is not None:
+            self._views[self.current_view] = value
+        else:
+            self._branches[self.current_branch] = value
 
     @property
     def logfile(self) -> Path:
@@ -362,8 +365,13 @@ class LogManager:
         # create directory if it doesn't exist
         Path(self.logfile).parent.mkdir(parents=True, exist_ok=True)
 
-        # write current branch
-        self.log.write_jsonl(self.logfile)
+        # write current branch (or main branch if on a view)
+        # When on a view, conversation.jsonl must always contain the full main
+        # branch history — the view is persisted separately in views/ directory.
+        if self.current_view is not None:
+            self._branches["main"].write_jsonl(self.logfile)
+        else:
+            self.log.write_jsonl(self.logfile)
 
         # write other branches
         if branches:


### PR DESCRIPTION
## Summary

- Fix `write()` overwriting `conversation.jsonl` with compacted view content instead of the full main branch history — causes data loss on restart when autocompact is active
- Fix `log` setter silently updating the branch instead of the view when `current_view` is set — causes `edit()` and `undo()` to corrupt state while on a view

## Details

**Bug 1 (data loss):** When on a compacted view, `self.log` returns the view data but `self.logfile` returns `conversation.jsonl`. Line 366 writes compacted content to the main conversation file. The full history in `self._branches["main"]` exists in memory but is never persisted — lost on process restart.

**Bug 2 (setter inconsistency):** The `log` setter always updates `self._branches[self.current_branch]` regardless of view state. When on a view, `self.log` getter returns view data but the setter writes to the branch. Operations like `edit()` and `undo()` silently corrupt state.

## Test plan

- [x] `test_view_write_preserves_main_history` — verifies conversation.jsonl contains full history after view write
- [x] `test_view_log_setter_updates_view` — verifies setter updates view dict, not branch
- [x] `test_view_undo_works_on_view` — verifies undo modifies view, not main branch
- [x] All 12 logmanager tests pass
- [x] mypy clean
- [x] ruff clean
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes data loss and state corruption in `LogManager` when using views by ensuring correct log persistence and updates.
> 
>   - **Behavior**:
>     - Fix `write()` in `logmanager.py` to write full main branch history to `conversation.jsonl` when on a view, preventing data loss.
>     - Fix `log` setter in `logmanager.py` to update the view instead of the branch when `current_view` is set, preventing state corruption.
>   - **Tests**:
>     - Add `test_view_write_preserves_main_history` to ensure full history is preserved in `conversation.jsonl`.
>     - Add `test_view_log_setter_updates_view` to ensure the log setter updates the view.
>     - Add `test_view_undo_works_on_view` to ensure `undo()` modifies the view, not the main branch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for bf2e6d273fd05e74d9a9547a00407ea563755aa8. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->