### PR TITLE
fix(acp): replace assert guards with explicit runtime checks

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -429,7 +429,9 @@ class GptmeAgent:
                     "Ensure API keys are set in environment or config.toml."
                 )
                 logger.error(self._init_error)
-                return InitializeResponse(protocol_version=protocol_version)  # type: ignore[misc]
+                return _check_acp_import(InitializeResponse, "InitializeResponse")(
+                    protocol_version=protocol_version
+                )  # type: ignore[misc]
 
             self._initialized = True
             # Capture the resolved model (from config/env/auto-detect)


### PR DESCRIPTION
## Summary

- Replace 10 bare `assert` statements in `gptme/acp/agent.py` with explicit `if ... is None: raise RuntimeError(...)` checks
- Add `_check_acp_import()` helper function to keep the checks DRY
- Aligns ACP module with established pattern in `server/api.py` (line 263) and `server/api_v2.py` (line 390)

## Why

Python's `assert` statements are stripped when running with `python -O` (optimized mode). The existing asserts guard lazy-imported ACP types (`InitializeResponse`, `NewSessionResponse`, `PromptResponse`) — if assertions are disabled, these become silent `NoneType is not callable` crashes instead of clear error messages.

The server modules already explicitly avoid assert for this reason:
```python
# server/api.py:263
# Validate request body (use proper checks, not assert which can be disabled with -O)

# server/api_v2.py:390
# (cannot use assert as it can be disabled with python -O)
```

## Test plan

- [x] All 109 ACP tests pass
- [x] ruff check passes
- [x] mypy passes
- [x] No behavioral change — same error conditions, just RuntimeError instead of AssertionError
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `assert` statements with explicit runtime checks in `gptme/acp/agent.py` to prevent silent failures in optimized mode, introducing `_check_acp_import()` for consistency.
> 
>   - **Behavior**:
>     - Replace 10 `assert` statements in `gptme/acp/agent.py` with `if ... is None: raise RuntimeError(...)` checks.
>     - Introduce `_check_acp_import()` to centralize import checks for `InitializeResponse`, `NewSessionResponse`, `PromptResponse`.
>     - Aligns with patterns in `server/api.py` and `server/api_v2.py`.
>   - **Rationale**:
>     - Prevents silent failures when running Python with `-O` (optimized mode) by replacing `assert` with explicit checks.
>   - **Testing**:
>     - All 109 ACP tests pass.
>     - `ruff` and `mypy` checks pass.
>     - No behavioral change, only exception type changes from `AssertionError` to `RuntimeError`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for dd1073e4fd665d33f6090f331dad04751b12f400. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->