### PR TITLE
ci(test): skip expensive tests on docs/config-only PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,53 @@ env:
   OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
 
 jobs:
+  # Detect which paths changed to skip expensive jobs on docs/config-only PRs
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      # Core Python code changed (any gptme source, tests, or deps)
+      code: ${{ steps.filter.outputs.code }}
+      # LLM/API-related code changed (llm, acp, tools, agent, tests)
+      api-related: ${{ steps.filter.outputs.api-related }}
+    steps:
+    - uses: actions/checkout@v6
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          code:
+            - 'gptme/**'
+            - 'tests/**'
+            - 'poetry.lock'
+            - 'pyproject.toml'
+            - 'Makefile'
+            - '.github/workflows/test.yml'
+          api-related:
+            - 'gptme/llm/**'
+            - 'gptme/acp/**'
+            - 'gptme/tools/**'
+            - 'gptme/agent/**'
+            - 'gptme/eval/**'
+            - 'gptme/chat.py'
+            - 'gptme/codeblock.py'
+            - 'gptme/message.py'
+            - 'gptme/prompts.py'
+            - 'gptme/session.py'
+            - 'gptme/executor.py'
+            - 'tests/**'
+            - 'poetry.lock'
+            - 'Makefile'
+            - '.github/workflows/test.yml'
+
   # Core tests: no API keys needed, runs all tests except requires_api/eval
   # Also includes slow tests (browser, MCP, integration, etc.) since they don't need API
   test-no-api:
+    needs: changes
+    # Always run on push to master; on PRs, only when code changed
+    if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
     name: Test without API keys
     runs-on: ubuntu-latest
     env:
@@ -83,6 +127,9 @@ jobs:
 
   # Minimal install test: no extras, tests the most common user installation config
   test-minimal:
+    needs: changes
+    # Always run on push to master; on PRs, only when code changed
+    if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
     name: Test without API keys or extras
     runs-on: ubuntu-latest
     env:
@@ -145,9 +192,14 @@ jobs:
         report_type: test_results
 
   # API tests: only run requires_api tests, across multiple cheap models
-  # This replaces the previous matrix that ran ALL slow tests on each model
+  # Skipped on docs/config-only PRs to reduce API spend (~$30+/day in Haiku costs)
   test-api:
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    needs: changes
+    # Run on push to master, or on PRs when API-related code changed (and not a fork)
+    if: |
+      (github.event_name == 'push') ||
+      (needs.changes.outputs.api-related == 'true' &&
+       (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'))
     name: API tests with ${{ matrix.model }}
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary

- Add path-based filtering to skip API tests and slow tests when only docs, CI config, or non-code files change
- Uses `dorny/paths-filter` to detect changes in a lightweight `changes` job
- All tests always run on push to master (safety net)

## Motivation

From #1434 and Erik's feedback on #1453: rather than moving slow tests to nightly (brittle, late failure detection), filter tests by what actually changed. This:

- **Saves API costs**: Haiku >$30/day, OpenRouter $30/mo — API tests only run when LLM/ACP/tools/agent code changes
- **Saves CI time**: Docs-only PRs skip all test jobs entirely (~7 min saved)
- **No regressions go unnoticed**: Push to master always runs everything

## How it works

New `changes` job runs first (~5s) and outputs two flags:
- `code`: any Python source, tests, deps, or Makefile changed
- `api-related`: LLM, ACP, tools, agent, chat, or test code changed

| PR type | test-no-api | test-minimal | test-api |
|---------|-------------|--------------|----------|
| Docs only | skip | skip | skip |
| CI config only | skip | skip | skip |
| Python code | run | run | skip (unless API-related) |
| LLM/ACP/tools | run | run | run |
| Push to master | run | run | run |

## Test plan

- [x] CI should pass on this PR (the `changes` job will detect code changes and run all tests)
- [ ] Verify docs-only PR skips expensive jobs (create test PR after merge)

Refs: #1434
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a `changes` job in `test.yml` to conditionally skip expensive tests on docs/config-only PRs, reducing API costs and CI time.
> 
>   - **Behavior**:
>     - Adds `changes` job in `test.yml` to detect path changes and set `code` and `api-related` flags.
>     - Skips `test-no-api`, `test-minimal`, and `test-api` jobs on docs/config-only PRs based on `changes` job output.
>     - Ensures all tests run on push to master.
>   - **Path Filtering**:
>     - Uses `dorny/paths-filter` to identify changes in `gptme/**`, `tests/**`, `poetry.lock`, `pyproject.toml`, `Makefile`, and `.github/workflows/test.yml` for `code` flag.
>     - Identifies changes in `gptme/llm/**`, `gptme/acp/**`, `gptme/tools/**`, `gptme/agent/**`, `gptme/eval/**`, and specific Python files for `api-related` flag.
>   - **Motivation**:
>     - Reduces API costs and CI time by skipping unnecessary tests on non-code PRs.
>     - Ensures no regressions by running all tests on master branch pushes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 209aa078e3570e94c97f426d393f43c5fad41360. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->