### PR TITLE
fix(context): use proper type annotations in config dataclasses

### DIFF
--- a/gptme/context/config.py
+++ b/gptme/context/config.py
@@ -1,6 +1,7 @@
 """Unified context configuration."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any
 
 from .selector.config import ContextSelectorConfig
 
@@ -24,15 +25,10 @@ class ContextConfig:
     enabled: bool = False  # Default: opt-in
 
     # Nested selector configuration
-    selector: ContextSelectorConfig = None  # type: ignore[assignment]
-
-    def __post_init__(self):
-        # Default selector config if not provided
-        if self.selector is None:
-            self.selector = ContextSelectorConfig()
+    selector: ContextSelectorConfig = field(default_factory=ContextSelectorConfig)
 
     @classmethod
-    def from_dict(cls, config_dict: dict) -> "ContextConfig":
+    def from_dict(cls, config_dict: dict[str, Any]) -> "ContextConfig":
         """Create config from dictionary (typically from gptme.toml).
 
         Example:

--- a/gptme/context/selector/config.py
+++ b/gptme/context/selector/config.py
@@ -1,7 +1,7 @@
 """Configuration schema for context selector."""
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal
 
 
 @dataclass
@@ -30,7 +30,7 @@ class ContextSelectorConfig:
     file_recency_weight: float = 1.0
 
     @classmethod
-    def from_dict(cls, config_dict: dict) -> "ContextSelectorConfig":
+    def from_dict(cls, config_dict: dict[str, Any]) -> "ContextSelectorConfig":
         """Create config from dictionary (typically from gptme.toml)."""
         return cls(
             **{k: v for k, v in config_dict.items() if k in cls.__dataclass_fields__}

--- a/gptme/context/selector/file_config.py
+++ b/gptme/context/selector/file_config.py
@@ -1,6 +1,6 @@
 """File-specific configuration for context selector."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from .config import ContextSelectorConfig
 
@@ -10,42 +10,35 @@ class FileSelectorConfig(ContextSelectorConfig):
     """Configuration for file selection with file-specific boosts."""
 
     # Mention count boosts (files mentioned more frequently)
-    mention_boost_thresholds: dict[int, float] = None  # type: ignore[assignment]
+    mention_boost_thresholds: dict[int, float] = field(
+        default_factory=lambda: {
+            10: 3.0,  # 10+ mentions: 3x boost
+            5: 2.0,  # 5-9 mentions: 2x boost
+            2: 1.5,  # 2-4 mentions: 1.5x boost
+            1: 1.0,  # 1 mention: no boost
+        }
+    )
 
     # Recency boosts (files modified recently)
-    recency_boost_hours: dict[float, float] = None  # type: ignore[assignment]
+    recency_boost_hours: dict[float, float] = field(
+        default_factory=lambda: {
+            1.0: 1.3,  # Modified in last hour: 1.3x boost
+            24.0: 1.1,  # Modified today: 1.1x boost
+            168.0: 1.05,  # Modified this week: 1.05x boost
+        }
+    )
 
     # File type weights (prioritize certain file types)
-    file_type_weights: dict[str, float] = None  # type: ignore[assignment]
-
-    def __post_init__(self):
-        # Default mention count boosts
-        if self.mention_boost_thresholds is None:
-            self.mention_boost_thresholds = {
-                10: 3.0,  # 10+ mentions: 3x boost
-                5: 2.0,  # 5-9 mentions: 2x boost
-                2: 1.5,  # 2-4 mentions: 1.5x boost
-                1: 1.0,  # 1 mention: no boost
-            }
-
-        # Default recency boosts (hours since last modification)
-        if self.recency_boost_hours is None:
-            self.recency_boost_hours = {
-                1.0: 1.3,  # Modified in last hour: 1.3x boost
-                24.0: 1.1,  # Modified today: 1.1x boost
-                168.0: 1.05,  # Modified this week: 1.05x boost
-            }
-
-        # Default file type weights
-        if self.file_type_weights is None:
-            self.file_type_weights = {
-                "py": 1.3,  # Python files more relevant
-                "md": 1.2,  # Markdown documentation
-                "toml": 1.1,  # Config files
-                "yaml": 1.1,
-                "json": 1.0,
-                "txt": 1.0,
-            }
+    file_type_weights: dict[str, float] = field(
+        default_factory=lambda: {
+            "py": 1.3,  # Python files more relevant
+            "md": 1.2,  # Markdown documentation
+            "toml": 1.1,  # Config files
+            "yaml": 1.1,
+            "json": 1.0,
+            "txt": 1.0,
+        }
+    )
 
     def get_mention_boost(self, mention_count: int) -> float:
         """Get boost factor based on mention count."""


### PR DESCRIPTION
## Summary
- Replace `type: ignore[assignment]` hacks with idiomatic `field(default_factory=...)` for dict fields in `FileSelectorConfig` and `ContextConfig.selector`
- Add `dict[str, Any]` type parameters to bare `dict` annotations in `from_dict()` methods
- Remove 4 `type: ignore[assignment]` suppressions while preserving identical runtime behavior

## Details

The context config dataclasses used a pattern of `field: dict[K, V] = None  # type: ignore[assignment]` with `__post_init__` to set defaults. This suppressed mypy type checking and was unnecessary — `field(default_factory=...)` handles this idiomatically.

**Files changed:**
- `gptme/context/selector/file_config.py` — 3 dict fields now use `default_factory`, `__post_init__` removed
- `gptme/context/config.py` — `selector` field uses `default_factory=ContextSelectorConfig`, `__post_init__` removed
- `gptme/context/selector/config.py` — `from_dict()` parameter typed as `dict[str, Any]`

## Test plan
- [x] All 13 `test_file_selector_integration.py` tests pass
- [x] All 18 `test_integration_phase4.py` tests pass (6 skipped — LLM-dependent)
- [x] mypy clean on all modified files
- [x] Pre-commit hooks pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve type annotations and remove unnecessary type ignores in configuration dataclasses using `field(default_factory=...)`.
> 
>   - **Type Annotations**:
>     - Replace `type: ignore[assignment]` with `field(default_factory=...)` for dict fields in `FileSelectorConfig` and `ContextConfig.selector`.
>     - Add `dict[str, Any]` type parameters to `from_dict()` methods in `config.py` and `selector/config.py`.
>   - **Code Cleanup**:
>     - Remove `__post_init__` methods in `config.py` and `file_config.py` by using `default_factory`.
>     - Eliminate 4 `type: ignore[assignment]` suppressions while maintaining runtime behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for c510108ece8bf96dc88cbfa79c17913c56a9d915. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->