### PR TITLE
fix: remove stale xfail, register marker, close tts socket

### DIFF
--- a/gptme/tools/tts.py
+++ b/gptme/tools/tts.py
@@ -66,9 +66,11 @@ def is_available() -> bool:
         return False
 
     # available if a server is running on localhost:8765
-    server_available = (
-        socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex((host, port)) == 0
-    )
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        server_available = sock.connect_ex((host, port)) == 0
+    finally:
+        sock.close()
     return server_available
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,6 +273,7 @@ markers = [
     "requires_api: marks tests that require API access",
     "flaky: marks tests as flaky (retried automatically)",
     "integration: marks tests as integration tests requiring external services",
+    "xdist_group: marks tests that should run in the same xdist group",
 ]
 
 [tool.coverage.run]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -228,7 +228,6 @@ def test_shell(args: list[str], runner: CliRunner):
     assert result.exit_code == 0
 
 
-@pytest.mark.xfail(strict=False, reason="Flaky in CI")
 def test_shell_file(args: list[str], runner: CliRunner):
     # test running the shell tool with a filename
     # make sure we don't accidentally expand the filename and include it in the shell command


### PR DESCRIPTION
## Summary
- Remove stale `xfail(reason="Flaky in CI")` from `test_shell_file` — the test now passes consistently (was showing as XPASS in every run)
- Register `xdist_group` marker in `[tool.pytest.ini_options]` to suppress `PytestUnknownMarkWarning`
- Fix resource leak in `gptme/tools/tts.py`: properly close socket after checking if TTS server is available (was causing `ResourceWarning: unclosed socket` in test output)

## Test plan
- [x] Ran `pytest tests/test_cli.py` — 16 passed, 0 xpassed, 0 warnings (was 15 passed + 1 xpassed + 3 warnings)
- [x] Verified `test_shell_file` passes without `xfail` marker
- [x] Verified `xdist_group` warning is gone
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove stale xfail marker, register xdist_group marker, and fix socket resource leak in TTS tool.
> 
>   - **Testing**:
>     - Remove stale `xfail` marker from `test_shell_file` in `test_cli.py` as it now passes consistently.
>     - Register `xdist_group` marker in `pyproject.toml` to suppress `PytestUnknownMarkWarning`.
>   - **Resource Management**:
>     - Fix resource leak in `is_available()` in `tts.py` by ensuring socket is closed after use.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 182f2f03acec956117f8faf2b992024c570a755d. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->