### PR TITLE
style: remove self-assignment and add timezone to datetime.now() calls

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,12 +6,12 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 import re
-from datetime import date
+from datetime import datetime, timezone
 
 from docutils import nodes
 from docutils.parsers.rst import Directive
 
-year = date.today().year
+year = datetime.now(tz=timezone.utc).year
 project = "gptme"
 copyright = f"{year}, Erik Bjäreholt"
 author = "Erik Bjäreholt"

--- a/gptme/__init__.py
+++ b/gptme/__init__.py
@@ -6,4 +6,3 @@ from .message import Message
 from .prompts import get_prompt
 
 __all__ = ["chat", "LogManager", "Message", "get_prompt", "Codeblock", "__version__"]
-__version__ = __version__

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -8,7 +8,7 @@ import signal
 import sys
 import traceback
 import warnings
-from datetime import datetime
+from datetime import datetime, timezone
 from itertools import islice
 from pathlib import Path
 from typing import Literal
@@ -353,7 +353,8 @@ def main(
         profile_dir = Path("profiles")
         profile_dir.mkdir(exist_ok=True)
         profile_path = (
-            profile_dir / f"gptme-{datetime.now().strftime('%Y%m%d-%H%M%S')}.prof"
+            profile_dir
+            / f"gptme-{datetime.now(tz=timezone.utc).strftime('%Y%m%d-%H%M%S')}.prof"
         )
 
         def save_profile():

--- a/gptme/context/selector/file_selector.py
+++ b/gptme/context/selector/file_selector.py
@@ -2,7 +2,7 @@
 
 import logging
 import subprocess
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from ...message import Message
@@ -137,7 +137,7 @@ def select_relevant_files(
                 candidates[f] = 0
 
     # Convert to FileItems with metadata
-    now = datetime.now().timestamp()
+    now = datetime.now(tz=timezone.utc).timestamp()
     file_items = []
 
     # Pre-calculate counts for mentioned files only (optimization)

--- a/gptme/eval/dspy/experiments.py
+++ b/gptme/eval/dspy/experiments.py
@@ -6,7 +6,7 @@ Refactored to use composition and single responsibility principle.
 
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -198,7 +198,7 @@ class ExperimentRunner:
             "tool_usage_score": baseline_results["tool_usage_score"],
             "judge_score": baseline_results["judge_score"],
             "num_examples": baseline_results["num_examples"],
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             "detailed_results": baseline_results,
         }
 
@@ -266,7 +266,7 @@ class OptimizationExperiment:
         self.results: dict[str, Any] = {
             "experiment_name": name,
             "model": model,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
         }
 
     def run_baseline_evaluation(
@@ -307,7 +307,7 @@ class OptimizationExperiment:
             "base_prompt": base_prompt,
             "optimized_prompt": optimized_prompt,
             "results": optimization_results,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
         }
 
         if "optimizations" not in self.results:
@@ -351,7 +351,7 @@ class OptimizationExperiment:
 
         self.results["comparisons"] = {
             "results": comparison_results,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
             "num_examples": num_examples,
         }
 


### PR DESCRIPTION
## Summary

- Remove pointless `__version__ = __version__` self-assignment in `__init__.py` (PLW0127)
- Add explicit `tz=timezone.utc` to `datetime.now()` calls in 4 files (DTZ005/DTZ011):
  - `gptme/cli/main.py` — profiling filename
  - `docs/conf.py` — copyright year
  - `gptme/context/selector/file_selector.py` — file recency calculation
  - `gptme/eval/dspy/experiments.py` — experiment timestamps

## Test plan

- [x] `ruff check` passes on all changed files
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy)
- [ ] CI green
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove redundant self-assignment and add timezone to `datetime.now()` calls in multiple files for improved code quality and correctness.
> 
>   - **Behavior**:
>     - Remove redundant `__version__ = __version__` in `__init__.py`.
>     - Add `tz=timezone.utc` to `datetime.now()` in `main.py`, `conf.py`, `file_selector.py`, and `experiments.py` for timezone awareness.
>   - **Misc**:
>     - Ensure `ruff check` and pre-commit hooks pass on all changed files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for a2f38bfc65eea55411b8eef05be1572bcbc61cd4. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->