### PR TITLE
style: use yellow-on-red prompt style for URL confirmation

### DIFF
--- a/gptme/commands/session.py
+++ b/gptme/commands/session.py
@@ -197,9 +197,12 @@ def cmd_restart(ctx: CommandContext) -> None:
     - Recovering from state issues
     """
     from ..tools.restart import _do_restart
+    from ..util.prompt import prompt_alert
 
-    response = input("Restart gptme? This will exit and restart the process. [y/N] ")
-    confirmed = response.lower().strip() in ("y", "yes")
+    response = prompt_alert(
+        "Restart gptme? This will exit and restart the process. [y/N]"
+    )
+    confirmed = response in ("y", "yes")
     if not confirmed:
         print("Restart cancelled.")
         return
@@ -253,8 +256,10 @@ def _rename(manager: "LogManager", new_name: str) -> None:
             raise ValueError(f"Generated name contains spaces: '{new_name}'")
         print(f"Generated name: {new_name}")
         if sys.stdin.isatty():
-            response = input("Confirm? [y/N] ")
-            confirmed = response.lower().strip() in ("y", "yes")
+            from ..util.prompt import prompt_alert
+
+            response = prompt_alert("Confirm? [y/N]")
+            confirmed = response in ("y", "yes")
         else:
             # Non-interactive mode - auto-approve
             confirmed = True

--- a/gptme/hooks/cli_confirm.py
+++ b/gptme/hooks/cli_confirm.py
@@ -27,7 +27,7 @@ from rich.console import Console
 
 from ..util.ask_execute import print_confirmation_help, print_preview
 from ..util.clipboard import copy
-from ..util.prompt import get_prompt_session
+from ..util.prompt import prompt_alert
 from ..util.sound import print_bell
 from ..util.terminal import terminal_state_title
 from ..util.useredit import edit_text_with_editor
@@ -117,20 +117,8 @@ def cli_confirm_hook(
     question = f"Execute {tool_use.tool}?"
 
     with terminal_state_title("❓ waiting for confirmation"):
-        session = get_prompt_session()
         prompt = f"{question} {choicestr}"
-
-        style_prompt_toolkit = "bold fg:ansiyellow bg:ansired"
-        answer = (
-            session.prompt(
-                [
-                    (style_prompt_toolkit, " " + prompt + " "),
-                    ("", " "),
-                ]
-            )
-            .lower()
-            .strip()
-        )
+        answer = prompt_alert(prompt)
 
     # Handle the response
     return _handle_response(answer, content, editable, copiable, tool_use)

--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -55,6 +55,8 @@ def _confirm_urls(urls: list[str]) -> list[str]:
     """
     from rich import print as rprint
 
+    from .prompt import prompt_alert
+
     if not urls:
         return []
 
@@ -66,7 +68,7 @@ def _confirm_urls(urls: list[str]) -> list[str]:
             rprint(f"  {i}. {url}")
 
     try:
-        response = input("Read URL(s)? [Y/n/select numbers] ").strip().lower()
+        response = prompt_alert("Read URL(s)? [Y/n/select numbers]")
     except (EOFError, KeyboardInterrupt):
         return []
 

--- a/gptme/util/prompt.py
+++ b/gptme/util/prompt.py
@@ -419,6 +419,34 @@ Only 10 lines.""",
 
 _prompt_session: PromptSession | None = None
 
+# Alert style for confirmation prompts (yellow text on red background)
+STYLE_ALERT = "bold fg:ansiyellow bg:ansired"
+
+
+def prompt_alert(prompt: str) -> str:
+    """Display an alert-style prompt with yellow text on red background.
+
+    Used for confirmation prompts that need to catch the user's attention,
+    like tool execution confirmation and URL reading confirmation.
+
+    Args:
+        prompt: The prompt text to display
+
+    Returns:
+        The user's response, lowercased and stripped
+    """
+    session = get_prompt_session()
+    return (
+        session.prompt(
+            [
+                (STYLE_ALERT, " " + prompt + " "),
+                ("", " "),
+            ]
+        )
+        .lower()
+        .strip()
+    )
+
 
 def get_prompt_session() -> PromptSession:
     """Create a PromptSession with history and completion support."""


### PR DESCRIPTION
Uses the same prompt_toolkit styling as ask_confirm (bold yellow on red background) for the URL confirmation prompt, providing consistent alert styling throughout the CLI.

Before: plain `input()` for URL confirmation  
After: styled prompt matching the tool execution confirmation

Closes no issues, just a small UX improvement.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Changes URL confirmation prompt in `_confirm_urls()` in `context.py` to use `prompt_toolkit` styling for consistent CLI alert styling.
> 
>   - **Behavior**:
>     - Changes URL confirmation prompt in `_confirm_urls()` in `context.py` to use `prompt_toolkit` styling (bold yellow on red background).
>     - Replaces `input()` with `session.prompt()` for consistent CLI alert styling.
>   - **Imports**:
>     - Adds `get_prompt_session` import in `context.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 48975a4f55e68e0e09706151713f2665771a9b2d. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->