### PR TITLE
fix(profiles): reject string tools field with clear error

### DIFF
--- a/gptme/profiles.py
+++ b/gptme/profiles.py
@@ -77,6 +77,15 @@ class Profile:
         behavior_data = data.get("behavior", {})
         behavior = ProfileBehavior(**behavior_data)
         profile_data = {k: v for k, v in data.items() if k != "behavior"}
+
+        # Validate tools field type: must be a list or None, not a bare string
+        tools = profile_data.get("tools")
+        if isinstance(tools, str):
+            raise TypeError(
+                f"Profile '{data.get('name', '?')}': "
+                f"'tools' must be a list (e.g. ['read', 'shell']), got string '{tools}'"
+            )
+
         return cls(behavior=behavior, **profile_data)
 
     def validate_tools(self, available_tool_names: set[str]) -> list[str]:

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -182,6 +182,54 @@ class TestValidateTools:
             )
 
 
+class TestInvalidToolsType:
+    """Tests for invalid tools field types."""
+
+    def test_tools_as_string_raises(self):
+        """Passing tools as a string should raise TypeError."""
+        data = {
+            "name": "bad",
+            "description": "Bad profile",
+            "tools": "shell",
+        }
+        with pytest.raises(TypeError, match="must be a list"):
+            Profile.from_dict(data)
+
+    def test_tools_as_string_in_markdown(self, tmp_path):
+        """Markdown profile with tools as bare string raises on parse."""
+        profile_md = tmp_path / "bad.md"
+        profile_md.write_text(
+            "---\n"
+            "name: bad-tools\n"
+            "description: Tools as string\n"
+            "tools: shell\n"
+            "---\n"
+            "\n"
+            "Bad profile.\n"
+        )
+        with pytest.raises(TypeError, match="must be a list"):
+            _parse_markdown_profile(profile_md)
+
+    def test_tools_as_list_works(self):
+        """Passing tools as a list works normally."""
+        data = {
+            "name": "good",
+            "description": "Good profile",
+            "tools": ["shell"],
+        }
+        profile = Profile.from_dict(data)
+        assert profile.tools == ["shell"]
+
+    def test_tools_none_works(self):
+        """Passing tools as None (all tools) works."""
+        data = {
+            "name": "all",
+            "description": "All tools",
+        }
+        profile = Profile.from_dict(data)
+        assert profile.tools is None
+
+
 class TestListProfiles:
     """Tests for list_profiles function."""
 


### PR DESCRIPTION
## Summary

When a profile specifies `tools` as a bare string (e.g. `tools: shell` in YAML) instead of a list (`tools: [shell]`), Python's `set()` treats the string as an iterable of characters, silently producing nonsensical tool names like `{'s', 'h', 'e', 'l'}`. This makes the tool allowlist completely ineffective — the profile accepts all tools instead of restricting to the intended set.

**Fix**: Add type validation in `Profile.from_dict()` that raises `TypeError` with a clear, actionable message when `tools` is a string instead of a list.

## Test plan

- [x] New test: string tools field raises TypeError with helpful message
- [x] New test: string tools in markdown profile raises TypeError
- [x] New test: list tools field works as expected
- [x] New test: None tools (all tools) works as expected
- [x] All 29 existing profile tests continue to pass
- [x] mypy clean
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add type validation in `Profile.from_dict()` to ensure `tools` is a list, raising `TypeError` for string inputs, with new tests verifying this behavior.
> 
>   - **Behavior**:
>     - In `Profile.from_dict()`, add type validation for `tools` field to ensure it is a list or `None`, raising `TypeError` if a string is provided.
>   - **Tests**:
>     - Add `TestInvalidToolsType` class in `test_profiles.py` with tests for string `tools` field raising `TypeError` and list `tools` field working correctly.
>     - Ensure all 29 existing profile tests pass without changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for c2f2f43b0aac3b3276054e354b6aa3bfd034129a. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->