### PR TITLE
fix(screenshot): add availability check for screenshot tools

### DIFF
--- a/gptme/tools/screenshot.py
+++ b/gptme/tools/screenshot.py
@@ -15,6 +15,7 @@ OUTPUT_DIR = Path("/tmp/outputs")
 IS_MACOS = platform.system() == "Darwin"
 IS_WAYLAND = os.environ.get("XDG_SESSION_TYPE") == "wayland"
 
+# TODO: check for screen recording permissions instead of prompting the llm
 INSTRUCTIONS = (
     "If all you see is a wallpaper, the user may have to allow screen capture in `System Preferences -> Security & Privacy -> Screen Recording`."
     if IS_MACOS


### PR DESCRIPTION
## Summary
- Adds `_is_available()` function that checks for screenshot tool presence (`screencapture` on macOS, `gnome-screenshot`/`scrot` on Linux)
- Sets `available=_is_available` on the `ToolSpec` so the tool is excluded when no screenshot tools are installed
- Previously the tool always loaded but would fail at runtime with `NotImplementedError`

Addresses the TODO comment in `screenshot.py`.

## Test plan
- [x] Existing `test_screenshot_path_validation` passes
- [x] Manual verification: `_is_available()` correctly detects `scrot` on Linux
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds availability check for screenshot tools in `screenshot.py` to prevent runtime errors when tools are missing.
> 
>   - **Behavior**:
>     - Adds `_is_available()` in `screenshot.py` to check for `screencapture` on macOS and `gnome-screenshot`/`scrot` on Linux.
>     - Updates `ToolSpec` in `screenshot.py` to use `_is_available` for the `available` attribute, excluding the tool if no screenshot tools are installed.
>     - Previously, the tool would load and fail at runtime with `NotImplementedError` if tools were unavailable.
>   - **Misc**:
>     - Removes TODO comment in `screenshot.py` regarding availability check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 8126e2076fd328d911e453260f1f3845d0253c50. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->