### PR TITLE
fix(test): set git identity in agent create E2E test for CI

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -634,13 +634,19 @@ class TestCLI:
         ).is_file()
 
     @pytest.mark.slow
-    def test_create_template_mode_e2e(self, runner, tmp_path):
+    def test_create_template_mode_e2e(self, runner, tmp_path, monkeypatch):
         """Test full `gptme-agent create` using the real gptme-agent-template repo.
 
         This exercises the actual critical path: clone real template, run real
         fork.sh, verify real workspace structure and name substitution.
         Marked slow because it clones from GitHub.
         """
+        # Set git identity for CI environments where it's not configured
+        monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
+        monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@test.com")
+        monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
+        monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@test.com")
+
         workspace = tmp_path / "test-agent-e2e"
         result = runner.invoke(
             main,


### PR DESCRIPTION
## Summary
- Set `GIT_AUTHOR_NAME`/`GIT_COMMITTER_NAME` env vars in `test_create_template_mode_e2e`
- Fixes CI failure where `fork.sh` runs `git commit` but CI runners lack git identity config

This test was merged in #1468 but fails in CI because GitHub Actions runners don't have `user.name`/`user.email` configured globally. The `GIT_*` env vars provide identity without modifying global git config.

## Test plan
- [ ] CI "Test without API keys" passes (was failing on this test)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set git identity environment variables in `test_create_template_mode_e2e` to fix CI failure due to missing git identity.
> 
>   - **Behavior**:
>     - Set `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, and `GIT_COMMITTER_EMAIL` in `test_create_template_mode_e2e` in `test_agent.py`.
>     - Fixes CI failure due to missing git identity when `fork.sh` runs `git commit`.
>   - **Testing**:
>     - Ensures CI "Test without API keys" passes, which was previously failing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 7d199faf798704fbad609e698d53c600b1d29319. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->