### PR TITLE
ci(bot): only run when comment mentions @gptme

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -8,6 +8,10 @@ permissions: write-all
 
 jobs:
   run-bot:
+    # Only run when the comment explicitly @-mentions the bot.
+    # Without this, CI spins up on every comment (even bot reviews, CI notifications, etc.)
+    # which wastes runner minutes for an immediate allowlist-fail exit.
+    if: contains(github.event.comment.body, '@gptme')
     runs-on: ubuntu-latest
     steps:
       # needed to run the action in the same repo

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -18,6 +18,9 @@ permissions: write-all
 
 jobs:
   run-bot:
+    # Only run when a comment explicitly @-mentions the bot.
+    # Without this filter, CI spins up on every comment to immediately fail the allowlist check.
+    if: contains(github.event.comment.body, '@gptme')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Add `if: contains(github.event.comment.body, '@gptme')` to `.github/workflows/bot.yml`
- Add same filter to the `docs/bot.md` Quick Start example

## Why

Without this filter, the bot workflow spins up a fresh runner on **every** issue/PR comment — even automated ones (Greptile reviews, CI notifications, GitHub bot messages, user discussion unrelated to the bot). The runner immediately fails the allowlist check and exits, but not before billing for a full startup.

Discovered in ErikBjare/bob where `~26 runs/day` were driven by this pattern. Fixing the filter alone is projected to save ~30-40% of total CI cost for repos with active PR/issue activity.

The fix matches how the bot is actually used: users must `@gptme <prompt>` to trigger it, so skipping runs where that pattern doesn't appear is a pure no-op.

## Context

Upstreamed from ErikBjare/bob#346 (Improve GitHub Actions cost/usage/speed).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add filter to GitHub Actions workflow to only trigger bot on comments mentioning `@gptme`, reducing unnecessary CI runs and costs.
> 
>   - **Behavior**:
>     - Add `if: contains(github.event.comment.body, '@gptme')` to `bot.yml` to only trigger on comments mentioning `@gptme`.
>     - Update `docs/bot.md` Quick Start example to include the same filter.
>   - **Rationale**:
>     - Prevents CI from running on every comment, reducing unnecessary runner usage and costs.
>     - Matches actual bot usage where `@gptme <prompt>` is required to trigger the bot.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 896ac0a7555c2a506e2609ff42fb4990cce261e2. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->