### PR TITLE
ci(test): mark OpenRouter GLM tests as experimental (continue-on-error)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,13 +152,17 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE: false
+    # OpenRouter tests are experimental: they may fail due to credit limits
+    # or third-party outages, and should not block PRs from merging.
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
-        model:
-          - 'openai/gpt-4o-mini'
-          - 'anthropic/claude-haiku-4-5'
-          - 'openrouter/z-ai/glm-5@z-ai'
+        include:
+          - model: 'openai/gpt-4o-mini'
+          - model: 'anthropic/claude-haiku-4-5'
+          - model: 'openrouter/z-ai/glm-5@z-ai'
+            experimental: true
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Mark the OpenRouter/GLM-5 API test matrix entry as `experimental: true` with `continue-on-error`
- OpenRouter tests fail with 402/403 when the monthly credit limit is hit (#1449), blocking all PRs from merging even though the failures are not code-related
- With this change, GLM failures are still visible in CI results but won't block PR merges

## Context

The OpenRouter API key has hit its monthly limit (see #1449), causing every open PR to show a CI failure. This is a third-party billing issue, not a code quality signal. Other CI providers (OpenAI, Anthropic) use direct API keys with sufficient quota and remain reliable.

Refs: #1434, #1449
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Marks OpenRouter GLM tests as experimental in CI to prevent non-code-related failures from blocking PR merges.
> 
>   - **CI Workflow**:
>     - Marks `openrouter/z-ai/glm-5@z-ai` model tests as `experimental` in `.github/workflows/test.yml`.
>     - Adds `continue-on-error: ${{ matrix.experimental || false }}` to allow non-blocking failures for experimental tests.
>   - **Context**:
>     - Addresses issue #1449 where OpenRouter tests fail due to monthly credit limit, blocking PR merges.
>     - Ensures GLM failures are visible but do not prevent PR merges.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for c5929145bcec31b960da1f00170d2e035d1f4a6f. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->