### PR TITLE
style: rename deprecated ruff TCH rules to TC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,7 @@ select = [
     "RET501", "RET505", "RET506", "RET507", "RET508",  # flake8-return
     "RUF010", "RUF019", "RUF100",  # ruff-specific
     "PLW1510",  # subprocess-run-without-check
-    "TCH001", "TCH002", "TCH003", "TCH004",  # flake8-type-checking
+    "TC001", "TC002", "TC003", "TC004",  # flake8-type-checking
     "PT003", "PT006", "PT011", "PT022",  # pytest style
 ]
 ignore = ["E402", "E501", "B905", "PERF203"]  # PERF203: try-except-in-loop often intentional


### PR DESCRIPTION
## Summary
- Rename `TCH001`-`TCH004` to `TC001`-`TC004` in ruff config
- These rules were remapped in ruff and produce deprecation warnings

Fixes the `TCH00x has been remapped to TC00x` warnings on every ruff invocation.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rename deprecated ruff rules `TCH001`-`TCH004` to `TC001`-`TC004` in `pyproject.toml` to fix deprecation warnings.
> 
>   - **Ruff Configuration**:
>     - Rename deprecated `TCH001`-`TCH004` to `TC001`-`TC004` in `pyproject.toml`.
>     - Fixes deprecation warnings: `TCH00x has been remapped to TC00x`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for d167baec63f7b7b8fb01abc4ec1624ec9c8232d7. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->