### PR TITLE
ci: comment out openrouter model test (too brittle for CI)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,8 +211,8 @@ jobs:
         include:
           - model: 'openai/gpt-4o-mini'
           - model: 'anthropic/claude-haiku-4-5'
-          - model: 'openrouter/minimax/minimax-m2.5'
-            experimental: true
+          # - model: 'openrouter/minimax/minimax-m2.5'  # disabled: too brittle (SSL errors, inconsistent stop reasons)
+          #   experimental: true
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
OpenRouter models have been unreliable in CI:
- `openrouter/z-ai/glm-5@z-ai`: Failed consistently (billing/API issues)
- `openrouter/minimax/minimax-m2.5`: Also failing with SSL errors and inconsistent stop reasons

Per @ErikBjare's direction: comment out the openrouter test matrix entry until a reliable subprovider/model is identified and investigated.

Fixes #1461

---
**Note**: The openrouter test can be re-enabled once we identify a stable model/provider. The CI infrastructure for multi-model testing remains intact.