### PR TITLE
ci(test): migrate deprecated codecov action, add coverage to test-no-api

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,20 @@ jobs:
         MODEL: local/test
       run: make test
 
+    - name: Upload coverage reports to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: no-api
+
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        report_type: test_results
+
   test:
     name: Test with `${{ matrix.extras }}` and ${{ matrix.model }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -150,6 +164,7 @@ jobs:
         command: make test SLOW=true
 
     - name: Upload coverage reports to Codecov
+      if: ${{ !cancelled() }}
       uses: codecov/codecov-action@v5
       env:
         MODEL: ${{ matrix.model }}
@@ -160,6 +175,7 @@ jobs:
 
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@v1
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        report_type: test_results


### PR DESCRIPTION
## Summary

- Replace deprecated `codecov/test-results-action@v1` with `codecov/codecov-action@v5` using `report_type: test_results` (eliminates deprecation warning in every CI run)
- Add coverage and test result uploads to the `test-no-api` job — previously only the API test job uploaded these, so no-API test runs were invisible in Codecov
- Add `if: !cancelled()` to coverage upload in `test` job for consistency (upload coverage even if tests fail)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update CI to use `codecov/codecov-action@v5` and ensure coverage uploads for all test jobs.
> 
>   - **CI Configuration**:
>     - Replace deprecated `codecov/test-results-action@v1` with `codecov/codecov-action@v5` in `test.yml`.
>     - Add `report_type: test_results` to the new Codecov action.
>   - **Test Jobs**:
>     - Add coverage and test result uploads to `test-no-api` job in `test.yml`.
>     - Add `if: !cancelled()` condition to coverage upload in `test` job for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 676e176b71d1f7e682445d3a2d112df2ea4da31a. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->