### PR TITLE
fix(acp): guard session_update calls against null connection in prompt()

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -736,7 +736,7 @@ class GptmeAgent:
                     content = gptme_message_to_acp_content(response_msg)
                     for block in content:
                         text = block.get("text", "")
-                        if text:
+                        if text and self._conn:
                             chunk = update_agent_message(text_block(text))
                             await self._conn.session_update(
                                 session_id=session_id,
@@ -755,11 +755,12 @@ class GptmeAgent:
             await self._complete_pending_tool_calls(session_id, success=False)
             # Send error message
             error_chunk = update_agent_message(text_block(f"Error: {e}"))
-            await self._conn.session_update(
-                session_id=session_id,
-                update=error_chunk,
-                source="gptme",
-            )
+            if self._conn:
+                await self._conn.session_update(
+                    session_id=session_id,
+                    update=error_chunk,
+                    source="gptme",
+                )
             assert PromptResponse is not None
             return PromptResponse(stop_reason="cancelled")
 


### PR DESCRIPTION
## Summary

- Fix two unguarded `self._conn.session_update()` calls in `prompt()` that crash with `AttributeError` when `self._conn` is `None`
- The error handler path (line 758) is especially dangerous: when an error occurs **and** the connection is lost, the handler itself crashes, masking the original error
- Add `if self._conn:` guards matching the established pattern used at 8 other call sites in the same file
- Add 3 tests verifying null-connection safety for tool call management methods

## Test plan

- [x] All 49 ACP agent tests pass (41 passed, 8 skipped — ACP package not installed)
- [x] `ruff check` clean
- [x] `mypy` clean
- [x] Pre-commit hooks pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add connection guards to `session_update` calls in `prompt()` to prevent crashes when connection is `None`, and add tests for null-connection safety.
> 
>   - **Behavior**:
>     - Add `if self._conn:` guards to `session_update` calls in `prompt()` to prevent `AttributeError` when `self._conn` is `None`.
>     - Specifically guards error handler path (line 758) to prevent crash masking original error.
>   - **Tests**:
>     - Add `TestConnNullGuard` class in `test_acp_agent.py` with tests for null-connection safety in tool call management methods.
>     - Verifies `_complete_pending_tool_calls`, `_report_tool_call`, and `_update_tool_call` handle `None` connection gracefully.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 6dfc67278c05f2724a055c0ab372fbb353d41df1. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->