### PR TITLE
test(shell): add tests for allowlist auto-confirm behavior

### DIFF
--- a/tests/test_shell_allowlist_autoconfirm.py
+++ b/tests/test_shell_allowlist_autoconfirm.py
@@ -45,23 +45,28 @@ ALLOWLIST_TEST_CASES = [
     ("rm -rf /tmp/foo", False, "rm command"),
     ("python script.py", False, "python command"),
     ("npm install", False, "npm command"),
-    # Dangerous patterns with allowlisted commands - should NOT be allowlisted
-    ("find . -name '*.py' -exec rm {} \\;", False, "find -exec rm"),
-    ("find . -type f -exec cat {} \\;", False, "find -exec cat"),
+    # Pipes to non-allowlisted commands - blocked by allowlist (not in allowlist)
+    ("cat file | xargs rm", False, "pipe to xargs (not in allowlist)"),
+    ("grep pattern file | xargs python", False, "pipe to xargs"),
+    ("cat file | sh", False, "pipe to sh (not in allowlist)"),
+    ("head file | bash", False, "pipe to bash (not in allowlist)"),
+    ("ls | python -c 'import sys'", False, "pipe to python"),
+    ("cat data.csv | perl -lane", False, "pipe to perl"),
+    # Dangerous flags within allowlisted commands - blocked by flag check
+    ("find . -name '*.py' -exec rm {} \\;", False, "find -exec rm (dangerous flag)"),
+    ("find . -type f -exec cat {} \\;", False, "find -exec cat (dangerous flag)"),
     (
         "find / -name passwd -exec cat {} \\;",
         False,
         "find -exec to read sensitive files",
     ),
-    ("find . -name '*.log' -execdir rm {} \\;", False, "find -execdir"),
-    ("find /tmp -type f -delete", False, "find -delete"),
-    ("find . -name '*.txt' -ok cat {} \\;", False, "find -ok"),
-    ("cat file | xargs rm", False, "pipe to xargs rm"),
-    ("grep pattern file | xargs python", False, "pipe to xargs python"),
-    ("cat file | sh", False, "pipe to sh"),
-    ("head file | bash", False, "pipe to bash"),
-    ("ls | zsh", False, "pipe to zsh"),
-    ("cat script.sh | fish", False, "pipe to fish"),
+    (
+        "find . -name '*.log' -execdir rm {} \\;",
+        False,
+        "find -execdir (dangerous flag)",
+    ),
+    ("find /tmp -type f -delete", False, "find -delete (dangerous flag)"),
+    ("find . -name '*.txt' -ok cat {} \\;", False, "find -ok (dangerous flag)"),
 ]
 
 


### PR DESCRIPTION
## Summary

Add comprehensive tests verifying that allowlisted shell commands (like `cat file | head -100`) skip confirmation entirely.

## Problem

User reported being asked to confirm a read-only command (`cat gptme/cli/commands.py | head -100`) which should be auto-approved by default since both `cat` and `head` are in the allowlist.

## Investigation

Testing confirmed the allowlist logic is working correctly:
- `is_allowlisted('cat gptme/cli/commands.py | head -100')` returns `True`
- The `execute_shell` function skips `execute_with_confirmation` for allowlisted commands
- The `shell_allowlist_hook` correctly returns `ConfirmationResult.confirm()`

## Changes

1. **New test file** (`tests/test_shell_allowlist_autoconfirm.py`):
   - 13 tests for `is_allowlisted()` function covering various command patterns
   - 5 tests for `shell_allowlist_hook` function
   - 2 end-to-end tests for `execute_shell` verifying confirmation is skipped

2. **Debug logging** (in `gptme/tools/shell.py`):
   - Added logging when commands are allowlisted and skipping confirmation
   - Added logging when commands are not allowlisted and require confirmation

## Test Results

All 20 tests pass, confirming the allowlist behavior is working as expected.

## Notes

The investigation suggests the original issue may have been:
- An older version that didn't have this working
- A misunderstanding about what was happening
- Some edge case not captured by the tests

The added logging will help diagnose any future issues with the confirmation behavior.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add tests for allowlisted shell commands to skip confirmation and enhance logging in `gptme/tools/shell.py`.
> 
>   - **Tests**:
>     - Add `tests/test_shell_allowlist_autoconfirm.py` with 13 tests for `is_allowlisted()`, 5 for `shell_allowlist_hook`, and 2 end-to-end tests for `execute_shell`.
>   - **Logging**:
>     - Add debug logging in `gptme/tools/shell.py` to log when commands are allowlisted and skip confirmation, and when they are not and require confirmation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for b364c42a0e03230a4f3e48dba09354c825cf75f6. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->