### PR TITLE
fix(test): configure pytest-asyncio and add as explicit dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -407,6 +407,19 @@ files = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+description = "Backport of asyncio.Runner, a context manager that controls event loop life cycle."
+optional = false
+python-versions = "<3.11,>=3.8"
+groups = ["dev"]
+markers = "python_version == \"3.10\""
+files = [
+    {file = "backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5"},
+    {file = "backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162"},
+]
+
+[[package]]
 name = "bashlex"
 version = "0.18"
 description = "Python parser for bash"
@@ -5453,6 +5466,27 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5"},
+    {file = "pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5"},
+]
+
+[package.dependencies]
+backports-asyncio-runner = {version = ">=1.1,<2", markers = "python_version < \"3.11\""}
+pytest = ">=8.2,<10"
+typing-extensions = {version = ">=4.12", markers = "python_version < \"3.13\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
+
+[[package]]
 name = "pytest-cov"
 version = "6.0.0"
 description = "Pytest plugin for measuring coverage."
@@ -8375,4 +8409,4 @@ youtube = ["youtube_transcript_api"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "27722abe1b338bbd7a08ddf059b90daaaa108dbfe376e851ee442a11dc7121f1"
+content-hash = "a41bcf4902f61a739ad0d50d71c4843782974da9fd20f0959c621e77f852901b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ openapi-spec-validator = "^0.7.2"
 
 # test
 pytest = "^8.0"
+pytest-asyncio = "*"
 pytest-cov = "*"
 pytest-xdist = "^3.5.0"
 pytest-profiling = "^1.7.0"


### PR DESCRIPTION
## Summary
- Configure `asyncio_mode = "auto"` and `asyncio_default_fixture_loop_scope = "function"` in pytest config to suppress the `PytestDeprecationWarning` about unset fixture loop scope
- Add `pytest-asyncio` as an explicit dev dependency (was previously installed transitively)

## Context
Every test run was producing this warning:
```
PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
```

The `asyncio_mode = "auto"` setting also means async test functions are automatically collected without needing `@pytest.mark.asyncio` decorators.

## Test plan
- [x] Verified warning is gone: `pytest tests/test_hooks.py::test_async_hook -W error::DeprecationWarning` passes
- [ ] CI passes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Configure pytest for asyncio and add `pytest-asyncio` as a dev dependency to suppress deprecation warnings.
> 
>   - **Configuration**:
>     - Set `asyncio_mode = "auto"` and `asyncio_default_fixture_loop_scope = "function"` in `pyproject.toml` to suppress `PytestDeprecationWarning`.
>     - `asyncio_mode = "auto"` allows automatic collection of async test functions without `@pytest.mark.asyncio`.
>   - **Dependencies**:
>     - Add `pytest-asyncio` as an explicit dev dependency in `pyproject.toml`.
>   - **Testing**:
>     - Verified warning is gone by running `pytest tests/test_hooks.py::test_async_hook -W error::DeprecationWarning`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 09c4d1ef337343f533d730d2820d773ab7eda91e. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->