### PR TITLE
Support GPTME_ prefix for environment variables

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -128,7 +128,7 @@ The interface provides /commands during a conversation:
 {commands_help}"""
 
 
-@click.command(help=docstring)
+@click.command(help=docstring, context_settings={"auto_envvar_prefix": "GPTME"})
 @click.pass_context
 @click.argument(
     "prompts",

--- a/gptme/config.py
+++ b/gptme/config.py
@@ -950,12 +950,20 @@ class Config:
         return mcp
 
     def get_env(self, key: str, default: str | None = None) -> str | None:
-        """Gets an environment variable, checks the config file if it's not set in the environment."""
+        """Gets an environment variable, checks the config file if it's not set in the environment.
+
+        Checks both ``GPTME_<KEY>`` and ``<KEY>`` forms for environment variables,
+        with the prefixed form taking precedence. Config file lookups always use
+        the bare (unprefixed) key.
+        """
+        prefixed = f"GPTME_{key}" if not key.startswith("GPTME_") else key
+        bare = key.removeprefix("GPTME_") if key.startswith("GPTME_") else key
         return (
-            os.environ.get(key)
-            or (self.chat and self.chat.env.get(key))
-            or (self.project and self.project.env.get(key))
-            or self.user.env.get(key)
+            os.environ.get(prefixed)
+            or os.environ.get(bare)
+            or (self.chat and self.chat.env.get(bare))
+            or (self.project and self.project.env.get(bare))
+            or self.user.env.get(bare)
             or default
         )
 


### PR DESCRIPTION
Updated based on @TimeToBuildBob's feedback and #1418.

**What changed from v1:**
- Dropped the per-option `envvar=` approach in favor of `auto_envvar_prefix="GPTME"` on the command (as in #1418) — one line, covers everything
- Fixed the Greptile-flagged bug: config file lookups (`chat.env`, `project.env`, `user.env`) now always use the bare key, so passing a prefixed key like `GPTME_MODEL` to `get_env()` won't fail config resolution

**Why keep the `get_env()` change on top of `auto_envvar_prefix`:**

`auto_envvar_prefix` only covers Click's CLI parsing. But `get_env()` is called from a bunch of places outside Click — `init_model()`, the HTTP server, eval environments, etc. Without the `get_env()` update, setting `GPTME_MODEL` in a systemd unit or Docker container would work for the CLI entry point but not for the server or eval runner.

This PR makes both paths consistent: `GPTME_MODEL` works everywhere, not just through Click.

Partial fix for #1415