### PR TITLE
feat(acp): return modes and models in NewSessionResponse

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -1027,10 +1027,12 @@ class GptmeAgent:
     def _cleanup_session(self, session_id: str) -> None:
         """Remove all per-session state for a given session.
 
-        Cleans up _session_models, _tool_calls, and _permission_policies
-        to prevent unbounded memory growth from accumulated sessions.
+        Cleans up _session_models, _session_modes, _tool_calls, and
+        _permission_policies to prevent unbounded memory growth from
+        accumulated sessions.
         """
         self._session_models.pop(session_id, None)
+        self._session_modes.pop(session_id, None)
         self._tool_calls.pop(session_id, None)
         self._permission_policies.pop(session_id, None)
         self._session_commands_advertised.discard(session_id)

--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -507,12 +507,13 @@ class TestCleanupSession:
     """Tests for _cleanup_session and cancel methods."""
 
     def test_cleanup_removes_all_state(self):
-        """_cleanup_session should remove session_models, tool_calls, and permission_policies."""
+        """_cleanup_session should remove session_models, session_modes, tool_calls, and permission_policies."""
         agent = GptmeAgent()
         sid = "session_cleanup_test"
 
         # Populate all per-session state
         agent._session_models[sid] = "anthropic/claude-sonnet-4-6"
+        agent._session_modes[sid] = "auto"
         agent._tool_calls[sid] = {
             "call_1": ToolCall(
                 tool_call_id="call_1", title="Test", kind=ToolKind.EXECUTE
@@ -525,6 +526,7 @@ class TestCleanupSession:
         agent._cleanup_session(sid)
 
         assert sid not in agent._session_models
+        assert sid not in agent._session_modes
         assert sid not in agent._tool_calls
         assert sid not in agent._permission_policies
         assert sid not in agent._session_commands_advertised


### PR DESCRIPTION
## Summary
- Returns available modes (`default`, `auto`) and models in `NewSessionResponse`, enabling ACP clients like Zed to display mode switching and model selection UI
- Implements `set_session_mode` handler — "auto" mode skips tool permission prompts (like `--no-confirm`)
- Models populated from gptme's `MODELS` registry, excluding deprecated entries

## Details
**Modes:**
- `default`: Interactive mode — tools require confirmation before executing
- `auto`: Autonomous mode — tools auto-approved without user confirmation

**Models:**
- Lists all non-deprecated models from the built-in registry (OpenAI, Anthropic, OpenRouter, etc.)
- Current model reflects per-session override or global default

Partial fix for #1422.

## Test plan
- [x] 14 new tests covering modes state, models state, set_session_mode, and auto-mode permission bypass
- [x] All 75 ACP agent tests pass
- [x] mypy clean
- [ ] CI passes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `GptmeAgent` to return modes and models in `NewSessionResponse` and implements session mode handling, with comprehensive tests added.
> 
>   - **Behavior**:
>     - `NewSessionResponse` now includes available modes (`default`, `auto`) and models, enabling UI for mode switching and model selection.
>     - Implements `set_session_mode` in `GptmeAgent` to handle mode changes; "auto" mode skips tool permission prompts.
>     - Models are sourced from `MODELS` registry, excluding deprecated ones.
>   - **Functions**:
>     - Adds `_build_modes_state()` and `_build_models_state()` to construct session state.
>     - Updates `new_session()` to include modes and models in the response.
>   - **Tests**:
>     - Adds 14 tests for modes, models, `set_session_mode`, and auto-mode permission bypass in `test_acp_agent.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for a6c3406dbf3fbcb4d7f258650302aaf528586936. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->