### PR TITLE
fix(deps): bump pypdf minimum to >=6.7.3 for security fixes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5421,14 +5421,14 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pypdf"
-version = "6.7.1"
+version = "6.7.3"
 description = "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pypdf-6.7.1-py3-none-any.whl", hash = "sha256:a02ccbb06463f7c334ce1612e91b3e68a8e827f3cee100b9941771e6066b094e"},
-    {file = "pypdf-6.7.1.tar.gz", hash = "sha256:6b7a63be5563a0a35d54c6d6b550d75c00b8ccf36384be96365355e296e6b3b0"},
+    {file = "pypdf-6.7.3-py3-none-any.whl", hash = "sha256:cd25ac508f20b554a9fafd825186e3ba29591a69b78c156783c5d8a2d63a1c0a"},
+    {file = "pypdf-6.7.3.tar.gz", hash = "sha256:eca55c78d0ec7baa06f9288e2be5c4e8242d5cbb62c7a4b94f2716f8e50076d2"},
 ]
 
 [package.dependencies]
@@ -8409,4 +8409,4 @@ youtube = ["youtube_transcript_api"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "a41bcf4902f61a739ad0d50d71c4843782974da9fd20f0959c621e77f852901b"
+content-hash = "d704f090be12acd79514f9ebea5224deb49be2742ad783bfff50bbb8bfed8858"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ tomlkit = "*"
 typing-extensions = "*"
 platformdirs = "^4.3"
 lxml = "*"
-pypdf = ">=5.1.0"  # For PDF text extraction in browser tool
+pypdf = ">=6.7.3"  # For PDF text extraction in browser tool (CVE fix: RAM exhaustion + infinite loop)
 requests = "^2.32"  # For HTTP requests in browser tool (PDF detection)
 json-repair = "^0.32.0"
 mcp = "^1.13.0"


### PR DESCRIPTION
## Summary
- Bumps pypdf minimum version from `>=5.1.0` to `>=6.7.3`
- Fixes Dependabot alert #90 (medium): FlateDecode XFA streams can exhaust RAM
- Fixes Dependabot alert #88 (low): infinite loop with circular /Prev entries in cross-reference table

## Test plan
- [ ] CI passes (no functional changes, just version constraint bump)
- [ ] Verify Dependabot alerts auto-close after merge
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `pypdf` minimum version to `>=6.7.3` in `pyproject.toml` to fix security vulnerabilities.
> 
>   - **Dependencies**:
>     - Bump `pypdf` minimum version from `>=5.1.0` to `>=6.7.3` in `pyproject.toml`.
>     - Addresses security issues: RAM exhaustion in FlateDecode XFA streams and infinite loop with circular /Prev entries in cross-reference table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for bbe59ff011b4fc06616bfa31076bdeca688b178d. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->