### PR TITLE
fix(release): skip branch push for pre-releases

### DIFF
--- a/scripts/publish_release.sh
+++ b/scripts/publish_release.sh
@@ -71,10 +71,24 @@ echo "Publishing release: ${TAG} (pre-release=${PRERELEASE})"
 
 echo "Pushing ${TAG} to origin..."
 if [ "$DRY_RUN" = "false" ]; then
-    git push origin HEAD:master
+    if [ "$PRERELEASE" = "false" ]; then
+        # Stable releases: push version bump commit to master.
+        # Requires the user/bot to have branch protection bypass rights.
+        git push origin HEAD:master
+    else
+        # Pre-releases: skip the branch push entirely.
+        # The tag push (below) will carry the version-bump commit to GitHub
+        # as an unreachable-from-branch object — that's fine for dev builds.
+        # This avoids hitting branch protection rules in CI.
+        echo "  Skipping branch push for pre-release (branch protection safe)."
+    fi
     git push origin "${TAG}"
 else
-    echo "  [dry-run] git push origin HEAD:master"
+    if [ "$PRERELEASE" = "false" ]; then
+        echo "  [dry-run] git push origin HEAD:master"
+    else
+        echo "  [dry-run] Skipping branch push for pre-release"
+    fi
     echo "  [dry-run] git push origin ${TAG}"
 fi
 


### PR DESCRIPTION
## Summary
- Pre-release (dev) builds no longer push the version bump commit to `master`, avoiding branch protection rule violations
- The tag push still carries the commit to GitHub as an unreachable-from-branch object, sufficient for GH release + PyPI publish
- Stable releases continue pushing to master (maintainer has bypass permissions)

Fixes the `workflow_dispatch` failure reported in #1532:
```
remote: error: GH013: Repository rule violations found for refs/heads/master.
remote: - Changes must be made through a pull request.
```

## Test plan
- [ ] Re-run `workflow_dispatch` with `release_type: dev` after merge
- [ ] Verify the dev release tag is created and PyPI package is published
- [ ] Verify `make release` (stable) still works with maintainer bypass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Pre-release builds skip pushing version bump commit to `master` in `publish_release.sh`, avoiding branch protection rule violations while still allowing tag push for GitHub release and PyPI publish.
> 
>   - **Behavior**:
>     - Pre-release builds skip pushing version bump commit to `master` in `publish_release.sh`, avoiding branch protection rule violations.
>     - Tag push still occurs for pre-releases, allowing GitHub release and PyPI publish.
>     - Stable releases continue pushing to `master` as before.
>   - **Testing**:
>     - Re-run `workflow_dispatch` with `release_type: dev` to verify dev release tag creation and PyPI package publication.
>     - Verify `make release` for stable releases works with maintainer bypass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 9a92c80efd2e82a563cff72937fde1cf310b34e9. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->