### PR TITLE
fix(acp): remove slash prefix from advertised command names

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -709,7 +709,7 @@ class GptmeAgent:
             from ..commands import get_commands_with_descriptions
 
             acp_commands = [
-                AvailableCommand(name=f"/{name}", description=desc)
+                AvailableCommand(name=name, description=desc)
                 for name, desc in get_commands_with_descriptions()
             ]
             await self._conn.session_update(
@@ -1096,7 +1096,9 @@ class GptmeAgent:
                     session_id=conv.id,
                     cwd=session_cwd,
                     title=conv.name if conv.name != conv.id else None,
-                    updated_at=datetime.fromtimestamp(conv.modified, tz=timezone.utc).isoformat(),
+                    updated_at=datetime.fromtimestamp(
+                        conv.modified, tz=timezone.utc
+                    ).isoformat(),
                 )
             )
             active_ids.discard(conv.id)


### PR DESCRIPTION
## Summary

- Fix double-slash bug in ACP slash command autocomplete (reported in #1393 by @Andrei-Pozolotin)
- `AvailableCommand.name` was registered as `/help` but ACP spec expects bare `help` — the client (Zed) adds the `/` prefix itself
- This caused autocomplete to produce `//help`, which bypassed the slash command handler entirely

## Details

The chain of failures:
1. gptme registers commands as `/help`, `/model`, etc. (slash already in the name)
2. Zed prepends its own `/` during autocomplete → `//help`
3. `is_message_command("//help")` returns `False` (expects single slash)
4. Command bypasses the handler and goes to the LLM
5. ACP SDK fires "not supported" with mangled command list

Fix: remove the `f"/{name}"` prefix — use bare `name` from `get_commands_with_descriptions()`.

## Test plan

- [x] Added regression test `test_command_names_have_no_slash_prefix` verifying no command starts with `/`
- [x] All 82 ACP agent tests pass
- [x] Typecheck clean (334 source files)
- [ ] @Andrei-Pozolotin to verify slash commands work in Zed after this fix

Closes #1393 (or significantly progresses it — the remaining issues from the original report were already fixed by #1419 and #1420)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes double-slash bug in ACP command autocomplete by removing slash prefix from command names in `agent.py`.
> 
>   - **Behavior**:
>     - Fixes double-slash bug in ACP slash command autocomplete by removing the slash prefix from `AvailableCommand.name` in `agent.py`.
>     - Ensures `is_message_command()` correctly identifies commands without extra slashes.
>   - **Tests**:
>     - Adds `test_command_names_have_no_slash_prefix` in `test_acp_agent.py` to verify command names do not start with a slash.
>   - **Misc**:
>     - Minor formatting changes in `agent.py` for better readability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for f07ada680281924b0c5072b937a69165cdfe8b1a. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->