### PR TITLE
ci(test): mark GLM-5 tests as experimental (continue-on-error)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,13 +152,15 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE: false
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
-        model:
-          - 'openai/gpt-4o-mini'
-          - 'anthropic/claude-haiku-4-5'
-          - 'openrouter/z-ai/glm-5@z-ai'
+        include:
+          - model: 'openai/gpt-4o-mini'
+          - model: 'anthropic/claude-haiku-4-5'
+          - model: 'openrouter/z-ai/glm-5@z-ai'
+            experimental: true
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Marks the OpenRouter GLM-5 tests as experimental so billing/credit failures don't block other PRs.

Changes:
- Convert test-api matrix from simple list to `include` format
- Add `continue-on-error: ${{ matrix.experimental || false }}` at job level
- Mark `openrouter/z-ai/glm-5@z-ai` as `experimental: true`

Related: #1434, #1449
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Marks `openrouter/z-ai/glm-5@z-ai` tests as experimental in `test.yml`, allowing them to fail without blocking PRs.
> 
>   - **Behavior**:
>     - Marks `openrouter/z-ai/glm-5@z-ai` tests as experimental in `test.yml`.
>     - Adds `continue-on-error: ${{ matrix.experimental || false }}` to allow experimental tests to fail without blocking PRs.
>   - **Configuration**:
>     - Converts `test-api` matrix from a simple list to `include` format in `test.yml`.
>     - Adds `experimental: true` to `openrouter/z-ai/glm-5@z-ai` in the matrix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 2ded5376645916ee7b9e0720643fd5c535f162dd. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->