### PR TITLE
fix(tmux): use check=False in kill_session for proper error messages

### DIFF
--- a/gptme/tools/tmux.py
+++ b/gptme/tools/tmux.py
@@ -278,7 +278,7 @@ def kill_session(session_id: str) -> Message:
         session_id = f"gptme_{session_id}"
     result = subprocess.run(
         ["tmux", "kill-session", "-t", session_id],
-        check=True,
+        check=False,
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
## Summary
- `kill_session()` used `check=True` with `subprocess.run()`, which raises `CalledProcessError` on non-zero exit
- This made the `returncode != 0` check dead code — error messages were never shown, users got unhandled exceptions instead
- Changed to `check=False` so the error handling works as written

## Test plan
- [x] All 13 tmux tests pass (including `test_kills_session`)
- [x] mypy clean
- [x] ruff clean (explicit `check=False`)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `check=True` to `check=False` in `kill_session()` to enable error handling instead of raising exceptions.
> 
>   - **Behavior**:
>     - Change `check=True` to `check=False` in `kill_session()` in `tmux.py` to allow error handling instead of raising `CalledProcessError`.
>     - Ensures error messages are shown when `returncode != 0`.
>   - **Testing**:
>     - All 13 tmux tests pass, including `test_kills_session`.
>     - `mypy` and `ruff` checks are clean.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for e3a8736e41cb2044b358bd261c3f5bfd6648a149. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->