### PR TITLE
ci(test): move slow tests to nightly scheduled workflow

### DIFF
--- a/.github/workflows/test-slow.yml
+++ b/.github/workflows/test-slow.yml
@@ -1,0 +1,76 @@
+name: Test (slow)
+
+# Run slow tests nightly to catch regressions in browser, MCP, integration, etc.
+# These were previously run on every PR/push but are network-dependent and time-consuming.
+# Fast tests still run on every PR/push in test.yml.
+
+on:
+  schedule:
+    - cron: '0 4 * * *'  # Daily at 4 AM UTC
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  test-slow:
+    name: Test (slow, no API keys)
+    runs-on: ubuntu-latest
+    env:
+      RELEASE: false
+      OPENAI_API_KEY: ''
+      ANTHROPIC_API_KEY: ''
+      DEEPSEEK_API_KEY: ''
+      OPENROUTER_API_KEY: ''
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        submodules: 'recursive'
+    - name: Install apt dependencies
+      run: sudo apt-get install universal-ctags pandoc tmux x11-xserver-utils xvfb
+
+    - name: Set up Xvfb
+      run: |
+        Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+        echo "DISPLAY=:99" >> $GITHUB_ENV
+
+    - name: Store cache ID in file .cache-id
+      id: cache-id
+      run: echo "noextras" > .cache-id
+
+    - name: Install poetry
+      run: pipx install poetry
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+        cache: 'poetry'
+        cache-dependency-path: |
+          poetry.lock
+          .cache-id
+
+    - name: Install dependencies
+      run: |
+        make build
+        poetry install -E all
+
+    - name: Install playwright
+      run: poetry run playwright install chromium
+
+    - name: Run slow tests
+      env:
+        TERM: xterm
+        MODEL: local/test
+      run: make test SLOW=true
+
+    - name: Upload coverage reports to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: slow
+
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        report_type: test_results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,7 @@ env:
   OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
 
 jobs:
-  # Core tests: no API keys needed, runs all tests except requires_api/eval
-  # Also includes slow tests (browser, MCP, integration, etc.) since they don't need API
+  # Core tests: no API keys needed, fast tests only (slow tests run nightly in test-slow.yml)
   test-no-api:
     name: Test without API keys
     runs-on: ubuntu-latest
@@ -61,11 +60,11 @@ jobs:
     - name: Install playwright
       run: poetry run playwright install chromium
 
-    - name: Run tests (without API keys, including slow)
+    - name: Run tests (without API keys, fast only)
       env:
         TERM: xterm
         MODEL: local/test
-      run: make test SLOW=true
+      run: make test
 
     - name: Upload coverage reports to Codecov
       if: ${{ !cancelled() }}


### PR DESCRIPTION
## Summary

- Move slow tests (browser, MCP, integration, etc.) from per-PR CI to a nightly scheduled workflow
- The `test-no-api` job now runs fast tests only, dropping from ~7.5min to ~3min
- New `test-slow.yml` workflow runs all slow tests at 4 AM UTC, with manual trigger support

## Rationale

Slow tests are network-dependent (hitting external URLs like GitHub API, DuckDuckGo, arxiv, superuserlabs.org) and add ~4 minutes to every PR CI run. They catch regressions that fast tests don't, but those regressions are rare enough that nightly coverage is sufficient.

This is the remaining optimization item from #1434.

## Changes

- `.github/workflows/test.yml`: Remove `SLOW=true` from `test-no-api` job
- `.github/workflows/test-slow.yml`: New nightly workflow (identical setup to `test-no-api`, but with `SLOW=true`)

## Test plan

- [x] CI should pass on this PR (the test-no-api job will now run faster)
- [ ] Verify nightly workflow runs correctly after merge (or trigger via workflow_dispatch)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move slow tests to nightly workflow, reducing per-PR CI runtime by excluding them from `test.yml`.
> 
>   - **Behavior**:
>     - Move slow tests (browser, MCP, integration) from per-PR CI to nightly workflow in `test-slow.yml`.
>     - `test-no-api` job in `test.yml` now runs only fast tests, reducing runtime from ~7.5min to ~3min.
>     - New `test-slow.yml` runs slow tests nightly at 4 AM UTC, with manual trigger support.
>   - **Workflows**:
>     - `.github/workflows/test.yml`: Remove `SLOW=true` from `test-no-api` job.
>     - `.github/workflows/test-slow.yml`: New workflow for slow tests, identical setup to `test-no-api` but with `SLOW=true`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for fc50504fbfba43da4339a6ad9a0c7764da2d8d2b. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->