### PR TITLE
fix(chats): escape regex in search highlight and fix repr'd output

### DIFF
--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -175,7 +175,7 @@ def _format_message_with_context(
             re.escape(query),
             lambda m: f"\033[1;31m{m.group(0)}\033[0m",
             highlighted,
-            flags=re.DOTALL | re.IGNORECASE,
+            flags=re.IGNORECASE,
         )
         formatted_matches.append(highlighted)
 

--- a/tests/test_tools_chats.py
+++ b/tests/test_tools_chats.py
@@ -48,7 +48,9 @@ def test_format_message_no_repr_quotes():
 
 
 def test_format_message_case_insensitive_highlight():
-    """Test that highlighting works case-insensitively."""
+    """Test that highlighting works case-insensitively and preserves original casing."""
     result = _format_message_with_context("Hello WORLD", "world")
     # The ANSI highlight should be present
     assert "\033[1;31m" in result
+    # Original casing must be preserved inside the highlight (not lowercased)
+    assert "WORLD" in result


### PR DESCRIPTION
## Summary
- Fix `re.sub` crash when search query contains regex metacharacters (`(`, `)`, `[`, `+`, `*`, `.`)
- Remove `!r` that wrapped matched text in repr quotes (e.g. `'python'` instead of `python`)
- Add `re.IGNORECASE` for consistent case-insensitive highlighting

## Context
`_format_message_with_context` in `gptme/tools/chats.py` used raw `query` in `re.sub()` without escaping. Searching for queries like `myFunc(` or `file.txt` would crash with `re.error`. The `!r` format specifier in the replacement lambda produced ugly quoted output.

Related to #437 (stale PR from Feb 2025 with merge conflicts that addressed similar issues).

## Test plan
- [x] Added 5 unit tests covering: basic highlighting, no-match fallback, regex special chars, no repr quotes, case-insensitive highlight
- [x] All 6 tests pass (`pytest tests/test_tools_chats.py`)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix regex metacharacter crash and improve highlighting in `_format_message_with_context` in `gptme/tools/chats.py`.
> 
>   - **Behavior**:
>     - Fix crash in `_format_message_with_context` in `gptme/tools/chats.py` when search query contains regex metacharacters by using `re.escape()`.
>     - Remove `!r` from the replacement lambda to avoid wrapping matched text in repr quotes.
>     - Add `re.IGNORECASE` to `re.sub()` for case-insensitive highlighting.
>   - **Tests**:
>     - Add 5 unit tests in `tests/test_tools_chats.py` for basic highlighting, no-match fallback, regex special chars, no repr quotes, and case-insensitive highlight.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 8b845278d60d7811a01ce09ff1f51bff63b1c62b. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->