### PR TITLE
fix(acp): include gptme version in ACP agent startup log

### DIFF
--- a/gptme/acp/__main__.py
+++ b/gptme/acp/__main__.py
@@ -147,7 +147,13 @@ def main() -> int:
         )
         return 1
 
-    logger.info("Starting gptme ACP agent...")
+    try:
+        import importlib.metadata
+
+        _version = importlib.metadata.version("gptme")
+    except Exception:
+        _version = "unknown"
+    logger.info("Starting gptme ACP agent (v%s)...", _version)
 
     try:
         asyncio.run(_run_acp(real_stdin, real_stdout))


### PR DESCRIPTION
Show gptme version in ACP agent startup log message (e.g. `Starting gptme ACP agent (v0.31.0)...`). Uses `importlib.metadata` with graceful fallback to `unknown`. Requested in #1393.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Logs `gptme` version in ACP agent startup message using `importlib.metadata` with fallback to 'unknown'.
> 
>   - **Behavior**:
>     - Logs `gptme` version in ACP agent startup message in `main()` in `__main__.py`.
>     - Uses `importlib.metadata` to fetch version, falls back to 'unknown' on error.
>   - **Misc**:
>     - Addresses request from issue #1393.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 08f4b71028b1ade4a763d492e478d492f02f1ac7. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->