### PR TITLE
fix(tools): pass instructions to ToolSpec in vision and subagent

### DIFF
--- a/gptme/tools/subagent.py
+++ b/gptme/tools/subagent.py
@@ -1491,6 +1491,7 @@ CONTEXT: This is for the gptme server API, see existing endpoints in server.py
 tool = ToolSpec(
     name="subagent",
     desc="Create and manage subagents",
+    instructions=instructions,
     examples=examples,
     functions=[
         subagent,

--- a/gptme/tools/vision.py
+++ b/gptme/tools/vision.py
@@ -90,5 +90,6 @@ Use the `view_image` Python function with `ipython` tool to view an image file.
 tool = ToolSpec(
     name="vision",
     desc="Viewing images",
+    instructions=instructions,
     functions=[view_image],
 )


### PR DESCRIPTION
## Summary

- Fixed `vision` tool: `instructions` variable was defined but never passed to `ToolSpec()`, so LLMs never received guidance on using `view_image`
- Fixed `subagent` tool: Same issue — detailed instructions (32 lines) were defined but never wired into the tool spec

Both are 1-line fixes adding `instructions=instructions` to the `ToolSpec()` constructor.

## Test plan

- [x] Trivially correct — passes an already-defined variable
- [ ] CI tests pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes missing `instructions` in `ToolSpec` for `vision` and `subagent` tools, ensuring proper guidance is provided.
> 
>   - **Behavior**:
>     - Fixes `vision` tool by passing `instructions` to `ToolSpec` in `vision.py`, enabling LLMs to receive guidance for `view_image`.
>     - Fixes `subagent` tool by passing `instructions` to `ToolSpec` in `subagent.py`, ensuring detailed instructions are utilized.
>   - **Implementation**:
>     - Adds `instructions=instructions` to `ToolSpec()` constructor in both `vision.py` and `subagent.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for a579bab611ae3567345637efc9c56ca4577c504c. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->