### PR TITLE
fix(logmanager,tmux): prevent crashes on undo overflow and send-keys missing args

### DIFF
--- a/gptme/logmanager.py
+++ b/gptme/logmanager.py
@@ -433,6 +433,8 @@ class LogManager:
         if not quiet:
             print("[yellow]Undoing messages:[/yellow]")
         for _ in range(n):
+            if not self.log:
+                break
             undid = self.log[-1]
             self.log = self.log.pop()
             if not quiet:

--- a/gptme/tools/tmux.py
+++ b/gptme/tools/tmux.py
@@ -439,7 +439,14 @@ def execute_tmux(
         if command == "new-session":
             yield new_session(_args)
         elif command == "send-keys":
-            pane_id, keys = _args.split(maxsplit=1)
+            send_parts = _args.split(maxsplit=1)
+            if len(send_parts) < 2:
+                yield Message(
+                    "system",
+                    "Error: send-keys requires both pane_id and keys arguments",
+                )
+                continue
+            pane_id, keys = send_parts
             yield send_keys(pane_id, keys)
         elif command == "inspect-pane":
             # Use default cache directory for saving full output when truncated

--- a/tests/test_logmanager.py
+++ b/tests/test_logmanager.py
@@ -260,6 +260,24 @@ def test_view_undo_works_on_view():
     assert len(mgr._branches["main"]) == 2  # hello + hi
 
 
+def test_undo_more_than_log_length():
+    """Regression: undo(n) where n > len(log) should not crash."""
+    log = LogManager()
+    log.append(Message("user", "hello"))
+    log.append(Message("assistant", "world"))
+    # undo more messages than exist — should stop gracefully, not IndexError
+    log.undo(n=10, quiet=True)
+    assert len(log.log) == 0
+
+
+def test_undo_on_empty_log():
+    """Regression: undo on empty log should print warning, not crash."""
+    log = LogManager()
+    # should return early with "Nothing to undo"
+    log.undo(quiet=True)
+    assert len(log.log) == 0
+
+
 def test_read_jsonl_malformed(tmp_path):
     """Test that malformed JSON lines are skipped gracefully."""
     jsonl_file = tmp_path / "test.jsonl"

--- a/tests/test_tools_tmux.py
+++ b/tests/test_tools_tmux.py
@@ -9,6 +9,7 @@ import pytest
 
 from gptme.tools.tmux import (
     _capture_pane,
+    execute_tmux,
     get_sessions,
     kill_session,
     list_sessions,
@@ -20,6 +21,26 @@ from gptme.tools.tmux import (
 pytestmark = pytest.mark.skipif(
     shutil.which("tmux") is None, reason="tmux not available"
 )
+
+
+@pytest.mark.skipif(False, reason="")  # override pytestmark — no tmux needed
+class TestExecuteParsing:
+    """Tests for execute_tmux argument parsing (no real tmux needed)."""
+
+    pytestmark: list[pytest.MarkDecorator] = []  # clear module-level skipif
+
+    def test_send_keys_missing_keys_argument(self):
+        """Regression: send-keys with only pane_id should error, not crash."""
+        msgs = list(execute_tmux("send-keys pane_0", args=[], kwargs=None))
+        assert len(msgs) == 1
+        assert "Error" in msgs[0].content
+        assert "send-keys" in msgs[0].content
+
+    def test_send_keys_missing_all_arguments(self):
+        """send-keys with no arguments should error."""
+        msgs = list(execute_tmux("send-keys", args=[], kwargs=None))
+        assert len(msgs) == 1
+        assert "Error" in msgs[0].content
 
 
 def _get_worker_id() -> str:


### PR DESCRIPTION
## Summary

Two crash fixes found through systematic code review:

- **LogManager.undo(n) IndexError**: When `n` exceeds the number of messages in the log, `self.log[-1]` crashes with `IndexError` inside the undo loop. The emptiness check at line 421 only guards the loop entry, not subsequent iterations. Fixed by adding a `break` when the log becomes empty during iteration.

- **tmux send-keys ValueError**: When `send-keys` is called with only a pane_id and no keys argument (e.g. `send-keys pane_0`), `_args.split(maxsplit=1)` returns a single element, causing `ValueError: not enough values to unpack`. The `len(parts) < 2` check at line 430 catches missing arguments for the outer command, but not for the inner send-keys arguments. Fixed by validating the split result before unpacking.

## Test plan

- [x] Added `test_undo_more_than_log_length` — verifies undo(10) on 2-message log doesn't crash
- [x] Added `test_undo_on_empty_log` — verifies undo on empty log returns gracefully
- [x] Added `test_send_keys_missing_keys_argument` — verifies error message instead of ValueError
- [x] Added `test_send_keys_missing_all_arguments` — verifies error for bare `send-keys`
- [x] All 11 logmanager tests pass
- [x] All tmux parsing tests pass
- [x] mypy clean, ruff clean
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes crashes in `LogManager.undo()` and `tmux send-keys` by adding checks for log length and argument presence, with new tests for these cases.
> 
>   - **Behavior**:
>     - Fix `IndexError` in `LogManager.undo()` when `n` exceeds log length by adding a break condition.
>     - Fix `ValueError` in `execute_tmux()` for `send-keys` command when missing arguments by checking split result length.
>   - **Tests**:
>     - Add `test_undo_more_than_log_length` and `test_undo_on_empty_log` in `test_logmanager.py` to verify `undo()` behavior with excessive `n` and empty logs.
>     - Add `test_send_keys_missing_keys_argument` and `test_send_keys_missing_all_arguments` in `test_tools_tmux.py` to verify error handling for `send-keys` command with missing arguments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 21fdcc1826dfa89ffba633763cc351bb3ff91456. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->