### PR TITLE
fix(acp): return agentInfo in initialize response

### DIFF
--- a/tests/test_acp_agent.py
+++ b/tests/test_acp_agent.py
@@ -491,6 +491,18 @@ class TestInitializeWithoutAcp:
         except RuntimeError as e:
             assert "agent-client-protocol" in str(e)
 
+    def test_initialize_returns_agent_info(self):
+        """Initialize response should include agentInfo with name and version."""
+        agent = GptmeAgent()
+        try:
+            result = _run(agent.initialize(protocol_version=1))
+        except RuntimeError:
+            pytest.skip("ACP package not installed")
+        assert result.agentInfo is not None
+        assert result.agentInfo.name == "gptme"
+        assert result.agentInfo.title == "gptme ACP Agent"
+        assert result.agentInfo.version  # non-empty version string
+
     def test_load_session_returns_none_for_missing(self):
         """load_session returns None for sessions not on disk.
 


### PR DESCRIPTION
## Summary

- Include `agentInfo` (name, title, version) in the ACP `InitializeResponse`
- Editors like Zed can now identify the agent instead of showing generic "agent stderr" in logs
- Adds lazy import for `Implementation` from `acp.schema`
- Adds test verifying `agentInfo` fields in initialize response

Closes #1439
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `agentInfo` to `InitializeResponse` in `gptme/acp/agent.py` and tests it, allowing editors to display specific agent details.
> 
>   - **Behavior**:
>     - `initialize()` in `gptme/acp/agent.py` now includes `agentInfo` (name, title, version) in `InitializeResponse`.
>     - Editors can display specific agent details instead of generic messages.
>   - **Imports**:
>     - Adds lazy import for `Implementation` from `acp.schema` in `gptme/acp/agent.py`.
>   - **Tests**:
>     - Adds `test_initialize_returns_agent_info` in `tests/test_acp_agent.py` to verify `agentInfo` fields in initialize response.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for d914003d56163b99b350f7512bfb277e72671e47. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->