### PR TITLE
ci(test): move slow tests to no-api job, remove SLOW from provider matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,11 +60,11 @@ jobs:
     - name: Install playwright
       run: poetry run playwright install chromium
 
-    - name: Run tests (without API keys)
+    - name: Run tests (without API keys, including slow tests)
       env:
         TERM: xterm
         MODEL: local/test
-      run: make test
+      run: make test SLOW=true
 
     - name: Upload coverage reports to Codecov
       if: ${{ !cancelled() }}
@@ -161,7 +161,7 @@ jobs:
         timeout_minutes: 15
         max_attempts: 1  # favor pytest retries (mark with flaky)
         retry_wait_seconds: 10
-        command: make test SLOW=true
+        command: make test
 
     - name: Upload coverage reports to Codecov
       if: ${{ !cancelled() }}


### PR DESCRIPTION
## Problem

The provider matrix jobs (Haiku + GPT-4o-mini) ran `make test SLOW=true`, including all slow tests — many of which make expensive LLM calls on every push and PR. This was costing >$100/mo in Haiku tokens.

## Root Cause

`SLOW=true` removes the `-m "not slow and not eval"` pytest filter, so **all** slow tests run with real API calls. Slow tests include browser automation, MCP servers, full agent runs, etc. — all billable against Haiku/GPT-4o-mini on every PR push.

## Fix

**Swap SLOW placement:**

| Job | Before | After | Effect |
|-----|--------|-------|--------|
| `test-no-api` | `make test` | `make test SLOW=true` | Slow tests now run without LLM cost (conftest auto-skips `requires_api` tests when no keys are set) |
| `test` (matrix) | `make test SLOW=true` | `make test` | Only fast provider-specific tests run per push/PR |

## Result

- **Slow test coverage preserved**: runs in the no-api job (0 LLM tokens)
- **Provider coverage preserved**: quick `requires_api` tests still run on every PR
- **Cost reduction**: slow LLM-heavy tests no longer run per-provider per-push

Closes #1434
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move slow tests to `test-no-api` job in `test.yml` to reduce API call costs and maintain test coverage.
> 
>   - **Behavior**:
>     - Move `make test SLOW=true` from `test` (matrix) job to `test-no-api` job in `test.yml`.
>     - `test-no-api` job now runs slow tests without API keys, avoiding LLM costs.
>     - `test` (matrix) job now runs only fast tests, maintaining provider coverage.
>   - **Cost Reduction**:
>     - Slow tests no longer incur costs from Haiku/GPT-4o-mini API calls on every PR push.
>   - **Coverage**:
>     - Slow test coverage preserved in `test-no-api` job.
>     - Provider-specific fast tests continue in `test` (matrix) job.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 405aead6ca0fae61f0d0e7dadc00cff15804c4c0. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->