### PR TITLE
fix(browser): add exhaustive return path in read_url

### DIFF
--- a/gptme/tools/browser.py
+++ b/gptme/tools/browser.py
@@ -501,8 +501,7 @@ def read_url(url: str, max_pages: int | None = None) -> str:
     assert browser
     if browser == "playwright":
         return read_url_playwright(url)
-    if browser == "lynx":
-        return read_url_lynx(url)
+    return read_url_lynx(url)
 
 
 def search(query: str, engine: EngineType = "perplexity") -> str:


### PR DESCRIPTION
## Summary
- `read_url()` used two consecutive `if` statements for playwright/lynx backends without an `else`, leaving a code path that implicitly returns `None` despite the `str` return type annotation
- Changed to `if/else` for exhaustive branch coverage
- Consistent with how `screenshot_url()` and `read_logs()` handle their browser backend selection

## Test plan
- [x] All 7 browser tests pass
- [x] mypy clean
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure exhaustive return paths in `read_url()` in `browser.py` by using `if/else` for backend selection.
> 
>   - **Behavior**:
>     - Modify `read_url()` in `browser.py` to use `if/else` for exhaustive return paths, ensuring it returns a `str` as annotated.
>     - Aligns `read_url()` behavior with `screenshot_url()` and `read_logs()` for backend selection.
>   - **Testing**:
>     - All 7 browser tests pass.
>     - `mypy` reports no issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 1ddd36de0127e41ff5d49eb266b9fa58f1adb133. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->