### PR TITLE
feat(profiles): add computer-use profile and document --tools +computer

### DIFF
--- a/docs/server.rst
+++ b/docs/server.rst
@@ -116,11 +116,8 @@ You can enable the ``computer`` tool locally on Linux systems, though this is no
 
 .. code-block:: bash
 
-   # Enable computer tool in addition to default tools (recommended)
+   # Enable computer tool in addition to default tools
    gptme --tools +computer
-
-   # Avoid this unless you explicitly want only the computer tool
-   gptme --tools computer
 
 Set an appropriate screen resolution for your vision model before use.
 
@@ -129,8 +126,15 @@ parent context smaller:
 
 .. code-block:: python
 
+   # Desktop interaction (mouse, keyboard, screenshots)
    subagent(
        "computer-use",
+       "Click the Submit button, wait for the modal, and screenshot the result",
+   )
+
+   # Web browsing and testing
+   subagent(
+       "browser-use",
        "Open localhost:5173, capture a screenshot, and report UI issues",
    )
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -132,7 +132,7 @@ Tool Selection Patterns
 
 Use ``--tools`` to control which tools are available.
 
-- ``--tools shell,read`` replaces defaults with exactly those tools.
+- ``--tools read,append`` replaces defaults with exactly those tools.
 - ``--tools +computer`` adds the ``computer`` tool on top of defaults.
 
 .. code-block:: bash
@@ -140,17 +140,21 @@ Use ``--tools`` to control which tools are available.
     # Add computer use while keeping the standard default tools
     gptme --tools +computer "take a screenshot and summarize what you see"
 
-    # Replace defaults entirely (advanced)
-    gptme --tools computer "only computer tool is available"
-
 For long visual tasks, use a subagent profile to avoid bloating parent context
 with repeated screenshots:
 
 .. code-block:: python
 
+    # Desktop interaction (mouse, keyboard, screenshots)
     subagent(
         "computer-use",
-        "Navigate app UI, capture evidence, and return a concise bug report",
+        "Click the Submit button, wait for the modal, and screenshot the result",
+    )
+
+    # Web browsing and testing
+    subagent(
+        "browser-use",
+        "Navigate web app UI, capture evidence, and return a concise bug report",
     )
 
 See available profiles with:

--- a/gptme/profiles.py
+++ b/gptme/profiles.py
@@ -165,10 +165,7 @@ BUILTIN_PROFILES: dict[str, Profile] = {
     ),
     "computer-use": Profile(
         name="computer-use",
-        description=(
-            "Computer-use specialist for visual UI testing via subagent. "
-            "Run with --tools +computer so defaults remain available."
-        ),
+        description="Computer-use specialist for visual UI testing and desktop interaction",
         system_prompt=(
             "You are in COMPUTER-USE mode, specialized for visual UI testing and "
             "desktop interaction. Prioritize efficient, evidence-first workflows:\n"
@@ -178,7 +175,22 @@ BUILTIN_PROFILES: dict[str, Profile] = {
             "- When used as a subagent, keep parent context lean by summarizing key results\n"
             "- Avoid unnecessary file modifications unless explicitly requested\n"
         ),
-        tools=["computer", "screenshot", "vision", "browser", "shell", "read"],
+        tools=["computer", "vision", "ipython", "shell"],
+        behavior=ProfileBehavior(),
+    ),
+    "browser-use": Profile(
+        name="browser-use",
+        description="Browser-use specialist for web interaction and testing",
+        system_prompt=(
+            "You are in BROWSER-USE mode, specialized for web browsing and "
+            "interaction. Prioritize efficient, evidence-first workflows:\n"
+            "- Use the browser tool for navigating websites and web applications\n"
+            "- Take screenshots to verify visual state and capture evidence\n"
+            "- Prefer returning structured findings (issues, repro steps, observations)\n"
+            "- When used as a subagent, keep parent context lean by summarizing key results\n"
+            "- Avoid unnecessary file modifications unless explicitly requested\n"
+        ),
+        tools=["browser", "screenshot", "vision", "shell"],
         behavior=ProfileBehavior(),
     ),
 }

--- a/gptme/tools/subagent.py
+++ b/gptme/tools/subagent.py
@@ -785,7 +785,7 @@ def subagent(
             - Tool access restrictions (which tools the subagent can use)
             - Behavior rules (read-only, no-network, etc.)
             Use 'gptme-util profile list' to see available profiles.
-            Built-in profiles: default, explorer, researcher, developer, isolated, computer-use.
+            Built-in profiles: default, explorer, researcher, developer, isolated, computer-use, browser-use.
             If not set, auto-detected from agent_id when it matches a profile name.
         model: Model to use for the subagent. Overrides parent's model.
             Useful for routing cheap tasks to faster/cheaper models.
@@ -1427,11 +1427,13 @@ When agent_id matches a profile name, the profile is auto-applied:
 - researcher: Web research without file modification (tools: browser, read)
 - developer: Full development capabilities (all tools)
 - isolated: Restricted processing for untrusted content (tools: read, ipython)
-- computer-use: Visual UI testing specialist (tools: computer, screenshot, vision, browser, shell, read)
+- computer-use: Visual UI testing specialist (tools: computer, vision, ipython, shell)
+- browser-use: Web interaction and testing specialist (tools: browser, screenshot, vision, shell)
 
 Example: `subagent("explorer", "Explore codebase")`
 With model override: `subagent("researcher", "Find docs", model="openai/gpt-4o-mini")`
-Computer-use example: `subagent("computer-use", "Open localhost:5173, take a screenshot, and report UI issues")`
+Computer-use example: `subagent("computer-use", "Click the Submit button, wait for the modal, and screenshot the result")`
+Browser-use example: `subagent("browser-use", "Open localhost:5173, take a screenshot, and report UI issues")`
 
 Use subagent_read_log() to inspect a subagent's conversation log for debugging.
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -112,7 +112,19 @@ class TestBuiltinProfiles:
         assert computer_use.name == "computer-use"
         assert computer_use.tools is not None
         assert "computer" in computer_use.tools
-        assert "screenshot" in computer_use.tools
+        assert "vision" in computer_use.tools
+        assert "ipython" in computer_use.tools
+        assert "shell" in computer_use.tools
+
+    def test_browser_use_profile(self):
+        browser_use = BUILTIN_PROFILES["browser-use"]
+
+        assert browser_use.name == "browser-use"
+        assert browser_use.tools is not None
+        assert "browser" in browser_use.tools
+        assert "screenshot" in browser_use.tools
+        assert "vision" in browser_use.tools
+        assert "shell" in browser_use.tools
 
 
 class TestGetProfile:


### PR DESCRIPTION
## Summary
Implements the follow-up from #1491:

- adds a built-in `computer-use` agent profile for visual UI testing workflows
- documents the correct additive syntax `--tools +computer` (instead of replacing defaults)
- documents subagent usage pattern to keep parent context lean during screenshot-heavy workflows
- updates subagent docs to include the new built-in profile

## Changes
- `gptme/profiles.py`
  - add `computer-use` profile with focused system prompt and toolset:
    - `computer`, `screenshot`, `vision`, `browser`, `shell`, `read`
- `docs/server.rst`
  - clarify `gptme --tools +computer` (recommended)
  - note that `gptme --tools computer` replaces defaults
  - add `subagent("computer-use", ...)` example
- `docs/usage.rst`
  - add **Tool Selection Patterns** section
  - explain replacement vs additive tool selection
  - add profile listing command and subagent pattern example
- `gptme/tools/subagent.py`
  - include `computer-use` in built-in profiles docs and examples
- `tests/test_profiles.py`
  - add regression test for built-in `computer-use` profile

## Validation
- `uv run pytest tests/test_profiles.py -q` ✅ (35 passed)
- `uv run pytest tests/test_tools_subagent.py -q` ✅ (47 passed)
- `uv run pytest tests/test_cli.py -q -k 'not requires_api and not slow'` ✅ (14 passed)

Closes #1491

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `computer-use` profile for visual UI testing and updates documentation and tests accordingly.
> 
>   - **Behavior**:
>     - Adds `computer-use` profile in `profiles.py` with tools: `computer`, `screenshot`, `vision`, `browser`, `shell`, `read`.
>     - Documents `--tools +computer` usage in `server.rst` and `usage.rst`.
>     - Updates `subagent` examples in `subagent.py` to include `computer-use` profile.
>   - **Documentation**:
>     - Clarifies additive vs replacement tool selection in `usage.rst`.
>     - Adds `subagent("computer-use", ...)` example in `server.rst`.
>   - **Tests**:
>     - Adds test for `computer-use` profile in `test_profiles.py`.
>   - **Validation**:
>     - All tests in `test_profiles.py`, `test_tools_subagent.py`, and `test_cli.py` pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 1853ca10facafbfb1b73310b196272948fd940bc. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->