### PR TITLE
ci(benchmark): use hyperfine for stable startup measurements

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,16 +31,18 @@ jobs:
 
     - name: Install hyperfine
       run: |
-        wget -q https://github.com/sharkdp/hyperfine/releases/download/v1.18.0/hyperfine_1.18.0_amd64.deb
-        sudo dpkg -i hyperfine_1.18.0_amd64.deb
+        sudo apt-get install -y hyperfine
 
     - name: Benchmark cold startup
       id: cold
       run: |
-        # Cold startup: --prepare clears .pyc before each run
+        # Get virtualenv path so we can clear .pyc files in dependencies too
+        VENV_PATH=$(poetry env info --path)
+
+        # Cold startup: --prepare clears .pyc in repo AND virtualenv, drops OS page cache
         hyperfine \
           --runs 5 \
-          --prepare 'find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; find . -type f -name "*.pyc" -delete 2>/dev/null; true' \
+          --prepare "find . '$VENV_PATH' -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; sudo sh -c 'sync && echo 3 > /proc/sys/vm/drop_caches' 2>/dev/null; true" \
           --export-json cold.json \
           'poetry run python -c "from gptme.cli.main import main"'
 


### PR DESCRIPTION
## Summary
- Replaces single-run timing with hyperfine for statistical stability
- Cold startup: 5 runs with `--prepare` to clear .pyc before each
- Warm startup: 10 runs with 3 warmup iterations
- Uses median instead of single measurement to reduce CI flakiness
- Reports stddev for visibility into measurement variance

Closes #1527

## Test plan
- [ ] CI benchmark workflow passes with hyperfine
- [ ] Verify median values are within expected thresholds
- [ ] Check that stddev is reasonable (should be much lower than single-measurement variance)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces single-run timing with hyperfine in CI for stable startup measurements, using median and stddev for cold and warm startups.
> 
>   - **Benchmarking**:
>     - Replaces single-run timing with `hyperfine` in `benchmark.yml` for stable measurements.
>     - Cold startup: 5 runs with `--prepare` to clear `.pyc` files before each.
>     - Warm startup: 10 runs with 3 warmup iterations.
>     - Uses median instead of single measurement to reduce CI flakiness.
>     - Reports standard deviation for measurement variance visibility.
>   - **Installation**:
>     - Installs `hyperfine` in `benchmark.yml` for benchmarking.
>   - **Output**:
>     - Outputs median and standard deviation for cold and warm startups.
>     - Checks if startup times exceed thresholds and reports errors if they do.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 12c20637843c85b180e30b7bd840d6da4ba1a2e7. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->