### PR TITLE
style: enable PT011/PT022 rules, clean up unused noqa and imports

### DIFF
--- a/gptme/commands/__init__.py
+++ b/gptme/commands/__init__.py
@@ -15,11 +15,11 @@ from pathlib import Path
 from .. import llm as _llm  # noqa: F401
 
 # Import command modules to register their commands
-from . import (
-    export,  # noqa: F401
-    llm,  # noqa: F401
-    meta,  # noqa: F401
-    session,  # noqa: F401
+from . import (  # noqa: F401
+    export,
+    llm,
+    meta,
+    session,
 )
 
 # Re-export core types and functions from base

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,7 @@ select = [
     "RUF010", "RUF019", "RUF100",  # ruff-specific
     "PLW1510",  # subprocess-run-without-check
     "TCH001", "TCH002", "TCH003", "TCH004",  # flake8-type-checking
-    "PT003", "PT006", "PT022",  # pytest style (auto-fixable subset)
+    "PT003", "PT006", "PT011", "PT022",  # pytest style
 ]
 ignore = ["E402", "E501", "B905"]
 #fixable = ["ALL"]

--- a/tests/test_lessons_parser.py
+++ b/tests/test_lessons_parser.py
@@ -212,7 +212,9 @@ invalid: yaml: syntax:
 """
             lesson_file.write_text(content)
 
-            with pytest.raises(ValueError) as exc_info:
+            with pytest.raises(
+                ValueError, match="Invalid YAML frontmatter"
+            ) as exc_info:
                 parse_lesson(lesson_file)
             assert "Invalid YAML frontmatter" in str(exc_info.value)
 

--- a/tests/test_master_context.py
+++ b/tests/test_master_context.py
@@ -98,7 +98,7 @@ def test_recover_from_master_context_invalid_json():
 
     try:
         byte_range = MessageByteRange(message_idx=0, byte_start=0, byte_end=22)
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError, match="Invalid JSON at byte range") as excinfo:
             recover_from_master_context(path, byte_range)
         assert "Invalid JSON at byte range" in str(excinfo.value)
     finally:
@@ -118,7 +118,7 @@ def test_recover_from_master_context_missing_content():
             data = rf.read()
         byte_range = MessageByteRange(message_idx=0, byte_start=0, byte_end=len(data))
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError, match="has no 'content' field") as excinfo:
             recover_from_master_context(path, byte_range)
         assert "has no 'content' field" in str(excinfo.value)
     finally:

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Any, cast
 
 import pytest
-import tomlkit  # noqa
 
 from gptme.config import ChatConfig, MCPConfig
 from gptme.llm.models import ModelMeta, get_default_model

--- a/tests/test_shell_fd_leak.py
+++ b/tests/test_shell_fd_leak.py
@@ -25,15 +25,15 @@ def test_shell_session_pipes_closed_after_close():
     # After close, these file descriptors should be closed
     # Trying to use them should raise OSError (bad file descriptor)
     if stdout_fd is not None:
-        with pytest.raises(OSError):
+        with pytest.raises(OSError, match="Bad file descriptor"):
             os.fstat(stdout_fd)
 
     if stderr_fd is not None:
-        with pytest.raises(OSError):
+        with pytest.raises(OSError, match="Bad file descriptor"):
             os.fstat(stderr_fd)
 
     if stdin_fd is not None:
-        with pytest.raises(OSError):
+        with pytest.raises(OSError, match="Bad file descriptor"):
             os.fstat(stdin_fd)
 
 
@@ -59,7 +59,7 @@ def test_conversation_shell_cleanup():
 
     # File descriptors should be closed
     if stdout_fd is not None:
-        with pytest.raises(OSError):
+        with pytest.raises(OSError, match="Bad file descriptor"):
             os.fstat(stdout_fd)
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -49,7 +49,7 @@ def test_init_tools_allowlist_from_env():
 
 
 def test_init_tools_fails():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="not found"):
         init_tools(allowlist=["save", "missing_tool"])
 
 

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -43,11 +43,11 @@ class TestURI:
 
     def test_uri_invalid(self):
         """Test that invalid URIs raise ValueError."""
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Invalid URI"):
             URI("not-a-uri")
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Invalid URI"):
             URI("/local/path")
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Invalid URI"):
             URI("relative/path.txt")
 
     def test_uri_equality(self):


### PR DESCRIPTION
## Summary

- **Enable PT011** (pytest-raises-too-broad) and **PT022** (pytest-useless-yield-fixture) ruff rules
- Add `match=` patterns to all 11 `pytest.raises()` calls across 5 test files, ensuring tests verify the correct exception message rather than just the exception type
- Remove 6 unused `noqa: F401` directives (side-effect imports properly re-suppressed)
- Remove unused `tomlkit` import in `test_server_v2.py`
- Replace `f.write` loop with `f.writelines` (FURB122) in `scripts/train/collect.py`
- Replace `yield` with `return` in 2 fixtures without teardown (PT022) in `conftest.py`

## Details

### PT011 fixes (11 violations → 0)
Each `pytest.raises(ValueError)` / `pytest.raises(OSError)` now includes a `match=` parameter with a substring of the actual error message from the source code:

| File | Match pattern | Source |
|------|---------------|--------|
| `test_lessons_parser.py` | `"Invalid YAML frontmatter"` | `parser.py:356` |
| `test_master_context.py` | `"Invalid JSON at byte range"` | `master_context.py:124` |
| `test_master_context.py` | `"has no 'content' field"` | `master_context.py:130` |
| `test_shell_fd_leak.py` (×4) | `"Bad file descriptor"` | `os.fstat()` on closed fd |
| `test_tools.py` | `"not found"` | `tools/__init__.py:161` |
| `test_uri.py` (×3) | `"Invalid URI"` | `uri.py:75` |

### PT022 fixes (2 violations → 0)
`server_thread` and `setup_conversation` fixtures in `conftest.py` use `yield` but have no teardown code — replaced with `return`.

## Test plan
- [x] All modified test files pass locally (`pytest` — 92 tests pass)
- [x] `ruff check` clean (0 violations for PT011, PT022, RUF100)
- [ ] CI passes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable PT011/PT022 rules, add match patterns to exception tests, and clean up unused code elements.
> 
>   - **Linting Rules**:
>     - Enable `PT011` and `PT022` rules in `pyproject.toml`.
>   - **Exception Handling**:
>     - Add `match=` parameter to `pytest.raises()` in `test_lessons_parser.py`, `test_master_context.py`, `test_shell_fd_leak.py`, `test_tools.py`, and `test_uri.py` to ensure correct exception messages.
>   - **Code Cleanup**:
>     - Remove 6 unused `noqa: F401` directives in `commands/__init__.py`.
>     - Remove unused `tomlkit` import in `test_server_v2.py`.
>     - Replace `f.write` loop with `f.writelines` in `scripts/train/collect.py`.
>     - Replace `yield` with `return` in `server_thread` and `setup_conversation` fixtures in `conftest.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for d4555e0fcb2c9d0527a06484b61a15214d878b32. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->