### PR TITLE
fix(subagent): hard-enforce profile tool restrictions at execution level

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -887,7 +887,7 @@ def profile_group():
     """Commands for managing agent profiles.
 
     Profiles define system prompts, tool access, and behavior rules.
-    They provide soft/prompting-based guidance for the agent.
+    Tool restrictions are hard-enforced in subagent and CLI mode.
 
     Example:
         gptme-util profile list          # List all profiles
@@ -968,8 +968,8 @@ def profile_show(name: str):
     console.print(Panel(content, title=f"Profile: {name}"))
 
     console.print(
-        "\n[dim]Note: Profile restrictions are soft/prompting-based. "
-        "The agent follows instructions but there's no hard technical enforcement.[/dim]"
+        "\n[dim]Note: Tool restrictions are hard-enforced in subagent and CLI mode. "
+        "Behavior rules (read_only, no_network) remain soft/prompting-based.[/dim]"
     )
 
 

--- a/gptme/profiles.py
+++ b/gptme/profiles.py
@@ -1,13 +1,15 @@
 """Agent profiles for pre-configured system prompts and tool access.
 
-Profiles provide soft/prompting-based guidance combining:
-- System prompt customization (behavioral hints)
-- Tool access suggestions (which tools to prefer)
+Profiles combine:
+- System prompt customization (behavioral guidance)
+- Tool access restrictions (hard-enforced when used via subagent tool)
 - Behavior rules (read-only, no-network, etc.)
 
-IMPORTANT: Profile restrictions are soft enforcement via prompting only.
-The agent receives instructions about limitations but there's no hard
-technical enforcement at the tool level.
+Tool restrictions are hard-enforced in subagent thread mode: only allowed
+tools are loaded into the execution context, so the LLM cannot call
+restricted tools even if it tries. CLI mode (--agent-profile) also
+hard-enforces via the tool allowlist. Behavior rules (read_only, no_network)
+remain soft/prompting-based.
 
 This enables creating specialized agents like "explorer" (read-only),
 "researcher" (web access), or "developer" (full capabilities).

--- a/gptme/tools/subagent.py
+++ b/gptme/tools/subagent.py
@@ -44,7 +44,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal, TypedDict
 
 from ..message import Message
-from . import get_tools
+from . import get_tools, set_tools
 from .base import ToolSpec, ToolUse
 
 
@@ -251,7 +251,7 @@ def _create_subagent_thread(
         context_include: For selective mode, list of context components
         workspace: Workspace directory
         target: Who will review the results ("parent" or "planner")
-        profile_name: Optional agent profile to apply (system prompt + tool hints)
+        profile_name: Optional agent profile to apply (system prompt + hard tool enforcement)
     """
     # noreorder
     from gptme import chat  # fmt: skip
@@ -285,6 +285,8 @@ def _create_subagent_thread(
         for ct in complete_tools:
             if ct not in available_tools:
                 available_tools.append(ct)
+        # Hard enforcement: replace loaded tools so execute_msg() only sees allowed tools
+        set_tools(available_tools)
     else:
         available_tools = get_tools()
 


### PR DESCRIPTION
Profile tool restrictions in subagent thread mode were only soft-enforced: the filtered tool list was passed to `get_prompt()` for system messages, but the ContextVar still held all tools. This meant `execute_msg()` could still run tools outside the profile's allowlist.

**Fix**: Call `set_tools(available_tools)` after filtering, so only allowed tools are loaded in the subagent's execution context.

**Changes** (single commit on clean master):
- Add `set_tools()` call in `_create_subagent_thread` after tool filtering
- Update `profiles.py` docstring to reflect hard enforcement  
- Update CLI help text (profile show, profile group)
- Add 2 tests: enforcement for explorer profile, no-op for developer

All 58 subagent + profile tests passing.

Closes part of #1457 (item 1: hard tool enforcement).