### PR TITLE
fix(acp): remove slash prefix from AvailableCommand names

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -709,7 +709,7 @@ class GptmeAgent:
             from ..commands import get_commands_with_descriptions
 
             acp_commands = [
-                AvailableCommand(name=f"/{name}", description=desc)
+                AvailableCommand(name=name, description=desc)
                 for name, desc in get_commands_with_descriptions()
             ]
             await self._conn.session_update(
@@ -1096,7 +1096,9 @@ class GptmeAgent:
                     session_id=conv.id,
                     cwd=session_cwd,
                     title=conv.name if conv.name != conv.id else None,
-                    updated_at=datetime.fromtimestamp(conv.modified, tz=timezone.utc).isoformat(),
+                    updated_at=datetime.fromtimestamp(
+                        conv.modified, tz=timezone.utc
+                    ).isoformat(),
                 )
             )
             active_ids.discard(conv.id)


### PR DESCRIPTION
## Problem

`AvailableCommand.name` was set with a leading `/` prefix (e.g., `/help`, `/model`). Per the ACP spec, the `name` field should **not** include the slash — Zed appends it automatically when displaying slash commands.

This caused two problems:
1. Zed displayed double-slash commands like `//help` instead of `/help`
2. `is_message_command()` checks `count("/") == 1`, so `//help` (with count=2) was **not routed to the command handler** at all — it fell through to the LLM instead

Reported by @Andrei-Pozolotin in #1393.

## Fix

Remove the `f"/{name}"` → `name` change in `_send_available_commands()`. One-line fix.

## Testing

- Pre-commit hooks pass (mypy, ruff)
- Zed should now show `/help`, `/model`, etc. (single slash)
- Commands will now be correctly recognized by `is_message_command()` when invoked via Zed's slash command autocomplete
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `AvailableCommand.name` in `agent.py` to exclude leading slash, resolving display and routing issues in Zed.
> 
>   - **Behavior**:
>     - Fixes `AvailableCommand.name` in `_send_available_commands()` in `agent.py` to exclude leading slash, resolving double-slash display issue in Zed.
>     - Ensures `is_message_command()` correctly routes commands by checking for a single slash.
>   - **Testing**:
>     - Pre-commit hooks pass (mypy, ruff).
>     - Verified Zed displays commands with a single slash and routes them correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 81ff53406aa057ace63f771a9ba8425ec55bda05. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->