### PR TITLE
fix: add timezone awareness to all datetime calls

### DIFF
--- a/gptme/hooks/cache_awareness.py
+++ b/gptme/hooks/cache_awareness.py
@@ -38,7 +38,7 @@ import logging
 from collections.abc import Callable, Generator
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, TypedDict
 
 from ..hooks import HookType, StopPropagation, register_hook
@@ -254,7 +254,7 @@ def _handle_cache_invalidated(
     state = _get_state()
 
     # Update state
-    state.last_invalidation = datetime.now()
+    state.last_invalidation = datetime.now(tz=timezone.utc)
     state.last_invalidation_reason = reason
     state.tokens_before_invalidation = tokens_before
     state.tokens_after_invalidation = tokens_after

--- a/gptme/hooks/time_awareness.py
+++ b/gptme/hooks/time_awareness.py
@@ -16,7 +16,7 @@ Shows time elapsed messages at: 1min, 5min, 10min, 15min, 20min, then every 10mi
 import logging
 from collections.abc import Generator
 from contextvars import ContextVar
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -71,14 +71,16 @@ def add_time_message(
 
         # Initialize conversation start time if first message
         if workspace_str not in conversation_start_times:
-            conversation_start_times[workspace_str] = datetime.now()
+            conversation_start_times[workspace_str] = datetime.now(tz=timezone.utc)
             _conversation_start_times_var.set(conversation_start_times)
             shown_milestones[workspace_str] = set()
             _shown_milestones_var.set(shown_milestones)
             return
 
         # Calculate elapsed time in minutes
-        elapsed = datetime.now() - conversation_start_times[workspace_str]
+        elapsed = (
+            datetime.now(tz=timezone.utc) - conversation_start_times[workspace_str]
+        )
         elapsed_minutes = int(elapsed.total_seconds() / 60)
 
         # Determine which milestone to show
@@ -93,7 +95,7 @@ def add_time_message(
             hours = elapsed_minutes // 60
             minutes = elapsed_minutes % 60
 
-            time_str = datetime.now().strftime("%H:%M")
+            time_str = datetime.now(tz=timezone.utc).strftime("%H:%M")
             if hours > 0:
                 elapsed_str = f"{hours}h {minutes}min" if minutes > 0 else f"{hours}h"
             else:

--- a/gptme/llm/llm_openai_models.py
+++ b/gptme/llm/llm_openai_models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -16,7 +16,7 @@ OPENAI_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_output": 10,
         "supports_vision": True,
         "supports_reasoning": True,
-        "knowledge_cutoff": datetime(2024, 9, 30),
+        "knowledge_cutoff": datetime(2024, 9, 30, tzinfo=timezone.utc),
     },
     "gpt-5-mini": {
         "context": 400_000,
@@ -25,7 +25,7 @@ OPENAI_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_output": 2,
         "supports_vision": True,
         "supports_reasoning": True,
-        "knowledge_cutoff": datetime(2024, 5, 31),
+        "knowledge_cutoff": datetime(2024, 5, 31, tzinfo=timezone.utc),
     },
     "gpt-5-nano": {
         "context": 400_000,
@@ -34,7 +34,7 @@ OPENAI_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_output": 0.4,
         "supports_vision": True,
         "supports_reasoning": True,
-        "knowledge_cutoff": datetime(2024, 5, 31),
+        "knowledge_cutoff": datetime(2024, 5, 31, tzinfo=timezone.utc),
     },
     # GPT-4.1
     "gpt-4.1": {
@@ -43,7 +43,7 @@ OPENAI_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_input": 2,
         "price_output": 8,
         "supports_vision": True,
-        "knowledge_cutoff": datetime(2024, 6, 1),
+        "knowledge_cutoff": datetime(2024, 6, 1, tzinfo=timezone.utc),
     },
     "gpt-4.1-mini": {
         "context": 1_047_576,
@@ -51,7 +51,7 @@ OPENAI_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_input": 0.4,
         "price_output": 1.6,
         "supports_vision": True,
-        "knowledge_cutoff": datetime(2024, 6, 1),
+        "knowledge_cutoff": datetime(2024, 6, 1, tzinfo=timezone.utc),
     },
     "gpt-4.1-nano": {
         "context": 1_047_576,
@@ -59,7 +59,7 @@ OPENAI_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_input": 0.1,
         "price_output": 0.4,
         "supports_vision": True,
-        "knowledge_cutoff": datetime(2024, 6, 1),
+        "knowledge_cutoff": datetime(2024, 6, 1, tzinfo=timezone.utc),
     },
     # GPT-4o
     "gpt-4o": {
@@ -68,20 +68,20 @@ OPENAI_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_output": 15,
         "supports_vision": True,
         # October 2023
-        "knowledge_cutoff": datetime(2023, 10, 1),
+        "knowledge_cutoff": datetime(2023, 10, 1, tzinfo=timezone.utc),
     },
     "gpt-4o-2024-08-06": {
         "context": 128_000,
         "price_input": 2.5,
         "price_output": 10,
-        "knowledge_cutoff": datetime(2023, 10, 1),
+        "knowledge_cutoff": datetime(2023, 10, 1, tzinfo=timezone.utc),
         "deprecated": True,
     },
     "gpt-4o-2024-05-13": {
         "context": 128_000,
         "price_input": 5,
         "price_output": 15,
-        "knowledge_cutoff": datetime(2023, 10, 1),
+        "knowledge_cutoff": datetime(2023, 10, 1, tzinfo=timezone.utc),
         "deprecated": True,
     },
     # GPT-4o mini
@@ -90,13 +90,13 @@ OPENAI_MODELS: dict[str, "_ModelDictMeta"] = {
         "price_input": 0.15,
         "price_output": 0.6,
         "supports_vision": True,
-        "knowledge_cutoff": datetime(2023, 10, 1),
+        "knowledge_cutoff": datetime(2023, 10, 1, tzinfo=timezone.utc),
     },
     "gpt-4o-mini-2024-07-18": {
         "context": 128_000,
         "price_input": 0.15,
         "price_output": 0.6,
-        "knowledge_cutoff": datetime(2023, 10, 1),
+        "knowledge_cutoff": datetime(2023, 10, 1, tzinfo=timezone.utc),
         "deprecated": True,
     },
     # OpenAI o4-mini

--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -2,7 +2,7 @@ import logging
 import re
 from contextvars import ContextVar
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import (
     TYPE_CHECKING,
     Literal,
@@ -184,7 +184,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_vision": True,
             "supports_reasoning": True,
             "knowledge_cutoff": datetime(
-                2025, 8, 1
+                2025, 8, 1, tzinfo=timezone.utc
             ),  # training cutoff Aug 2025, reliable May 2025
         },
         "claude-sonnet-4-6": {
@@ -195,7 +195,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_vision": True,
             "supports_reasoning": True,
             "knowledge_cutoff": datetime(
-                2026, 1, 1
+                2026, 1, 1, tzinfo=timezone.utc
             ),  # training cutoff Jan 2026, reliable Aug 2025
         },
         "claude-opus-4-5-20251101": {
@@ -206,7 +206,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_vision": True,
             "supports_reasoning": True,
             "knowledge_cutoff": datetime(
-                2025, 8, 1
+                2025, 8, 1, tzinfo=timezone.utc
             ),  # training cutoff Aug 2025, reliable May 2025
         },
         "claude-sonnet-4-5-20250929": {
@@ -217,7 +217,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_vision": True,
             "supports_reasoning": True,
             "knowledge_cutoff": datetime(
-                2025, 7, 1
+                2025, 7, 1, tzinfo=timezone.utc
             ),  # training cutoff Jul 2025, reliable Jan 2025
         },
         "claude-haiku-4-5-20251001": {
@@ -227,7 +227,9 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 5,
             "supports_vision": True,
             "supports_reasoning": True,
-            "knowledge_cutoff": datetime(2025, 7, 1),  # "reliable cutoff" is Feb 2025
+            "knowledge_cutoff": datetime(
+                2025, 7, 1, tzinfo=timezone.utc
+            ),  # "reliable cutoff" is Feb 2025
         },
         "claude-opus-4-1-20250805": {
             "context": 200_000,
@@ -236,7 +238,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 75,
             "supports_vision": True,
             "supports_reasoning": True,
-            "knowledge_cutoff": datetime(2025, 3, 1),
+            "knowledge_cutoff": datetime(2025, 3, 1, tzinfo=timezone.utc),
         },
         "claude-opus-4-20250514": {
             "context": 200_000,
@@ -245,7 +247,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 75,
             "supports_vision": True,
             "supports_reasoning": True,
-            "knowledge_cutoff": datetime(2025, 3, 1),
+            "knowledge_cutoff": datetime(2025, 3, 1, tzinfo=timezone.utc),
         },
         "claude-sonnet-4-20250514": {
             "context": 200_000,
@@ -254,7 +256,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 15,
             "supports_vision": True,
             "supports_reasoning": True,
-            "knowledge_cutoff": datetime(2025, 3, 1),
+            "knowledge_cutoff": datetime(2025, 3, 1, tzinfo=timezone.utc),
         },
         "claude-3-7-sonnet-20250219": {
             "context": 200_000,
@@ -263,7 +265,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 15,
             "supports_vision": True,
             "supports_reasoning": True,
-            "knowledge_cutoff": datetime(2024, 10, 1),
+            "knowledge_cutoff": datetime(2024, 10, 1, tzinfo=timezone.utc),
             "deprecated": True,  # superseded by claude-sonnet-4+
         },
         "claude-3-5-sonnet-20241022": {
@@ -272,7 +274,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 3,
             "price_output": 15,
             "supports_vision": True,
-            "knowledge_cutoff": datetime(2024, 4, 1),
+            "knowledge_cutoff": datetime(2024, 4, 1, tzinfo=timezone.utc),
             "deprecated": True,  # superseded by claude-sonnet-4+
         },
         "claude-3-5-sonnet-20240620": {
@@ -281,7 +283,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 3,
             "price_output": 15,
             "supports_vision": True,
-            "knowledge_cutoff": datetime(2024, 4, 1),
+            "knowledge_cutoff": datetime(2024, 4, 1, tzinfo=timezone.utc),
             "deprecated": True,  # superseded by claude-3-5-sonnet-20241022
         },
         "claude-3-5-haiku-20241022": {
@@ -290,7 +292,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 1,
             "price_output": 5,
             "supports_vision": True,
-            "knowledge_cutoff": datetime(2024, 4, 1),
+            "knowledge_cutoff": datetime(2024, 4, 1, tzinfo=timezone.utc),
             "deprecated": True,  # superseded by claude-haiku-4-5
         },
         "claude-3-haiku-20240307": {
@@ -299,7 +301,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 0.25,
             "price_output": 1.25,
             "supports_vision": True,
-            "knowledge_cutoff": datetime(2024, 4, 1),
+            "knowledge_cutoff": datetime(2024, 4, 1, tzinfo=timezone.utc),
             "deprecated": True,  # superseded by claude-3-5-haiku
         },
         "claude-3-opus-20240229": {
@@ -308,7 +310,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 15,
             "price_output": 75,
             "supports_vision": True,
-            "knowledge_cutoff": datetime(2023, 8, 1),
+            "knowledge_cutoff": datetime(2023, 8, 1, tzinfo=timezone.utc),
             "deprecated": True,  # superseded by claude-opus-4+
         },
         "claude-3-opus-latest": {
@@ -317,7 +319,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_input": 15,
             "price_output": 75,
             "supports_vision": True,
-            "knowledge_cutoff": datetime(2023, 8, 1),
+            "knowledge_cutoff": datetime(2023, 8, 1, tzinfo=timezone.utc),
             "deprecated": True,  # resolves to claude-3-opus-20240229 (deprecated)
         },
     },

--- a/gptme/logmanager.py
+++ b/gptme/logmanager.py
@@ -18,7 +18,7 @@ if os.name == "nt":
 from collections.abc import Generator
 from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
-from datetime import datetime
+from datetime import datetime, timezone
 from itertools import islice, zip_longest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -696,8 +696,12 @@ class ConversationMeta:
         output = f"{self.name} (id: {self.id})"
         if metadata:
             output += f"\nMessages: {self.messages}"
-            output += f"\nCreated:  {datetime.fromtimestamp(self.created)}"
-            output += f"\nModified: {datetime.fromtimestamp(self.modified)}"
+            output += (
+                f"\nCreated:  {datetime.fromtimestamp(self.created, tz=timezone.utc)}"
+            )
+            output += (
+                f"\nModified: {datetime.fromtimestamp(self.modified, tz=timezone.utc)}"
+            )
             if self.branches > 1:
                 output += f"\n({self.branches} branches)"
         return output

--- a/gptme/prompts.py
+++ b/gptme/prompts.py
@@ -764,7 +764,7 @@ def prompt_chat_history() -> Generator[Message, None, None]:
                 # Add conversation metadata
                 summary_parts.append(f"## {conv.name}")
                 summary_parts.append(
-                    f"Modified: {datetime.fromtimestamp(conv.modified).strftime('%Y-%m-%d %H:%M')}"
+                    f"Modified: {datetime.fromtimestamp(conv.modified, tz=timezone.utc).strftime('%Y-%m-%d %H:%M')}"
                 )
 
                 # Always show first exchange to establish context

--- a/gptme/server/api.py
+++ b/gptme/server/api.py
@@ -10,7 +10,7 @@ import io
 import logging
 from collections.abc import Generator
 from contextlib import redirect_stdout
-from datetime import datetime
+from datetime import datetime, timezone
 from importlib import resources
 from itertools import islice
 from pathlib import Path
@@ -220,7 +220,9 @@ def api_conversation_put(logfile: str):
                 400,
             )
         timestamp: datetime = (
-            isoparse(msg["timestamp"]) if "timestamp" in msg else datetime.now()
+            isoparse(msg["timestamp"])
+            if "timestamp" in msg
+            else datetime.now(tz=timezone.utc)
         )
         msgs.append(Message(msg["role"], msg["content"], timestamp=timestamp))
 

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -7,7 +7,7 @@ Session management, tool execution, and agent creation are handled by separate m
 
 import logging
 import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 from itertools import islice
 from typing import cast
 
@@ -217,7 +217,9 @@ def api_conversation_put(conversation_id: str):
                 400,
             )
         timestamp: datetime = (
-            isoparse(msg["timestamp"]) if "timestamp" in msg else datetime.now()
+            isoparse(msg["timestamp"])
+            if "timestamp" in msg
+            else datetime.now(tz=timezone.utc)
         )
         msgs.append(Message(msg["role"], msg["content"], timestamp=timestamp))
 

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -13,7 +13,7 @@ import uuid
 from collections import defaultdict
 from collections.abc import Generator, Iterable
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
 
@@ -153,7 +153,7 @@ class SessionManager:
     @classmethod
     def clean_inactive_sessions(cls, max_age_minutes: int = 60) -> None:
         """Clean up inactive sessions."""
-        cutoff = datetime.now() - timedelta(minutes=max_age_minutes)
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(minutes=max_age_minutes)
         to_remove = []
 
         for session_id, session in cls._sessions.items():

--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -10,7 +10,7 @@ import json
 import logging
 import subprocess
 from dataclasses import asdict, dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
 
@@ -696,13 +696,13 @@ def api_tasks_create():
 
     try:
         # Generate task ID
-        task_id = f"task-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+        task_id = f"task-{datetime.now(tz=timezone.utc).strftime('%Y%m%d-%H%M%S')}"
 
         # Create task
         task = Task(
             id=task_id,
             content=req_json["content"],
-            created_at=datetime.now().isoformat(),
+            created_at=datetime.now(tz=timezone.utc).isoformat(),
             status="pending",
             target_type=req_json.get("target_type", "stdout"),
             target_repo=req_json.get("target_repo"),

--- a/gptme/server/workspace_api.py
+++ b/gptme/server/workspace_api.py
@@ -5,7 +5,7 @@ Workspace API endpoints for browsing files in conversation workspaces.
 import logging
 import mimetypes
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal, TypedDict
 
@@ -114,7 +114,9 @@ class WorkspaceFile:
             "path": self.relative_path,
             "type": "directory" if self.is_dir else "file",
             "size": stat.st_size,
-            "modified": datetime.fromtimestamp(stat.st_mtime).isoformat(),
+            "modified": datetime.fromtimestamp(
+                stat.st_mtime, tz=timezone.utc
+            ).isoformat(),
             "mime_type": self.mime_type,
         }
 

--- a/gptme/session.py
+++ b/gptme/session.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -38,12 +38,14 @@ class BaseSession:
     log: LogManager | None = None
     conversation_id: str | None = None
     active: bool = True
-    created_at: datetime = field(default_factory=datetime.now)
-    last_activity: datetime = field(default_factory=datetime.now)
+    created_at: datetime = field(default_factory=lambda: datetime.now(tz=timezone.utc))
+    last_activity: datetime = field(
+        default_factory=lambda: datetime.now(tz=timezone.utc)
+    )
 
     def touch(self) -> None:
         """Update last activity timestamp."""
-        self.last_activity = datetime.now()
+        self.last_activity = datetime.now(tz=timezone.utc)
 
     def deactivate(self) -> None:
         """Mark session as inactive."""
@@ -143,7 +145,7 @@ class SessionRegistry:
         Returns:
             List of removed session IDs
         """
-        cutoff = datetime.now() - timedelta(minutes=max_age_minutes)
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(minutes=max_age_minutes)
         to_remove: list[str] = []
 
         for session_id, session in self._sessions.items():

--- a/gptme/tools/autocompact.py
+++ b/gptme/tools/autocompact.py
@@ -9,7 +9,7 @@ import logging
 import re
 import time
 from collections.abc import Generator
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
@@ -1141,7 +1141,7 @@ def _get_compacted_name(conversation_name: str) -> str:
     if not base_name:  # Safety: if entire name was the suffix (shouldn't happen)
         base_name = conversation_name
 
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d-%H%M%S")
     return f"{base_name}-compacted-{timestamp}"
 
 

--- a/gptme/tools/screenshot.py
+++ b/gptme/tools/screenshot.py
@@ -6,7 +6,7 @@ import os
 import platform
 import shutil
 import subprocess
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from .base import ToolSpec, ToolUse
@@ -64,7 +64,7 @@ def screenshot(path: Path | None = None) -> Path:
     """
 
     if path is None:
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
         path = OUTPUT_DIR / f"screenshot_{timestamp}.png"
         # Ensure OUTPUT_DIR exists
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/gptme/tools/todo.py
+++ b/gptme/tools/todo.py
@@ -16,7 +16,7 @@ import logging
 import shlex
 from collections import Counter
 from collections.abc import Generator
-from datetime import datetime
+from datetime import datetime, timezone
 
 from dateutil.parser import isoparse
 
@@ -45,8 +45,8 @@ class TodoItem:
         self.id = id
         self.text = text
         self.state = state  # pending, in_progress, completed, paused
-        self.created = created or datetime.now()
-        self.updated = datetime.now()
+        self.created = created or datetime.now(tz=timezone.utc)
+        self.updated = datetime.now(tz=timezone.utc)
 
     def to_dict(self) -> dict:
         return {
@@ -242,10 +242,12 @@ def _todowrite(operation: str, *args: str) -> str:
         valid_states = ["pending", "in_progress", "completed", "paused"]
         if update_value in valid_states:
             _current_todos[todo_id]["state"] = update_value
-            _current_todos[todo_id]["updated"] = datetime.now().isoformat()
+            _current_todos[todo_id]["updated"] = datetime.now(
+                tz=timezone.utc
+            ).isoformat()
             return f"Updated todo {todo_id} state to: {update_value}"
         _current_todos[todo_id]["text"] = update_value
-        _current_todos[todo_id]["updated"] = datetime.now().isoformat()
+        _current_todos[todo_id]["updated"] = datetime.now(tz=timezone.utc).isoformat()
         return f"Updated todo {todo_id} text to: {update_value}"
 
     if operation == "remove":

--- a/gptme/util/__init__.py
+++ b/gptme/util/__init__.py
@@ -7,7 +7,7 @@ import logging
 import re
 import shutil
 import textwrap
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import lru_cache
 from pathlib import Path
 from xml.sax.saxutils import escape as xml_escape
@@ -22,7 +22,7 @@ console = Console(log_path=False)
 
 def epoch_to_age(epoch, incl_date=False):
     # takes epoch and returns "x minutes ago", "3 hours ago", "yesterday", etc.
-    age = datetime.now() - datetime.fromtimestamp(epoch)
+    age = datetime.now(tz=timezone.utc) - datetime.fromtimestamp(epoch, tz=timezone.utc)
     if age < timedelta(minutes=1):
         return "just now"
     if age < timedelta(hours=1):

--- a/gptme/util/auto_naming.py
+++ b/gptme/util/auto_naming.py
@@ -1,7 +1,7 @@
 """Unified auto-naming system for conversations."""
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
@@ -53,13 +53,13 @@ def generate_conversation_name(
         logger.debug(f"Name '{name}' exists, retrying (attempt {attempt + 1})")
 
     # Final fallback with timestamp
-    timestamp = datetime.now().strftime("%H%M%S")
+    timestamp = datetime.now(tz=timezone.utc).strftime("%H%M%S")
     return f"{name}-{timestamp}"
 
 
 def generate_conversation_id(name: str | None, logs_dir: Path) -> str:
     """Generate a conversation ID for CLI usage with date prefix."""
-    datestr = datetime.now().strftime("%Y-%m-%d")
+    datestr = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
 
     if name == "random":
         name = None
@@ -81,7 +81,7 @@ def generate_conversation_id(name: str | None, logs_dir: Path) -> str:
         full_id = f"{datestr}-{name}-{attempt}"
         attempt += 1
         if attempt > 100:  # Safety valve
-            timestamp = datetime.now().strftime("%H%M%S")
+            timestamp = datetime.now(tz=timezone.utc).strftime("%H%M%S")
             full_id = f"{datestr}-{name}-{timestamp}"
             break
 
@@ -286,7 +286,7 @@ def _is_invalid_title(name: str) -> bool:
 def _starts_with_date(name: str) -> bool:
     """Check if name starts with a date in YYYY-MM-DD format."""
     try:
-        datetime.strptime(name[:10], "%Y-%m-%d")
+        datetime.strptime(name[:10], "%Y-%m-%d").replace(tzinfo=timezone.utc)
         return True
     except (ValueError, IndexError):
         return False

--- a/gptme/util/output_storage.py
+++ b/gptme/util/output_storage.py
@@ -7,7 +7,7 @@ and provides path reference for later retrieval.
 
 import hashlib
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ def save_large_output(
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Generate filename with timestamp and content hash
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
     content_hash = hashlib.sha256(content.encode()).hexdigest()[:8]
     filename = f"{timestamp}-{content_hash}.txt"
     saved_path = output_dir / filename

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,7 @@ select = [
     "PLW1510",  # subprocess-run-without-check
     "TC001", "TC002", "TC003", "TC004",  # flake8-type-checking
     "PT003", "PT006", "PT011", "PT022",  # pytest style
+    "DTZ",    # flake8-datetimez (require timezone-aware datetimes)
 ]
 ignore = ["E402", "E501", "B905", "PERF203"]  # PERF203: try-except-in-loop often intentional
 #fixable = ["ALL"]

--- a/scripts/convert_convo.py
+++ b/scripts/convert_convo.py
@@ -32,7 +32,7 @@ Example usage:
 
 import json
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TypedDict
 
@@ -92,7 +92,7 @@ def convert_conversation(
             pinned = msg.get("pinned", False)
 
             # Format timestamp for filename if needed
-            dt = isoparse(timestamp) if timestamp else datetime.now()
+            dt = isoparse(timestamp) if timestamp else datetime.now(tz=timezone.utc)
             timestamp_str = dt.strftime("%Y%m%d-%H%M%S")
 
             # Create filename using format string

--- a/scripts/list_user_messages.py
+++ b/scripts/list_user_messages.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from gptme.logmanager import ConversationMeta, Log, get_user_conversations
 
@@ -25,8 +25,8 @@ def print_user_messages(conv: ConversationMeta):
     if not lines:
         return
     print(f"Conversation: {conv.name}")
-    print(f"Created:  {datetime.fromtimestamp(conv.created)}")
-    print(f"Modified: {datetime.fromtimestamp(conv.modified)}")
+    print(f"Created:  {datetime.fromtimestamp(conv.created, tz=timezone.utc)}")
+    print(f"Modified: {datetime.fromtimestamp(conv.modified, tz=timezone.utc)}")
     print("---")
     print("\n".join(lines))
     print("---")

--- a/scripts/tts_server.py
+++ b/scripts/tts_server.py
@@ -31,7 +31,7 @@ import logging
 import os
 import sys
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from importlib.util import find_spec
 from pathlib import Path
 from textwrap import shorten
@@ -275,7 +275,7 @@ async def text_to_speech(
             )
 
         # Save audio to outputs directory with timestamp
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")[
+        timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S_%f")[
             :-3
         ]  # Remove last 3 digits of microseconds
         outputs_dir = Path("outputs")

--- a/tests/test_auto_compact.py
+++ b/tests/test_auto_compact.py
@@ -3,7 +3,7 @@ Tests for auto-compacting functionality that handles conversations with massive 
 """
 
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -32,9 +32,15 @@ def create_test_conversation():
     tool_output = f"Ran command: `find /usr -type f`\n{repeated_content}"
 
     return [
-        Message("user", "Please run a command to list files", datetime.now()),
-        Message("assistant", "I'll run the ls command for you.", datetime.now()),
-        Message("system", tool_output, datetime.now()),
+        Message(
+            "user", "Please run a command to list files", datetime.now(tz=timezone.utc)
+        ),
+        Message(
+            "assistant",
+            "I'll run the ls command for you.",
+            datetime.now(tz=timezone.utc),
+        ),
+        Message("system", tool_output, datetime.now(tz=timezone.utc)),
     ]
 
 
@@ -49,9 +55,11 @@ def test_should_auto_compact_with_massive_tool_result():
 def test_should_auto_compact_with_small_messages():
     """Test that should_auto_compact doesn't trigger for small conversations."""
     small_messages = [
-        Message("user", "Hello", datetime.now()),
-        Message("assistant", "Hi there!", datetime.now()),
-        Message("system", "Command executed successfully.", datetime.now()),
+        Message("user", "Hello", datetime.now(tz=timezone.utc)),
+        Message("assistant", "Hi there!", datetime.now(tz=timezone.utc)),
+        Message(
+            "system", "Command executed successfully.", datetime.now(tz=timezone.utc)
+        ),
     ]
 
     # Should not trigger auto-compacting
@@ -104,7 +112,7 @@ def test_create_tool_result_summary():
 
     content = "Ran command: `ls -la`\n/usr/bin/file1.txt\n/usr/bin/file2.txt\n..."
     tokens = 1000
-    msg = Message("system", content, timestamp=datetime.now())
+    msg = Message("system", content, timestamp=datetime.now(tz=timezone.utc))
 
     summary = create_tool_result_summary(msg.content, tokens, None, "autocompact")
 
@@ -123,7 +131,7 @@ def test_create_tool_result_summary_with_error():
         "Ran command: `invalid_command`\nError: command not found\nFailed to execute"
     )
     tokens = 500
-    msg = Message("system", content, timestamp=datetime.now())
+    msg = Message("system", content, timestamp=datetime.now(tz=timezone.utc))
 
     summary = create_tool_result_summary(msg.content, tokens, None, "autocompact")
 
@@ -135,9 +143,11 @@ def test_create_tool_result_summary_with_error():
 def test_auto_compact_preserves_small_messages():
     """Test that auto-compacting preserves small messages unchanged."""
     small_messages = [
-        Message("user", "Hello", datetime.now()),
-        Message("assistant", "Hi there!", datetime.now()),
-        Message("system", "Command executed successfully.", datetime.now()),
+        Message("user", "Hello", datetime.now(tz=timezone.utc)),
+        Message("assistant", "Hi there!", datetime.now(tz=timezone.utc)),
+        Message(
+            "system", "Command executed successfully.", datetime.now(tz=timezone.utc)
+        ),
     ]
 
     compacted = list(auto_compact_log(small_messages))
@@ -309,13 +319,35 @@ def test_strip_reasoning_preserves_content_without_tags():
 def test_auto_compact_strips_reasoning_from_older_messages():
     """Test that auto_compact_log strips reasoning from older messages."""
     messages = [
-        Message("user", "First <think>old reasoning</think>", datetime.now()),
-        Message("assistant", "Second <think>old reasoning</think>", datetime.now()),
-        Message("user", "Third <think>old reasoning</think>", datetime.now()),
-        Message("assistant", "Fourth <think>old reasoning</think>", datetime.now()),
-        Message("user", "Fifth <think>old reasoning</think>", datetime.now()),
-        Message("assistant", "Recent <think>recent reasoning</think>", datetime.now()),
-        Message("user", "Most recent <think>recent reasoning</think>", datetime.now()),
+        Message(
+            "user", "First <think>old reasoning</think>", datetime.now(tz=timezone.utc)
+        ),
+        Message(
+            "assistant",
+            "Second <think>old reasoning</think>",
+            datetime.now(tz=timezone.utc),
+        ),
+        Message(
+            "user", "Third <think>old reasoning</think>", datetime.now(tz=timezone.utc)
+        ),
+        Message(
+            "assistant",
+            "Fourth <think>old reasoning</think>",
+            datetime.now(tz=timezone.utc),
+        ),
+        Message(
+            "user", "Fifth <think>old reasoning</think>", datetime.now(tz=timezone.utc)
+        ),
+        Message(
+            "assistant",
+            "Recent <think>recent reasoning</think>",
+            datetime.now(tz=timezone.utc),
+        ),
+        Message(
+            "user",
+            "Most recent <think>recent reasoning</think>",
+            datetime.now(tz=timezone.utc),
+        ),
     ]
 
     # Apply auto-compacting with reasoning_strip_age_threshold=5
@@ -335,9 +367,21 @@ def test_auto_compact_strips_reasoning_from_older_messages():
 def test_auto_compact_reasoning_strip_threshold_zero():
     """Test that threshold=0 strips reasoning from all messages."""
     messages = [
-        Message("user", "Message 1 <think>reasoning 1</think>", datetime.now()),
-        Message("assistant", "Message 2 <think>reasoning 2</think>", datetime.now()),
-        Message("user", "Message 3 <think>reasoning 3</think>", datetime.now()),
+        Message(
+            "user",
+            "Message 1 <think>reasoning 1</think>",
+            datetime.now(tz=timezone.utc),
+        ),
+        Message(
+            "assistant",
+            "Message 2 <think>reasoning 2</think>",
+            datetime.now(tz=timezone.utc),
+        ),
+        Message(
+            "user",
+            "Message 3 <think>reasoning 3</think>",
+            datetime.now(tz=timezone.utc),
+        ),
     ]
 
     # Apply with threshold=0 (strip all)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from gptme.message import Message
@@ -35,7 +35,7 @@ def test_embed_attached_file_content(tmp_path):
         "user",
         "check this file",
         files=[file],
-        timestamp=datetime.now() - timedelta(minutes=1),
+        timestamp=datetime.now(tz=timezone.utc) - timedelta(minutes=1),
     )
 
     # Modify file after message timestamp

--- a/tests/test_file_selector_integration.py
+++ b/tests/test_file_selector_integration.py
@@ -1,6 +1,6 @@
 """Tests for file context selector integration."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -27,7 +27,7 @@ def temp_files(tmp_path: Path) -> dict[str, Path]:
     # Set different modification times (simulate recency)
     import os
 
-    now = datetime.now().timestamp()
+    now = datetime.now(tz=timezone.utc).timestamp()
     files["recent_py"].touch()  # Most recent
     os.utime(files["old_py"], times=(now - 86400, now - 86400))  # 1 day old
     os.utime(files["config"], times=(now - 3600, now - 3600))  # 1 hour old

--- a/tests/test_integration_phase4.py
+++ b/tests/test_integration_phase4.py
@@ -9,7 +9,7 @@ Tests the full workflow:
 
 import os
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -43,22 +43,22 @@ def conversation_about_git():
         Message(
             role="user",
             content="I need help with git workflow",
-            timestamp=datetime.now(),
+            timestamp=datetime.now(tz=timezone.utc),
         ),
         Message(
             role="assistant",
             content="I can help with git. What specific aspect?",
-            timestamp=datetime.now(),
+            timestamp=datetime.now(tz=timezone.utc),
         ),
         Message(
             role="user",
             content="How do I create a branch and push it correctly?",
-            timestamp=datetime.now(),
+            timestamp=datetime.now(tz=timezone.utc),
         ),
         Message(
             role="assistant",
             content="Let me show you the git worktree workflow",
-            timestamp=datetime.now(),
+            timestamp=datetime.now(tz=timezone.utc),
         ),
     ]
 
@@ -70,22 +70,22 @@ def conversation_about_shell():
         Message(
             role="user",
             content="I'm having issues with shell commands",
-            timestamp=datetime.now(),
+            timestamp=datetime.now(tz=timezone.utc),
         ),
         Message(
             role="assistant",
             content="What shell errors are you seeing?",
-            timestamp=datetime.now(),
+            timestamp=datetime.now(tz=timezone.utc),
         ),
         Message(
             role="user",
             content="Getting 'cd: too many arguments' error",
-            timestamp=datetime.now(),
+            timestamp=datetime.now(tz=timezone.utc),
         ),
         Message(
             role="assistant",
             content="This is likely a path quoting issue",
-            timestamp=datetime.now(),
+            timestamp=datetime.now(tz=timezone.utc),
         ),
     ]
 
@@ -97,22 +97,22 @@ def conversation_mixed_topics():
         Message(
             role="user",
             content="I need to commit my changes and then run some tests",
-            timestamp=datetime.now(),
+            timestamp=datetime.now(tz=timezone.utc),
         ),
         Message(
             role="assistant",
             content="First let's handle the git commit",
-            timestamp=datetime.now(),
+            timestamp=datetime.now(tz=timezone.utc),
         ),
         Message(
             role="user",
             content="Also, how do I quote paths with spaces in shell?",
-            timestamp=datetime.now(),
+            timestamp=datetime.now(tz=timezone.utc),
         ),
         Message(
             role="assistant",
             content="Use quotes around the path",
-            timestamp=datetime.now(),
+            timestamp=datetime.now(tz=timezone.utc),
         ),
     ]
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1,6 +1,6 @@
 import random
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 
@@ -115,7 +115,7 @@ def test_v2_create_conversation_default_system_prompt(
                 {
                     "role": "user",
                     "content": "Hello, this is a test message.",
-                    "timestamp": datetime.now().isoformat(),
+                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
                 }
             ]
         },

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,7 +1,7 @@
 """Tests for the shared session module."""
 
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -123,7 +123,9 @@ class TestSessionRegistry:
         # Make old-session appear old
         old_session = registry.get("old-session")
         assert old_session is not None
-        old_session.last_activity = datetime.now() - timedelta(minutes=120)
+        old_session.last_activity = datetime.now(tz=timezone.utc) - timedelta(
+            minutes=120
+        )
 
         # Cleanup with 60 minute threshold
         removed = registry.cleanup_inactive(max_age_minutes=60)

--- a/tests/test_tools_time_awareness.py
+++ b/tests/test_tools_time_awareness.py
@@ -1,6 +1,6 @@
 """Tests for the time-awareness tool."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -56,7 +56,7 @@ def test_time_milestones(load_time_awareness_tool, tmp_path, monkeypatch):
     log = Log()
 
     # Mock conversation start time to 30 minutes ago
-    now = datetime.now()
+    now = datetime.now(tz=timezone.utc)
     start_time = now - timedelta(minutes=30)
     conversation_start_times = _conversation_start_times_var.get()
     shown_milestones = _shown_milestones_var.get()
@@ -122,7 +122,7 @@ def test_milestone_progression(load_time_awareness_tool, tmp_path):
 
     workspace = tmp_path
     log = Log()
-    now = datetime.now()
+    now = datetime.now(tz=timezone.utc)
 
     # Set conversation start 25 minutes ago
     conversation_start_times = _conversation_start_times_var.get()
@@ -178,7 +178,7 @@ def test_time_format_hours(load_time_awareness_tool, tmp_path):
 
     workspace = tmp_path
     log = Log()
-    now = datetime.now()
+    now = datetime.now(tz=timezone.utc)
 
     # Set conversation start 125 minutes ago (2h 5min)
     conversation_start_times = _conversation_start_times_var.get()
@@ -217,7 +217,7 @@ def test_every_10min_after_20(load_time_awareness_tool, tmp_path):
 
     workspace = tmp_path
     log = Log()
-    now = datetime.now()
+    now = datetime.now(tz=timezone.utc)
 
     # Test 30, 40, 50 minute marks
     for minutes in [30, 40, 50]:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from gptme.util import (
     epoch_to_age,
@@ -14,7 +14,7 @@ def test_generate_name():
 
 
 def test_epoch_to_age():
-    epoch_today = datetime.now().timestamp()
+    epoch_today = datetime.now(tz=timezone.utc).timestamp()
     assert epoch_to_age(epoch_today) == "just now"
     epoch_yesterday = epoch_today - 24 * 60 * 60
     assert epoch_to_age(epoch_yesterday) == "yesterday"


### PR DESCRIPTION
## Summary

- Replace all 100 naive `datetime` calls with timezone-aware equivalents using `timezone.utc`
- Enable the `DTZ` ruff rule to prevent regression
- Covers 30 files: server, session, hooks, tools, utilities, scripts, and tests

Naive datetimes can cause `TypeError` when compared with aware datetimes (Python 3.12+) and produce incorrect results across DST boundaries or when the server runs in UTC but local code assumes local time.

## Changes by rule

| Rule | Count | Pattern |
|------|-------|---------|
| DTZ005 | 66 | `datetime.now()` → `datetime.now(tz=timezone.utc)` |
| DTZ001 | 26 | `datetime(y, m, d)` → `datetime(y, m, d, tzinfo=timezone.utc)` |
| DTZ006 | 7 | `datetime.fromtimestamp(t)` → `datetime.fromtimestamp(t, tz=timezone.utc)` |
| DTZ007 | 1 | `datetime.strptime(...)` → `datetime.strptime(...).replace(tzinfo=timezone.utc)` |

## Test plan

- [x] `ruff check --select DTZ` returns zero violations
- [x] `ruff check` passes (all rules)
- [x] 67 affected tests pass (`test_session`, `test_util`, `test_auto_compact`, `test_tools_time_awareness`)
- [ ] Full CI suite
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make all datetime calls timezone-aware using `timezone.utc` and enforce with `DTZ` ruff rule.
> 
>   - **Behavior**:
>     - Replaces 100 naive `datetime` calls with timezone-aware equivalents using `timezone.utc`.
>     - Enables `DTZ` ruff rule in `pyproject.toml` to enforce timezone-aware datetimes.
>   - **Files**:
>     - Updates `datetime.now()` to `datetime.now(tz=timezone.utc)` in `cache_awareness.py`, `time_awareness.py`, and `llm_openai_models.py`.
>     - Updates `datetime.fromtimestamp()` to `datetime.fromtimestamp(t, tz=timezone.utc)` in `logmanager.py`, `prompts.py`, and `workspace_api.py`.
>     - Updates `datetime(y, m, d)` to `datetime(y, m, d, tzinfo=timezone.utc)` in `llm_openai_models.py` and `models.py`.
>   - **Tests**:
>     - Updates 67 tests to use timezone-aware datetimes in `test_auto_compact.py`, `test_tools_time_awareness.py`, and `test_util.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for c37d7f7e91794f3629ccd41846c780a31c2d019c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->