### PR TITLE
feat(prompts): distinguish agent instruction files from context files

### DIFF
--- a/gptme/prompts.py
+++ b/gptme/prompts.py
@@ -596,7 +596,8 @@ def prompt_workspace(
     #   1. User config dir (~/.config/gptme/AGENTS.md) - global defaults
     #   2. Walk from home dir down to workspace, loading any AGENTS.md found
     #      e.g., ~/Programming/AGENTS.md → ~/Programming/gptme/AGENTS.md → workspace
-    files: list[Path] = []
+    agent_files: list[Path] = []  # Agent instruction files (AGENTS.md, etc.)
+    context_files: list[Path] = []  # Regular context files (README, etc.)
     seen_paths: set[str] = set()
     workspace_resolved = workspace.resolve()
     config_dir = Path(config_path).expanduser().resolve().parent
@@ -615,7 +616,7 @@ def prompt_workspace(
         if user_file.exists():
             resolved = str(user_file.resolve())
             if resolved not in seen_paths:
-                files.append(user_file)
+                agent_files.append(user_file)
                 seen_paths.add(resolved)
                 loaded_agent_files.add(resolved)
                 logger.debug(f"Loaded user-level agent file: {user_file}")
@@ -624,7 +625,7 @@ def prompt_workspace(
     #    Uses find_agent_files_in_tree() — shared with the agents_md_inject hook
     for agent_file in find_agent_files_in_tree(workspace_resolved, exclude=seen_paths):
         resolved = str(agent_file.resolve())
-        files.append(agent_file)
+        agent_files.append(agent_file)
         seen_paths.add(resolved)
         loaded_agent_files.add(resolved)
         logger.debug(f"Loaded agent file from tree: {agent_file}")
@@ -658,9 +659,9 @@ def prompt_workspace(
                 try:
                     f.resolve().relative_to(workspace_resolved)
                     resolved = str(f.resolve())
-                    # Skip if already loaded (e.g., from ALWAYS_LOAD_FILES)
+                    # Skip if already loaded (e.g., from agent files)
                     if resolved not in seen_paths:
-                        files.append(f)
+                        context_files.append(f)
                         seen_paths.add(resolved)
                 except ValueError:
                     logger.warning(
@@ -699,7 +700,7 @@ def prompt_workspace(
             if p.exists():
                 rp = str(p)
                 if rp not in seen_paths:
-                    files.append(p)
+                    context_files.append(p)
                     seen_paths.add(rp)
             else:
                 logger.debug(f"User-configured file not found: {p}")
@@ -711,14 +712,27 @@ def prompt_workspace(
     if sections:
         yield Message("system", f"# {title}\n\n" + "\n\n".join(sections))
 
-    # Yield files as a separate message (more stable than computed context)
-    valid_files: list[FilePath] = [file for file in files if file.exists()]
-    if valid_files:
-        file_list = "\n".join(f"- {file}" for file in valid_files)
+    # Yield agent instruction files first with explicit framing
+    valid_agent_files: list[FilePath] = [f for f in agent_files if f.exists()]
+    if valid_agent_files:
+        agent_file_list = "\n".join(f"- {file}" for file in valid_agent_files)
         yield Message(
             "system",
-            f"## Selected files\n\nRead more with `cat`.\n\n{file_list}",
-            files=valid_files,
+            "## Agent Instructions\n\n"
+            "The following files contain user-defined rules, preferences, and workflows. "
+            "**You MUST follow these instructions** - they take precedence over default behaviors.\n\n"
+            f"{agent_file_list}",
+            files=valid_agent_files,
+        )
+
+    # Yield context files separately (informational, not directives)
+    valid_context_files: list[FilePath] = [f for f in context_files if f.exists()]
+    if valid_context_files:
+        context_file_list = "\n".join(f"- {file}" for file in valid_context_files)
+        yield Message(
+            "system",
+            f"## Selected files\n\nRead more with `cat`.\n\n{context_file_list}",
+            files=valid_context_files,
         )
 
     # Computed context last (changes most often, least cacheable)


### PR DESCRIPTION
## Summary

Separates AGENTS.md/CLAUDE.md/GEMINI.md files from regular context files and adds explicit framing that these contain user-defined rules that MUST be followed.

## Changes

- Agent instruction files now appear under **"## Agent Instructions"** with clear directive:
  > "The following files contain user-defined rules, preferences, and workflows. **You MUST follow these instructions** - they take precedence over default behaviors."
- Regular context files (README, pyproject.toml, etc.) remain under "## Selected files" as before

## Motivation

The current prompt bundles agent instruction files with regular context files under a generic "Selected files" header. This caused issues where the LLM ignored explicit rules in AGENTS.md (like CI workflow, PR review requirements) because they appeared as optional context rather than directives.

This change makes it explicit that AGENTS.md files are rules to follow, not just informational context.

Supersedes #1555 (rebased on current master).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `prompt_workspace` in `gptme/prompts.py` now distinguishes agent instruction files from context files, ensuring agent instructions are treated as directives.
> 
>   - **Behavior**:
>     - `prompt_workspace` in `gptme/prompts.py` now separates agent instruction files (e.g., `AGENTS.md`) from regular context files.
>     - Agent instruction files are listed under "## Agent Instructions" with a directive to follow them as rules.
>     - Regular context files remain under "## Selected files".
>   - **Variables**:
>     - Introduces `agent_files` and `context_files` lists to distinguish between agent instructions and context files.
>   - **Logging**:
>     - Adds debug logging for loading agent files and context files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 0a27b4232b07c24a33267fd10a39078d1bbb4dea. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->