### PR TITLE
fix(acp): set agentInfo name to gptme

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -101,7 +101,7 @@ def _agent_info() -> Any:
     _Impl = _check_acp_import(Implementation, "Implementation")
     from gptme import __version__
 
-    return _Impl(name="gptme-acp", version=__version__)
+    return _Impl(name="gptme", version=__version__)
 
 
 class GptmeAgent:


### PR DESCRIPTION
## Summary

- Set `agentInfo` in the `InitializeResponse` with `name="gptme-acp"` and the package version
- This lets ACP clients (like Zed) display "gptme-acp" as the logger origin instead of the generic "agent stderr" label
- Added a lazy-imported `Implementation` type from `acp.schema` and a `_agent_info()` helper to build it

Fixes #1439.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sets `agentInfo` in `InitializeResponse` to "gptme-acp" with version, improving client logging in `gptme/acp/agent.py`.
> 
>   - **Behavior**:
>     - Sets `agentInfo` in `InitializeResponse` with `name="gptme-acp"` and package version in `initialize()`.
>     - Improves client logging by displaying "gptme-acp" instead of "agent stderr".
>   - **Imports**:
>     - Adds lazy-imported `Implementation` type from `acp.schema`.
>     - Introduces `_agent_info()` helper function to build `agentInfo`.
>   - **Misc**:
>     - Fixes #1439.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 5768cbf5ff69a0d8066ceb788e8dfe06193fa8c4. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->