### PR TITLE
fix(hooks): filter lockfiles and add token budget to active context

### DIFF
--- a/gptme/hooks/active_context.py
+++ b/gptme/hooks/active_context.py
@@ -14,6 +14,34 @@ from . import HookType, StopPropagation, register_hook
 
 logger = logging.getLogger(__name__)
 
+# Files that are never useful as LLM context (lockfiles, minified assets, etc.)
+_SKIP_FILENAMES: set[str] = {
+    "poetry.lock",
+    "uv.lock",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "Cargo.lock",
+    "Gemfile.lock",
+    "composer.lock",
+    "go.sum",
+    "flake.lock",
+    "Pipfile.lock",
+}
+
+_SKIP_SUFFIXES: set[str] = {
+    ".min.js",
+    ".min.css",
+    ".map",
+    ".pyc",
+    ".pyo",
+    ".whl",
+    ".egg-info",
+}
+
+# Approximate token budget for the entire context message (~30k tokens ≈ 120k chars)
+_TOKEN_BUDGET_CHARS = 120_000
+
 
 def context_hook(
     messages: list[Message],
@@ -57,29 +85,43 @@ def context_hook(
     if status := git_status():
         sections.append(status)
 
-    # TODO: this needs to be smarter (not include large files like poetry.lock)
-    #       should probably have a token-based budget, and should log a message about the token size of message generated
-
-    # Read contents of selected files
+    # Read contents of selected files, respecting skip lists and token budget
+    total_chars = 0
     for f in files[:10]:
-        if f.exists():
-            try:
-                display_path = file_to_display_path(f, workspace)
-                with open(f) as file:
-                    content = file.read()
-                if len(content) > 100000:
-                    # skip files that are too large
-                    logger.info(f"Skipping large file: {display_path}")
-                    continue
-                logger.info(f"Read file: {display_path} (size={len(content)} bytes)")
-                sections.append(md_codeblock(display_path, content))
-            except UnicodeDecodeError:
-                logger.debug(f"Skipping binary file: {f}")
-                sections.append(md_codeblock(str(display_path), "<binary file>"))
-            except OSError as e:
-                logger.warning(f"Error reading file {f}: {e}")
-        else:
+        if not f.exists():
             logger.info(f"File not found: {f}")
+            continue
+
+        # Skip known useless files (lockfiles, minified assets, etc.)
+        if f.name in _SKIP_FILENAMES or any(f.name.endswith(s) for s in _SKIP_SUFFIXES):
+            logger.info(f"Skipping non-useful file: {f.name}")
+            continue
+
+        try:
+            display_path = file_to_display_path(f, workspace)
+            with open(f) as file:
+                content = file.read()
+            if len(content) > 100_000:
+                logger.info(f"Skipping large file: {display_path}")
+                continue
+            # Check token budget before adding
+            if total_chars + len(content) > _TOKEN_BUDGET_CHARS:
+                logger.info(
+                    f"Token budget exhausted ({total_chars} chars used), "
+                    f"skipping {display_path} ({len(content)} chars)"
+                )
+                continue
+            total_chars += len(content)
+            logger.info(
+                f"Read file: {display_path} "
+                f"(size={len(content)} chars, ~{len(content) // 4} tokens)"
+            )
+            sections.append(md_codeblock(display_path, content))
+        except UnicodeDecodeError:
+            logger.debug(f"Skipping binary file: {f}")
+            sections.append(md_codeblock(str(display_path), "<binary file>"))
+        except OSError as e:
+            logger.warning(f"Error reading file {f}: {e}")
 
     if not sections:
         return
@@ -96,7 +138,9 @@ This context message will be removed and replaced with fresh context on every ne
 
 """ + "\n\n".join(sections)
 
-    logger.info("Length of active context injected: " + str(len(content)))
+    logger.info(
+        f"Active context injected: {len(content)} chars (~{len(content) // 4} tokens)"
+    )
     yield Message("system", content)
 
 

--- a/tests/test_active_context.py
+++ b/tests/test_active_context.py
@@ -1,0 +1,189 @@
+"""Tests for active context hook file filtering and token budget."""
+
+from unittest.mock import patch
+
+import pytest
+
+from gptme.hooks.active_context import (
+    _SKIP_FILENAMES,
+    _SKIP_SUFFIXES,
+    context_hook,
+)
+from gptme.message import Message
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """Create a workspace with various file types."""
+    # Normal source files
+    (tmp_path / "main.py").write_text("print('hello')\n")
+    (tmp_path / "utils.py").write_text("def helper(): pass\n")
+
+    # Lockfiles (should be skipped)
+    (tmp_path / "poetry.lock").write_text("[[package]]\nname = 'foo'\n" * 100)
+    (tmp_path / "uv.lock").write_text("version = 1\n" * 100)
+    (tmp_path / "package-lock.json").write_text('{"lockfileVersion": 3}\n')
+    (tmp_path / "yarn.lock").write_text("# yarn lockfile v1\n")
+
+    # Minified files (should be skipped)
+    (tmp_path / "bundle.min.js").write_text("var a=1;var b=2;" * 1000)
+    (tmp_path / "styles.min.css").write_text("body{margin:0}" * 500)
+
+    # Large file (should be skipped by size limit)
+    (tmp_path / "huge.txt").write_text("x" * 200_000)
+
+    return tmp_path
+
+
+def _run_hook(messages, workspace):
+    """Helper to run the context hook and collect results."""
+    with (
+        patch("gptme.util.context.use_fresh_context", return_value=True),
+        patch("gptme.hooks.active_context.git_status", return_value=""),
+    ):
+        results = list(context_hook(messages, workspace=workspace))
+    return results
+
+
+def _mock_select_files(file_list):
+    """Create a mock for select_relevant_files that returns specific files."""
+    return patch(
+        "gptme.hooks.active_context.select_relevant_files",
+        return_value=file_list,
+    )
+
+
+def test_skips_lockfiles(workspace):
+    """Lockfiles should never be included in context."""
+    files = [
+        workspace / "main.py",
+        workspace / "poetry.lock",
+        workspace / "uv.lock",
+        workspace / "package-lock.json",
+    ]
+    with _mock_select_files(files):
+        results = _run_hook([Message("user", "test")], workspace)
+
+    assert len(results) == 1
+    content = results[0].content
+    assert "main.py" in content
+    assert "poetry.lock" not in content
+    assert "uv.lock" not in content
+    assert "package-lock.json" not in content
+
+
+def test_skips_minified_files(workspace):
+    """Minified JS/CSS should not be included."""
+    files = [
+        workspace / "main.py",
+        workspace / "bundle.min.js",
+        workspace / "styles.min.css",
+    ]
+    with _mock_select_files(files):
+        results = _run_hook([Message("user", "test")], workspace)
+
+    assert len(results) == 1
+    content = results[0].content
+    assert "main.py" in content
+    assert "bundle.min.js" not in content
+    assert "styles.min.css" not in content
+
+
+def test_skips_large_files(workspace):
+    """Files over 100KB should be skipped."""
+    files = [workspace / "main.py", workspace / "huge.txt"]
+    with _mock_select_files(files):
+        results = _run_hook([Message("user", "test")], workspace)
+
+    assert len(results) == 1
+    content = results[0].content
+    assert "main.py" in content
+    assert "huge.txt" not in content
+
+
+def test_token_budget_respected(workspace):
+    """Should stop adding files once token budget is exhausted."""
+    # Create two files that individually fit in the 100KB per-file limit
+    # but together exceed the token budget.
+    # Each file is ~80KB (under 100KB limit), but two together exceed 120KB budget.
+    file_a = workspace / "file_a.py"
+    file_a.write_text("a = 1\n" * 14_000)  # ~84KB
+
+    file_b = workspace / "file_b.py"
+    file_b.write_text("b = 2\n" * 14_000)  # ~84KB
+
+    files = [file_a, file_b]
+    with _mock_select_files(files):
+        results = _run_hook([Message("user", "test")], workspace)
+
+    assert len(results) == 1
+    content = results[0].content
+    # file_a should be included (fits in budget)
+    assert "file_a.py" in content
+    # file_b should be skipped (budget exhausted after file_a)
+    assert "file_b.py" not in content
+
+
+def test_normal_files_included(workspace):
+    """Normal source files should be included."""
+    files = [workspace / "main.py", workspace / "utils.py"]
+    with _mock_select_files(files):
+        results = _run_hook([Message("user", "test")], workspace)
+
+    assert len(results) == 1
+    content = results[0].content
+    assert "main.py" in content
+    assert "utils.py" in content
+    assert "print('hello')" in content
+    assert "def helper(): pass" in content
+
+
+def test_skip_filenames_comprehensive():
+    """Verify all expected lockfile names are in the skip list."""
+    expected = {
+        "poetry.lock",
+        "uv.lock",
+        "package-lock.json",
+        "yarn.lock",
+        "pnpm-lock.yaml",
+        "Cargo.lock",
+        "Gemfile.lock",
+        "composer.lock",
+        "go.sum",
+        "flake.lock",
+        "Pipfile.lock",
+    }
+    assert expected == _SKIP_FILENAMES
+
+
+def test_skip_suffixes_comprehensive():
+    """Verify all expected skip suffixes are in the skip list."""
+    expected = {".min.js", ".min.css", ".map", ".pyc", ".pyo", ".whl", ".egg-info"}
+    assert expected == _SKIP_SUFFIXES
+
+
+def test_nonexistent_files_handled(workspace):
+    """Non-existent files should be silently skipped."""
+    files = [workspace / "main.py", workspace / "does_not_exist.py"]
+    with _mock_select_files(files):
+        results = _run_hook([Message("user", "test")], workspace)
+
+    assert len(results) == 1
+    content = results[0].content
+    assert "main.py" in content
+    assert "does_not_exist" not in content
+
+
+def test_binary_files_handled(workspace):
+    """Binary files should get a placeholder."""
+    binary = workspace / "data.bin"
+    binary.write_bytes(b"\x00\x01\x02\xff" * 100)
+
+    files = [workspace / "main.py", binary]
+    with _mock_select_files(files):
+        results = _run_hook([Message("user", "test")], workspace)
+
+    assert len(results) == 1
+    content = results[0].content
+    assert "main.py" in content
+    assert "<binary file>" in content


### PR DESCRIPTION
## Summary

The active context hook could waste tokens by including dependency lockfiles and had no budget to prevent unbounded context growth.

- Skip known non-useful files: 11 lockfile patterns (`poetry.lock`, `uv.lock`, `package-lock.json`, `yarn.lock`, etc.) and 7 suffix patterns (`.min.js`, `.min.css`, `.map`, `.pyc`, etc.)
- Add approximate token budget (~30k tokens / 120k chars) so context doesn't grow unboundedly across many files
- Improve logging: log approximate token counts per file and for total injected context
- Resolves the TODO at `gptme/hooks/active_context.py:60`

## Test plan

- [x] 9 new tests covering: lockfile skipping, minified file skipping, large file skipping, token budget enforcement, normal file inclusion, comprehensive skip list verification, nonexistent file handling, binary file handling
- [x] All tests pass locally
- [x] mypy clean (no new errors in changed file)
- [x] Pre-commit hooks pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `context_hook()` in `active_context.py` by filtering non-useful files, enforcing a token budget, and improving logging, with comprehensive tests added.
> 
>   - **Behavior**:
>     - Filters out non-useful files in `context_hook()` in `active_context.py`, skipping 11 lockfile patterns and 7 suffix patterns.
>     - Implements a token budget of ~30k tokens (120k chars) to prevent unbounded context growth.
>     - Improves logging to include approximate token counts per file and total context.
>   - **Tests**:
>     - Adds 9 tests in `test_active_context.py` for lockfile skipping, minified file skipping, large file skipping, token budget enforcement, normal file inclusion, comprehensive skip list verification, nonexistent file handling, and binary file handling.
>   - **Misc**:
>     - Resolves TODO in `active_context.py` regarding smarter file inclusion logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 3d618abcc7a160f951efb95160a62c392b12cc01. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->