### PR TITLE
fix(acp): wrap multi-line command output in code blocks for Markdown rendering

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -796,7 +796,12 @@ class GptmeAgent:
         output_parts: list[str] = []
         stdout_output = captured.getvalue()
         if stdout_output:
-            output_parts.append(stdout_output.rstrip())
+            # Wrap multi-line stdout in a code block to preserve formatting
+            # (e.g. /help, /tools output rendered as Markdown in ACP panels)
+            text = stdout_output.rstrip()
+            if "\n" in text:
+                text = f"```\n{text}\n```"
+            output_parts.append(text)
         output_parts.extend(
             resp_msg.content for resp_msg in response_msgs if resp_msg.content
         )


### PR DESCRIPTION
## Summary

- Wrap multi-line stdout output from slash commands (e.g. `/help`, `/tools`) in Markdown code blocks
- Zed's ACP panel renders text as Markdown, which collapses single newlines into one paragraph
- This makes `/help` output readable with preserved formatting

Before: All commands on one line
After: Commands properly formatted in a code block

Fixes the mangled `/help` display reported in #1393.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Wraps multi-line command outputs in Markdown code blocks in `agent.py` to preserve formatting in ACP panels, fixing issue #1393.
> 
>   - **Behavior**:
>     - Wraps multi-line stdout output from slash commands in Markdown code blocks in `_handle_slash_command()` in `agent.py`.
>     - Specifically affects commands like `/help` and `/tools` to preserve formatting in ACP panels.
>   - **Fixes**:
>     - Resolves issue #1393 regarding mangled `/help` display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 11f015715c9afc3b1c3157e2dfdb23adc186515c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->