### PR TITLE
fix(acp): return None from load_session to fix Zed session restore

### DIFF
--- a/gptme/acp/__main__.py
+++ b/gptme/acp/__main__.py
@@ -131,9 +131,11 @@ def main() -> int:
     # === FIRST: capture fds before ANY gptme imports ===
     real_stdin, real_stdout = _capture_stdio_transport()
 
-    # Logging goes to stderr (fd 2, untouched)
+    # Logging goes to stderr (fd 2, untouched).
+    # Respect GPTME_LOG_LEVEL env var for debugging ACP protocol issues.
+    log_level = os.environ.get("GPTME_LOG_LEVEL", "INFO").upper()
     logging.basicConfig(
-        level=logging.INFO,
+        level=getattr(logging, log_level, logging.INFO),
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         stream=sys.stderr,
     )

--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -865,18 +865,28 @@ class GptmeAgent:
         self,
         session_id: str,
         **kwargs: Any,
-    ) -> Any:
-        """Load an existing session (Phase 2 feature).
+    ) -> None:
+        """Attempt to load an existing session.
+
+        gptme ACP sessions are in-memory only and not persisted across restarts.
+        Returns None to signal the session is unavailable, letting the client
+        gracefully fall back to creating a new session via new_session().
+
+        Raising NotImplementedError here would cause a JSON-RPC internal error
+        (-32603) which breaks Zed's session lifecycle — the error state prevents
+        subsequent notifications (AvailableCommandsUpdate, model info) from being
+        processed by the client.
 
         Args:
             session_id: Session ID to load
 
         Returns:
-            Session data or error
+            None to indicate session is not available
         """
-        # Phase 2: Implement session persistence
-        logger.warning(f"load_session not yet implemented: {session_id}")
-        raise NotImplementedError("Session loading not yet implemented")
+        logger.info(
+            f"load_session: session {session_id[:8]} not available (sessions are in-memory only)"
+        )
+        return
 
     def _cleanup_session(self, session_id: str) -> None:
         """Remove all per-session state for a given session.

--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -491,10 +491,16 @@ class TestInitializeWithoutAcp:
         except RuntimeError as e:
             assert "agent-client-protocol" in str(e)
 
-    def test_load_session_not_implemented(self):
+    def test_load_session_returns_none(self):
+        """load_session returns None for unknown sessions (graceful fallback).
+
+        Returning None (instead of raising) lets ACP clients like Zed
+        gracefully fall back to new_session() without an RPC error that
+        would disrupt the session lifecycle.
+        """
         agent = GptmeAgent()
-        with pytest.raises(NotImplementedError, match="not yet implemented"):
-            _run(agent.load_session(session_id="fake_session"))
+        result = _run(agent.load_session(session_id="fake_session"))
+        assert result is None
 
 
 class TestCleanupSession:


### PR DESCRIPTION
## Summary

- **Root cause**: When Zed reopens its ACP panel, it calls `load_session` with the previous session ID. gptme raised `NotImplementedError`, causing a JSON-RPC internal error (-32603) that disrupted Zed's session lifecycle — preventing it from processing `AvailableCommandsUpdate` and model info notifications even after a new session was created.
- **Fix**: Return `None` from `load_session` instead of raising. Per the ACP spec, `None` means "session not available" and lets clients gracefully fall back to `new_session()`.
- **Bonus**: ACP log level now respects `GPTME_LOG_LEVEL` env var (e.g. `GPTME_LOG_LEVEL=DEBUG`) for easier protocol debugging.

## Context

This addresses the remaining regression reported in #1393 by @Andrei-Pozolotin. The previous fixes (#1394, #1396, #1412) correctly implemented slash command handling and `AvailableCommandsUpdate`, but the `load_session` error was preventing Zed from receiving those notifications.

The user's logs showed:
```
ERROR [agent_client_protocol::rpc] failed to handle notification: Error { code: -32603: Internal error, message: "Internal error", data: Some(String("Failed to get session")) }
INFO - ACP AvailableCommandsUpdate: sent 39 commands for session 48c5112d
```

The 39 commands were sent successfully by gptme, but Zed was in an error state from the failed `load_session` and discarded them.

## Test plan

- [x] All 58 ACP agent tests pass
- [x] `test_load_session_returns_none` verifies graceful None return
- [ ] @Andrei-Pozolotin to verify in Zed after install from master
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `load_session` in `agent.py` to return `None` for unknown sessions, allowing Zed to handle session restoration gracefully, and update logging configuration in `__main__.py`.
> 
>   - **Behavior**:
>     - `load_session` in `agent.py` now returns `None` instead of raising `NotImplementedError`, allowing Zed to handle session restoration gracefully.
>     - Logging in `__main__.py` now respects `GPTME_LOG_LEVEL` environment variable for debugging.
>   - **Tests**:
>     - Added `test_load_session_returns_none` in `test_acp_agent.py` to verify `load_session` returns `None` for unknown sessions.
>   - **Misc**:
>     - Minor logging changes in `__main__.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 8f533a00334fd1c4bb787c2c34db2e914f5142a6. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->