### PR TITLE
refactor(context): return mention counts from get_mentioned_files

### DIFF
--- a/gptme/hooks/active_context.py
+++ b/gptme/hooks/active_context.py
@@ -74,7 +74,7 @@ def context_hook(
     except Exception as e:
         logger.error(f"Failed to select files with context selector: {e}")
         # Fallback to simple mention counting if selector fails
-        files = get_mentioned_files(messages, workspace)[:10]
+        files = list(get_mentioned_files(messages, workspace).keys())[:10]
 
     if not files:
         return

--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -364,8 +364,13 @@ def git_status() -> str | None:
     return None
 
 
-def get_mentioned_files(msgs: list[Message], workspace: Path | None) -> list[Path]:
-    """Count files mentioned in messages."""
+def get_mentioned_files(msgs: list[Message], workspace: Path | None) -> dict[Path, int]:
+    """Get files mentioned in messages with their mention counts.
+
+    Returns:
+        Dict mapping file paths to mention counts,
+        ordered by (mention_count, mtime) descending.
+    """
     workspace_abs = workspace.resolve() if workspace else None
     files: Counter[Path] = Counter()
     for msg in msgs:
@@ -391,7 +396,7 @@ def get_mentioned_files(msgs: list[Message], workspace: Path | None) -> list[Pat
         except FileNotFoundError:
             return (files[f], 0)
 
-    return sorted(files.keys(), key=file_score, reverse=True)
+    return {f: files[f] for f in sorted(files.keys(), key=file_score, reverse=True)}
 
 
 # gather_fresh_context removal: Logic moved to gptme.hooks.context

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -91,10 +91,14 @@ def test_get_mentioned_files(tmp_path):
         Message("user", "check file2", files=[file2]),
     ]
 
-    # Should sort by mentions (file1 mentioned twice)
+    # Should return dict with counts, ordered by mentions (file1 mentioned twice)
     files = get_mentioned_files(msgs, tmp_path)
-    assert files[0] == file1
-    assert files[1] == file2
+    paths = list(files.keys())
+    assert paths[0] == file1
+    assert paths[1] == file2
+    # Verify counts are returned
+    assert files[file1.resolve()] == 2
+    assert files[file2.resolve()] == 1
 
 
 def test_use_fresh_context(monkeypatch):


### PR DESCRIPTION
## Summary
- `get_mentioned_files` now returns `dict[Path, int]` (ordered by mention count + recency) instead of `list[Path]`
- Eliminates duplicate message iteration in `file_selector.py` — it was re-scanning all messages to rebuild counts that `get_mentioned_files` already computed
- Removes ~10 lines of redundant path resolution logic from the file selection hot path

## Changes
- `gptme/util/context.py`: Return type changed from `list[Path]` to `dict[Path, int]`
- `gptme/context/selector/file_selector.py`: Use counts directly, remove redundant message iteration and unused `URI` import
- `gptme/hooks/active_context.py`: Updated to use `.keys()` on dict result
- `tests/test_context.py`: Updated test to verify counts are returned

## Test plan
- [x] All 13 context tests pass
- [x] All 28 file selector + context selector tests pass
- [x] All 9 active context hook tests pass
- [x] mypy clean on all modified files
- [x] ruff format + pre-commit pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `get_mentioned_files` to return mention counts, optimizing file selection logic and updating related tests.
> 
>   - **Behavior**:
>     - `get_mentioned_files` in `context.py` now returns `dict[Path, int]` instead of `list[Path]`, ordered by mention count and recency.
>     - Removes duplicate message iteration in `file_selector.py` by using mention counts directly.
>     - Simplifies path resolution logic in `file_selector.py`.
>   - **Code Changes**:
>     - `file_selector.py`: Uses mention counts directly, removes redundant iteration and unused `URI` import.
>     - `active_context.py`: Updated to use `.keys()` on dict result from `get_mentioned_files`.
>     - `tests/test_context.py`: Updated tests to verify mention counts are returned.
>   - **Misc**:
>     - Removes ~10 lines of redundant path resolution logic from the file selection hot path.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 4a2bcc4b6aa8e3c9e08743690ced7ed3e828dcaa. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->