### PR TITLE
fix(todo): allow setting paused state on todo items

### DIFF
--- a/tests/test_tools_todo.py
+++ b/tests/test_tools_todo.py
@@ -79,6 +79,27 @@ def test_todowrite_update_state():
     assert _current_todos["1"]["state"] == "completed"
 
 
+def test_todowrite_update_paused():
+    """Test updating todo state to paused."""
+    _todowrite("add", "Test", "todo")
+
+    # Update state to paused
+    result = _todowrite("update", "1", "paused")
+    assert "Updated todo 1 state to: paused" in result
+    assert _current_todos["1"]["state"] == "paused"
+
+    # Verify paused shows correct emoji in list
+    result = _todoread()
+    assert "⏸️" in result
+
+    # Verify paused counts as incomplete
+    from gptme.tools.todo import get_incomplete_todos_summary, has_incomplete_todos
+
+    assert has_incomplete_todos()
+    summary = get_incomplete_todos_summary()
+    assert "Test todo" in summary
+
+
 def test_todowrite_update_text():
     """Test updating todo text."""
     # Add a todo first


### PR DESCRIPTION
## Summary

The `TodoItem` class and display formatting already supported a `paused` state with its own emoji (⏸️), but `_todowrite()` rejected it as invalid since `valid_states` only included `pending/in_progress/completed`.

- Add `paused` to `valid_states` in `_todowrite()`
- Include `paused` in `has_incomplete_todos()` and `get_incomplete_todos_summary()` (paused items are incomplete)
- Update tool instructions to document the `paused` state
- Add test covering paused state: setting, emoji display, and incomplete tracking

## Test plan

- [x] All 19 todo tool tests pass (including new `test_todowrite_update_paused`)
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy)
- [ ] CI green
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for 'paused' state in todo tool, updating functions and tests to handle this new state.
> 
>   - **Behavior**:
>     - Add `paused` to `valid_states` in `_todowrite()` in `todo.py`.
>     - Include `paused` in `has_incomplete_todos()` and `get_incomplete_todos_summary()` in `todo.py`.
>     - Update tool instructions in `todo.py` to document the `paused` state.
>   - **Tests**:
>     - Add `test_todowrite_update_paused()` in `test_tools_todo.py` to cover setting, emoji display, and incomplete tracking for `paused` state.
>     - Ensure all 19 todo tool tests pass, including new test for `paused` state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 9b518b346b77354813be05aa459740ec60de7ac1. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->