### PR TITLE
fix: use quad backticks for tool output codeblocks

### DIFF
--- a/gptme/acp/agent.py
+++ b/gptme/acp/agent.py
@@ -23,6 +23,7 @@ from ..prompts import get_prompt
 from ..session import SessionRegistry
 from ..tools import get_tools, set_tools
 from ..util.auto_naming import generate_conversation_id
+from ..util.context import md_codeblock
 from .adapter import acp_content_to_gptme_message, gptme_message_to_acp_content
 from .types import (
     PermissionKind,
@@ -925,7 +926,7 @@ class GptmeAgent:
             # (e.g. /help, /tools output rendered as Markdown in ACP panels)
             text = stdout_output.rstrip()
             if "\n" in text:
-                text = f"```\n{text}\n```"
+                text = md_codeblock("", text)
             output_parts.append(text)
         output_parts.extend(
             resp_msg.content for resp_msg in response_msgs if resp_msg.content

--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -39,6 +39,7 @@ from ..telemetry import init_telemetry, shutdown_telemetry
 from ..tools import ToolFormat, get_available_tools, init_tools
 from ..util import epoch_to_age
 from ..util.auto_naming import generate_conversation_id
+from ..util.context import md_codeblock
 from ..util.interrupt import handle_keyboard_interrupt, set_interruptible
 from ..util.prompt import add_history
 
@@ -466,7 +467,7 @@ def main(
         # if piped input, append it to first prompt, or create a new prompt if none exists
         if not piped_input:
             return prompt_msgs
-        stdin_msg = Message("user", f"```stdin\n{piped_input}\n```")
+        stdin_msg = Message("user", md_codeblock("stdin", piped_input))
         if not prompt_msgs:
             prompt_msgs.append(stdin_msg)
         else:

--- a/gptme/tools/autocompact.py
+++ b/gptme/tools/autocompact.py
@@ -19,6 +19,7 @@ from ..hooks import HookType, StopPropagation, trigger_hook
 from ..llm.models import get_default_model, get_model
 from ..logmanager import Log, prepare_messages
 from ..message import Message, len_tokens
+from ..util.context import md_codeblock
 from ..util.master_context import (
     MessageByteRange,
     build_master_context_index,
@@ -1040,7 +1041,7 @@ Format the response as a structured document that could serve as a RESUME.md fil
     for file_path, file_content in loaded_files:
         file_msg = Message(
             "system",
-            f"Context file `{file_path}`:\n```\n{file_content}\n```",
+            f"Context file `{file_path}`:\n{md_codeblock('', file_content)}",
         )
         file_context_msgs.append(file_msg)
 

--- a/gptme/tools/precommit.py
+++ b/gptme/tools/precommit.py
@@ -248,7 +248,7 @@ def run_precommit_on_file(
             output = result.stdout or result.stderr
             yield Message(
                 "system",
-                f"Pre-commit checks failed for {path.name}:\n```\n{output}\n```",
+                f"Pre-commit checks failed for {path.name}:\n{md_codeblock('', output)}",
             )
         else:
             # Pre-commit checks passed

--- a/gptme/tools/python.py
+++ b/gptme/tools/python.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, TypeVar
 from ..constants import DECLINED_CONTENT
 from ..hooks import ConfirmAction, get_confirmation
 from ..message import Message
+from ..util.context import md_codeblock
 from . import get_tools
 from .base import (
     Parameter,
@@ -225,13 +226,13 @@ def execute_python(
         return
 
     if result.result is not None:
-        output += f"Result:\n```\n{result.result}\n```\n\n"
+        output += f"Result:\n{md_codeblock('', str(result.result))}\n\n"
 
     # only show stdout if there is no result
     elif captured_stdout:
-        output += f"```stdout\n{captured_stdout.rstrip()}\n```\n\n"
+        output += md_codeblock("stdout", captured_stdout.rstrip()) + "\n\n"
     if captured_stderr:
-        output += f"```stderr\n{captured_stderr.rstrip()}\n```\n\n"
+        output += md_codeblock("stderr", captured_stderr.rstrip()) + "\n\n"
     if result.error_in_exec:
         tb = result.error_in_exec.__traceback__
         while tb and tb.tb_next:

--- a/gptme/tools/read.py
+++ b/gptme/tools/read.py
@@ -9,6 +9,7 @@ from collections.abc import Generator
 from pathlib import Path
 
 from ..message import Message
+from ..util.context import md_codeblock
 from .base import (
     Parameter,
     ToolSpec,
@@ -128,7 +129,7 @@ def execute_read(
         shown = f"{start_idx + 1}-{end_idx}"
         range_info = f" (lines {shown} of {total_lines})"
 
-    yield Message("system", f"```{path}{range_info}\n{numbered}\n```")
+    yield Message("system", md_codeblock(f"{path}{range_info}", numbered))
 
 
 tool = ToolSpec(

--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -39,6 +39,7 @@ import bashlex
 from ..message import Message
 from ..util import get_installed_programs
 from ..util.ask_execute import execute_with_confirmation
+from ..util.context import md_codeblock
 from ..util.output_storage import save_large_output
 from ..util.tokens import get_tokenizer
 from .base import (
@@ -1650,15 +1651,15 @@ def execute_output_command(job_id_str: str) -> Generator[Message, None, None]:
         # Truncate if too long
         if len(stdout) > 8000:
             stdout = stdout[-8000:]
-            msg += "```stdout\n...(truncated)...\n" + stdout + "\n```\n\n"
+            msg += md_codeblock("stdout", "...(truncated)...\n" + stdout) + "\n\n"
         else:
-            msg += f"```stdout\n{stdout}\n```\n\n"
+            msg += md_codeblock("stdout", stdout) + "\n\n"
     if stderr:
         if len(stderr) > 2000:
             stderr = stderr[-2000:]
-            msg += "```stderr\n...(truncated)...\n" + stderr + "\n```\n\n"
+            msg += md_codeblock("stderr", "...(truncated)...\n" + stderr) + "\n\n"
         else:
-            msg += f"```stderr\n{stderr}\n```\n\n"
+            msg += md_codeblock("stderr", stderr) + "\n\n"
     if not stdout and not stderr:
         msg += "No output yet.\n"
 
@@ -1858,10 +1859,10 @@ def check_with_shellcheck(cmd: str) -> tuple[bool, bool, str]:
             if blocking_codes:
                 # Critical issues that should block execution
                 codes_str = ", ".join(sorted(blocking_codes))
-                message = f"Shellcheck found critical issues that prevent execution:\n```\n{output}```\n\nBlocking codes: {codes_str}"
+                message = f"Shellcheck found critical issues that prevent execution:\n{md_codeblock('', output)}\n\nBlocking codes: {codes_str}"
                 return True, True, message
             # Non-critical warnings
-            message = f"Shellcheck found potential issues:\n```\n{output}```"
+            message = f"Shellcheck found potential issues:\n{md_codeblock('', output)}"
             return True, False, message
 
         return False, False, ""
@@ -1897,9 +1898,9 @@ def _execute_preceding_commands(
         # Only report output if there is any
         output_parts = []
         if stdout and stdout.strip():
-            output_parts.append(f"```stdout\n{stdout.strip()}\n```")
+            output_parts.append(md_codeblock("stdout", stdout.strip()))
         if stderr and stderr.strip():
-            output_parts.append(f"```stderr\n{stderr.strip()}\n```")
+            output_parts.append(md_codeblock("stderr", stderr.strip()))
 
         if output_parts:
             yield Message(

--- a/gptme/tools/tmux.py
+++ b/gptme/tools/tmux.py
@@ -20,6 +20,7 @@ from time import sleep
 from ..constants import DECLINED_CONTENT
 from ..hooks import ConfirmAction, get_confirmation
 from ..message import Message
+from ..util.context import md_codeblock
 from ..util.output_storage import save_large_output
 from .base import (
     Parameter,
@@ -208,9 +209,10 @@ def new_session(command: str) -> Message:
         output,
         context=f"new-session {command[:50]}",
     )
+    stripped_command = command.strip("'")
     return Message(
         "system",
-        f"""Running `{command.strip("'")}` in session {session_id}.\n```output\n{truncated_output}\n```""",
+        f"Running `{stripped_command}` in session {session_id}.\n{md_codeblock('output', truncated_output)}",
     )
 
 
@@ -243,7 +245,7 @@ def send_keys(pane_id: str, keys: str) -> Message:
     )
     return Message(
         "system",
-        f"Sent '{keys}' to pane `{pane_id}`\n```output\n{truncated_output}\n```",
+        f"Sent '{keys}' to pane `{pane_id}`\n{md_codeblock('output', truncated_output)}",
     )
 
 
@@ -345,7 +347,7 @@ def wait_for_output(
                 "system",
                 f"Session `{session_id}` output stabilized after {elapsed:.1f}s "
                 f"(stable for {stable_duration:.1f}s).\n"
-                f"```output\n{truncated_output}\n```",
+                f"{md_codeblock('output', truncated_output)}",
             )
 
         # Check timeout
@@ -360,7 +362,7 @@ def wait_for_output(
                 "system",
                 f"Session `{session_id}` timed out after {timeout}s "
                 f"(output still changing).\n"
-                f"```output\n{truncated_output}\n```\n"
+                f"{md_codeblock('output', truncated_output)}\n"
                 f"Session still active. Use `kill-session {session_id}` to terminate "
                 f"or `send-keys {session_id} C-c` to interrupt.",
             )


### PR DESCRIPTION
Shell output, Python results, tmux output, file content, and other tool outputs can contain markdown codeblocks. Using triple backticks to wrap this content creates nested codeblock conflicts that are difficult to parse/understand.

This change updates all tool output formatting to use md_codeblock() which uses quad backticks, avoiding parsing conflicts when the content contains triple backticks.

**Affected tools:**
- shell: stdout/stderr, background job output, shellcheck output
- python: result, stdout, stderr  
- tmux: session output, wait output
- precommit: check output
- read: file content
- autocompact: context file content
- acp/agent: command stdout
- cli/main: piped stdin input
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates tool output formatting to use quad backticks via `md_codeblock()` to prevent nested codeblock conflicts across various tools.
> 
>   - **Behavior**:
>     - Updates tool output formatting to use `md_codeblock()` with quad backticks to avoid nested codeblock conflicts.
>     - Affects shell, python, tmux, precommit, read, autocompact, acp/agent, and cli/main tools.
>   - **Functions**:
>     - Replaces triple backticks with `md_codeblock()` in `execute_shell_impl()` in `shell.py`.
>     - Updates `execute_python()` in `python.py` to use `md_codeblock()` for result, stdout, and stderr.
>     - Modifies `run_precommit_on_file()` in `precommit.py` to use `md_codeblock()` for output.
>     - Changes `execute_read()` in `read.py` to use `md_codeblock()` for file content.
>     - Adjusts `_resume_via_llm()` in `autocompact.py` to use `md_codeblock()` for context file content.
>     - Updates `_handle_slash_command()` in `acp/agent.py` to use `md_codeblock()` for stdout output.
>     - Modifies `inject_stdin()` in `cli/main.py` to use `md_codeblock()` for piped input.
>     - Updates `wait_for_output()` in `tmux.py` to use `md_codeblock()` for session output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 70e07a989cc10b220cf408293d30645ff17b503a. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->