### PR TITLE
fix(hooks): resolve prompt file paths relative to agent's CWD

### DIFF
--- a/gptme/hooks/workspace_agents.py
+++ b/gptme/hooks/workspace_agents.py
@@ -445,12 +445,15 @@ def _parse_gptme(pid: int, cmdline: list[str], cwd: str) -> AgentInfo:
     prompt_summary = ""
     if is_non_interactive:
         for arg in cmdline:
-            if arg.endswith(".txt") and os.path.isfile(arg):
-                try:
-                    with open(arg) as f:
-                        prompt_summary = f.readline().strip()[:120]
-                except OSError:
-                    pass
+            if arg.endswith(".txt"):
+                # Resolve relative to the agent's CWD, not ours
+                file_path = os.path.join(cwd, arg) if not os.path.isabs(arg) else arg
+                if os.path.isfile(file_path):
+                    try:
+                        with open(file_path) as f:
+                            prompt_summary = f.readline().strip()[:120]
+                    except OSError:
+                        pass
                 break
 
     return AgentInfo(


### PR DESCRIPTION
## Summary

- Fix `_parse_gptme()` resolving `.txt` prompt file paths against the detecting process's CWD instead of the detected agent's CWD
- Relative paths are now joined with the agent's `cwd` parameter; absolute paths used as-is
- Add 3 tests for prompt file resolution (relative, absolute, missing)

## Context

When agent A detects agent B running `gptme -n prompt.txt` in `/home/user/project/`, the file check `os.path.isfile("prompt.txt")` resolved against agent A's CWD (e.g., `/home/user/gptme/`), not B's CWD. This caused prompt summaries to always be empty for agents in different directories.

## Test plan

- [x] 79 tests pass (3 new: relative path, absolute path, missing file fallback)
- [x] mypy clean
- [x] Pre-commit passes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `_parse_gptme()` to resolve prompt file paths relative to the agent's CWD, with tests for relative, absolute, and missing paths.
> 
>   - **Behavior**:
>     - Fix `_parse_gptme()` in `workspace_agents.py` to resolve `.txt` prompt file paths relative to the agent's CWD instead of the detecting process's CWD.
>     - Relative paths are joined with the agent's `cwd` parameter; absolute paths remain unchanged.
>   - **Tests**:
>     - Add tests in `test_workspace_agents.py` for prompt file resolution: relative path, absolute path, and missing file fallback.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for bf2a87a68c2546e9354696bfb4ff6a6473ff9fb0. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->