### PR TITLE
test(context): add image auto-attach pipeline tests + debug logging

### DIFF
--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -510,6 +510,7 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
                 file = file.expanduser()
                 if workspace and not file.is_absolute():
                     file = file.absolute().relative_to(workspace)
+                logger.debug(f"auto-attaching file: {file}")
                 files.append(file)
 
     # Process URLs (only confirmed ones in interactive mode)
@@ -524,6 +525,11 @@ def include_paths(msg: Message, workspace: Path | None = None) -> Message:
             append_msg += "\n\n" + contents
 
     if files:
+        logger.debug(
+            "include_paths: attaching %d file(s) to message: %s",
+            len(files),
+            [str(f) for f in files],
+        )
         msg = msg.replace(files=msg.files + files)
 
     # append the message with the file contents


### PR DESCRIPTION
## Summary

- Add 4 tests verifying the image auto-attach pipeline works end-to-end
- Add debug logging at key points in `include_paths()` for diagnosing image attachment issues

## Tests Added

| Test | What it verifies |
|------|-----------------|
| `test_include_paths_image_auto_attach` | Bare image path → `msg.files` |
| `test_include_paths_image_in_text` | Image path in "View this image: /path" text |
| `test_embed_attached_preserves_image_files` | Images survive `embed_attached_file_content` |
| `test_image_auto_attach_end_to_end` | Full pipeline: `include_paths` → `embed` → `msgs2dicts` |

## Context

During investigation of the image paste feature (#1379), I traced the full pipeline and confirmed the code path is correct — images should be auto-attached to `msg.files`, preserved through `embed_attached_file_content()`, and converted to base64 content blocks by providers.

These tests codify that expectation and the debug logging helps diagnose if images aren't being attached in practice.

## Test plan

- [x] All 13 tests in `test_chat.py` pass
- [x] Pre-commit hooks pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add tests for image auto-attach pipeline and debug logging in `include_paths()` to diagnose attachment issues.
> 
>   - **Tests**:
>     - Add `test_include_paths_image_auto_attach` to verify image paths are auto-attached to `msg.files`.
>     - Add `test_include_paths_image_in_text` to check image paths in text are auto-attached.
>     - Add `test_embed_attached_preserves_image_files` to ensure images remain in `msg.files` after `embed_attached_file_content()`.
>     - Add `test_image_auto_attach_end_to_end` for full pipeline verification from `include_paths` to `msgs2dicts`.
>   - **Logging**:
>     - Add debug logging in `include_paths()` in `context.py` to log file auto-attachment and the number of files attached.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for b96fe18ee890347e3a4b4177ca2ae5e2249a18b5. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->