### PR TITLE
fix(auth): don't truncate OAuth URL in fallback message

### DIFF
--- a/gptme/llm/llm_openai_subscription.py
+++ b/gptme/llm/llm_openai_subscription.py
@@ -295,7 +295,7 @@ def oauth_authenticate() -> SubscriptionAuth:
     server.timeout = 120  # 2 minutes should be sufficient for browser auth
 
     print("\n🔐 Opening browser for OpenAI authentication...")
-    print(f"   If browser doesn't open, visit: {auth_url[:80]}...")
+    print(f"   If browser doesn't open, visit:\n   {auth_url}")
 
     def open_browser() -> None:
         time.sleep(0.5)


### PR DESCRIPTION
## Summary

- The OAuth fallback message (`If browser doesn't open, visit: ...`) was truncating the URL to 80 characters with `auth_url[:80]`, making it unusable in headless/SSH environments where the browser can't open automatically.
- Print the full URL on a new line instead.

## Test plan

- [ ] Trigger OAuth flow in a headless environment (SSH session) and verify the full URL is printed and clickable/copyable
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> In `llm_openai_subscription.py`, `oauth_authenticate()` now prints the full OAuth URL on a new line instead of truncating it, aiding headless/SSH environments.
> 
>   - **Behavior**:
>     - In `oauth_authenticate()` in `llm_openai_subscription.py`, changed OAuth fallback message to print the full `auth_url` on a new line instead of truncating it to 80 characters.
>     - This ensures the URL is usable in headless/SSH environments where the browser cannot open automatically.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 908e99f138ba68a61e1ec03b5eeca21bbc7a38fa. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->