### PR TITLE
ci(test): skip API test matrix on fork PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,6 +147,7 @@ jobs:
   # API tests: only run requires_api tests, across multiple cheap models
   # This replaces the previous matrix that ran ALL slow tests on each model
   test-api:
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     name: API tests with ${{ matrix.model }}
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary

- Skip the `test-api` matrix jobs on fork PRs where API secrets aren't available
- Currently, fork PRs spin up 3 API test jobs that install all dependencies (including playwright) only to skip every test — wasting CI minutes
- The `if:` condition allows API tests on push events and same-repo PRs, but prevents them on fork PRs

Follow-up to #1436 and part of #1434.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize CI by skipping `test-api` jobs on fork PRs in `.github/workflows/test.yml`.
> 
>   - **CI Optimization**:
>     - Modify `test-api` job in `.github/workflows/test.yml` to skip on fork PRs by adding an `if:` condition.
>     - Ensures API tests only run on push events and same-repo PRs, preventing unnecessary CI usage on fork PRs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 92d420f76e0f9cff107427ae220bf7bd26f1965b. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->