### PR TITLE
fix(context): fix missing separator and inverted error handling in path parsing

### DIFF
--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -284,9 +284,10 @@ def embed_attached_file_content(
                     files_text[f] = md_codeblock(f, "<file was modified after message>")
     # Get list of display paths for the return value
     display_files = [f for _, f in files_with_originals]
+    file_content = "\n\n".join(files_text.values())
     return replace(
         msg,
-        content=msg.content + "\n\n".join(files_text.values()),
+        content=msg.content + ("\n\n" + file_content if file_content else ""),
         files=[f for f in display_files if f not in files_text],
     )
 
@@ -716,6 +717,6 @@ def _parse_prompt_files(prompt: str) -> Path | None:
             return None
     except OSError as oserr:  # pragma: no cover
         # some prompts are too long to be a path, so we can't read them
-        if oserr.errno != errno.ENAMETOOLONG:
+        if oserr.errno == errno.ENAMETOOLONG:
             return None
         raise

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -98,6 +98,71 @@ def test_find_potential_paths_punctuation():
     assert "https://example.com" in paths
 
 
+def test_embed_attached_file_content_separator(tmp_path):
+    """File contents should be separated from message content by double newlines."""
+    from gptme.message import Message
+    from gptme.util.context import embed_attached_file_content
+
+    # Create a test file
+    test_file = tmp_path / "test.py"
+    test_file.write_text("print('hello')")
+
+    # Message with content and an attached file
+    msg = Message("user", "Check this file", files=[test_file])
+    result = embed_attached_file_content(msg, workspace=tmp_path)
+
+    # The file content should be separated from the message content
+    assert result.content.startswith("Check this file\n\n")
+    assert "print('hello')" in result.content
+    # File should be removed from files list (embedded as text)
+    assert test_file not in result.files
+
+
+def test_embed_attached_file_content_multiple_files(tmp_path):
+    """Multiple embedded files should each be separated by double newlines."""
+    from gptme.message import Message
+    from gptme.util.context import embed_attached_file_content
+
+    # Create test files
+    file_a = tmp_path / "a.py"
+    file_a.write_text("code_a")
+    file_b = tmp_path / "b.py"
+    file_b.write_text("code_b")
+
+    msg = Message("user", "Review these", files=[file_a, file_b])
+    result = embed_attached_file_content(msg, workspace=tmp_path)
+
+    # Both files should be embedded with proper separation
+    assert result.content.startswith("Review these\n\n")
+    assert "code_a" in result.content
+    assert "code_b" in result.content
+    # The two codeblocks should be separated by double newlines
+    assert "\n\n````" in result.content
+
+
+def test_embed_attached_file_content_no_files():
+    """Message without files should be returned unchanged."""
+    from gptme.message import Message
+    from gptme.util.context import embed_attached_file_content
+
+    msg = Message("user", "No files here")
+    result = embed_attached_file_content(msg)
+
+    assert result.content == "No files here"
+
+
+def test_parse_prompt_files_long_string():
+    """Long strings that exceed filesystem limits should return None, not raise."""
+    from gptme.util.context import _parse_prompt_files
+
+    # A string that's too long to be a valid path (most systems limit to ~4096 chars)
+    long_string = "/" + "a" * 5000
+
+    # Should return None (not a path), not raise OSError
+    result = _parse_prompt_files(long_string)
+    assert result is None
+
+
 def test_find_potential_paths_ignores_xml_tags():
     """Paths inside XML tags should not be extracted (e.g. user pastes tool output)."""
     content = """


### PR DESCRIPTION
## Summary
- **Missing separator**: `embed_attached_file_content` concatenated file codeblocks directly to message content without a `\n\n` separator, producing malformed markdown like `"message text````python\ncode\n```"`
- **Inverted condition**: `_parse_prompt_files` had the `ENAMETOOLONG` check inverted vs `_resource_to_codeblock` — it would raise on long prompts (harmless) while silently swallowing real OS errors like permission denied

## Test plan
- [x] Added `test_embed_attached_file_content_separator` — verifies separator between content and embedded file
- [x] Added `test_embed_attached_file_content_multiple_files` — verifies multiple files separated correctly
- [x] Added `test_embed_attached_file_content_no_files` — verifies no-op when no files
- [x] Added `test_parse_prompt_files_long_string` — verifies ENAMETOOLONG returns None instead of raising
- [x] All existing tests pass (1447 passed)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes missing markdown separator and corrects error handling in path parsing, with new tests added.
> 
>   - **Behavior**:
>     - Fixes missing `\n\n` separator in `embed_attached_file_content()` in `context.py`, ensuring proper markdown formatting.
>     - Corrects inverted `ENAMETOOLONG` condition in `_parse_prompt_files()` in `context.py`, now correctly handling long prompts.
>   - **Tests**:
>     - Adds `test_embed_attached_file_content_separator` to verify separator between message content and embedded file.
>     - Adds `test_embed_attached_file_content_multiple_files` to verify multiple files are separated correctly.
>     - Adds `test_embed_attached_file_content_no_files` to verify no-op when no files are present.
>     - Adds `test_parse_prompt_files_long_string` to verify `ENAMETOOLONG` returns `None` instead of raising an error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 10e622abb01a4b437394e68e19e77fbc4f770215. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->