### PR TITLE
refactor(acp): remove unused adapter scaffolding

### DIFF
--- a/gptme/acp/adapter.py
+++ b/gptme/acp/adapter.py
@@ -2,24 +2,13 @@
 
 This module provides bidirectional conversion between:
 - gptme Message <-> ACP Content
-- gptme Codeblock <-> ACP ToolCall
-- gptme LogManager <-> ACP Session
 """
 
 from __future__ import annotations
 
-import uuid
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 from ..message import Message
-
-if TYPE_CHECKING:
-    from ..codeblock import Codeblock
-
-
-def generate_id() -> str:
-    """Generate a unique ID for ACP objects."""
-    return str(uuid.uuid4())[:8]
 
 
 def gptme_message_to_acp_content(msg: Message) -> list[dict]:
@@ -35,7 +24,6 @@ def gptme_message_to_acp_content(msg: Message) -> list[dict]:
 
     # Add main text content
     if msg.content:
-        # TODO: Handle codeblocks in Phase 2 - for now, just append plain text
         text = msg.content
         content.append(
             {
@@ -76,44 +64,3 @@ def acp_content_to_gptme_message(content: list, role: RoleType) -> Message:
                 text_parts.append(getattr(c, "text", "") or "")
 
     return Message(role=role, content="\n".join(text_parts))
-
-
-def gptme_codeblock_to_tool_info(block: Codeblock) -> dict:
-    """Convert a gptme Codeblock to ACP tool information.
-
-    Args:
-        block: gptme Codeblock
-
-    Returns:
-        Dictionary with tool information for ACP
-    """
-    # Determine tool kind based on language
-    kind = "execute"
-    if block.lang in ("save", "append", "patch"):
-        kind = "edit"
-    elif block.lang == "shell":
-        kind = "terminal"
-
-    return {
-        "id": generate_id(),
-        "kind": kind,
-        "name": f"{block.lang} execution",
-        "language": block.lang,
-        "content": block.content,
-    }
-
-
-def format_tool_result(result: str | None, success: bool = True) -> dict:
-    """Format tool execution result for ACP.
-
-    Args:
-        result: Tool execution output
-        success: Whether execution succeeded
-
-    Returns:
-        ACP-formatted result dictionary
-    """
-    return {
-        "status": "completed" if success else "failed",
-        "output": result or "",
-    }


### PR DESCRIPTION
## Summary

- Remove 3 dead functions from `adapter.py` that were Phase 2 scaffolding never integrated
- `generate_id()`: Superseded by `ToolCall.generate_id()` in types.py (also had inferior 8-char UUID vs 12-char)
- `gptme_codeblock_to_tool_info()`: Never called from any module
- `format_tool_result()`: Never called from any module
- Remove unused imports (`uuid`, `TYPE_CHECKING`, `Codeblock`) and obsolete TODO comment
- Remove corresponding tests for deleted functions

**-142 lines, 0 behavior change.** All 17 remaining adapter tests pass.

## Test plan

- [x] `pytest tests/test_acp_adapter.py` — 17/17 pass
- [x] `mypy gptme/acp/adapter.py` — clean
- [x] `ruff check gptme/acp/adapter.py` — clean
- [x] Verified no cross-module imports of removed functions
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unused functions and related tests from `adapter.py`, clean up imports and comments, with no behavior changes.
> 
>   - **Functions Removed**:
>     - `generate_id()`, `gptme_codeblock_to_tool_info()`, `format_tool_result()` removed from `adapter.py`.
>     - Corresponding tests removed from `test_acp_adapter.py`.
>   - **Imports and Comments**:
>     - Removed unused imports: `uuid`, `TYPE_CHECKING`, `Codeblock`.
>     - Removed obsolete TODO comment in `adapter.py`.
>   - **Testing**:
>     - All 17 remaining tests in `test_acp_adapter.py` pass.
>     - Verified no cross-module imports of removed functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for bf687d795a74bb327324e97cec8060ac630b2e7d. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->