### PR TITLE
fix(acp): prevent GC of fire-and-forget asyncio tasks + sort __all__

### DIFF
--- a/gptme/__init__.py
+++ b/gptme/__init__.py
@@ -5,4 +5,4 @@ from .logmanager import LogManager
 from .message import Message
 from .prompts import get_prompt
 
-__all__ = ["chat", "LogManager", "Message", "get_prompt", "Codeblock", "__version__"]
+__all__ = ["Codeblock", "LogManager", "Message", "__version__", "chat", "get_prompt"]


### PR DESCRIPTION
## Summary

- **Fix fire-and-forget `asyncio.create_task()` bug** in ACP agent: Background tasks for deferred session notifications were not stored, making them eligible for garbage collection before completion. Added `_create_background_task()` helper that keeps references in a `_background_tasks` set with automatic cleanup via `add_done_callback`.
- **Sort `__all__`** in `gptme/__init__.py` (RUF022 convention).

## Details

The `asyncio.create_task()` pattern in `new_session()` and `load_session()` creates tasks for `_send_session_open_notifications()` but discards the returned `Task` object. Per [Python docs](https://docs.python.org/3/library/asyncio-task.html#creating-tasks):

> **Important**: Save a reference to the result of this function, to avoid a task disappearing mid-execution. The event loop only keeps weak references to tasks. A task that isn't referenced elsewhere may get garbage collected at any time, even before it's done.

This could cause session notifications (available commands, model info) to silently fail to send in Zed/editors.

## Test plan

- [x] All 97 ACP agent tests pass
- [x] Ruff lint clean
- [x] Pre-commit hooks pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes potential garbage collection of background tasks in `agent.py` and sorts `__all__` in `__init__.py`.
> 
>   - **Behavior**:
>     - Fixes potential garbage collection of background tasks in `agent.py` by introducing `_create_background_task()` to manage task references.
>     - Ensures session notifications are not prematurely cancelled in `new_session()` and `load_session()`.
>   - **Code Style**:
>     - Sorts `__all__` in `__init__.py` according to RUF022 convention.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for ee1015ec27f2cd09642e3e415206f2d6f6e5cc13. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->