### PR TITLE
feat(subagent): add ACP execution mode for multi-harness subagents

### DIFF
--- a/gptme/tools/subagent.py
+++ b/gptme/tools/subagent.py
@@ -1015,11 +1015,7 @@ def subagent(
                     return status, summary
 
             try:
-                loop = asyncio.new_event_loop()
-                try:
-                    status, summary = loop.run_until_complete(_acp_run())
-                finally:
-                    loop.close()
+                status, summary = asyncio.run(_acp_run())
 
                 with _subagent_results_lock:
                     _subagent_results[agent_id] = ReturnType(status, summary)
@@ -1029,7 +1025,7 @@ def subagent(
                     _summarize_result(ReturnType(status, summary), max_chars=200),
                 )
             except Exception as e:
-                logger.error(f"ACP subagent {agent_id} failed: {e}")
+                logger.error(f"ACP subagent {agent_id} failed: {e}", exc_info=True)
                 with _subagent_results_lock:
                     _subagent_results[agent_id] = ReturnType("failure", str(e))
                 notify_completion(agent_id, "failure", f"ACP error: {e}")

--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -1325,3 +1325,51 @@ def test_acp_mode_handles_failure():
             assert "test-acp-fail" in _subagent_results
             result = _subagent_results["test-acp-fail"]
             assert result.status == "failure"
+
+
+def test_acp_mode_subagent_batch():
+    """Test that subagent_batch forwards use_acp and acp_command to subagent()."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from gptme.tools.subagent import (
+        _subagent_results,
+        _subagent_results_lock,
+        _subagents,
+        subagent_batch,
+    )
+
+    _subagents.clear()
+    with _subagent_results_lock:
+        _subagent_results.clear()
+
+    mock_client = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.stop_reason = "end_turn"
+    mock_client.run = AsyncMock(return_value=mock_result)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("gptme.acp.client.GptmeAcpClient", return_value=mock_client),
+        patch("gptme.tools.subagent.notify_completion"),
+    ):
+        job = subagent_batch(
+            [("batch-acp-1", "Task 1"), ("batch-acp-2", "Task 2")],
+            use_acp=True,
+            acp_command="fake-acp",
+        )
+
+        assert job.agent_ids == ["batch-acp-1", "batch-acp-2"]
+
+        # Wait for both ACP threads to complete
+        for agent_id in job.agent_ids:
+            sa = next(s for s in _subagents if s.agent_id == agent_id)
+            assert sa.execution_mode == "acp"
+            assert sa.acp_command == "fake-acp"
+            assert sa.thread is not None
+            sa.thread.join(timeout=10)
+
+        with _subagent_results_lock:
+            for agent_id in job.agent_ids:
+                assert agent_id in _subagent_results
+                assert _subagent_results[agent_id].status == "success"


### PR DESCRIPTION
## Summary

- Adds `use_acp=True` parameter to `subagent()` that runs subagents via the Agent Client Protocol (ACP)
- Enables multi-harness support: delegate work to any ACP-compatible agent (gptme, Claude Code, Cursor, etc.)
- `acp_command` parameter allows specifying which ACP agent to invoke (default: `gptme-acp`)
- Also exposed on `subagent_batch()` for parallel ACP subagents

The ACP path wraps `GptmeAcpClient` in a thread (async-to-sync bridge), collects streamed text from `session_update` notifications, and stores results via the standard `_subagent_results` mechanism. Hook-based completion notifications work identically to subprocess/thread modes.

Refs: #1534

## Test plan

- [x] 3 new tests: creation, result storage, error handling
- [x] All 49 existing subagent tests still pass
- [x] mypy clean
- [ ] CI pipeline
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds ACP execution mode to `subagent()` for multi-harness support, enabling subagents to run via ACP-compatible agents.
> 
>   - **Behavior**:
>     - Adds `use_acp=True` parameter to `subagent()` to run subagents via ACP.
>     - Supports multi-harness delegation to ACP-compatible agents (e.g., gptme, Claude Code).
>     - `acp_command` parameter specifies which ACP agent to invoke (default: `gptme-acp`).
>     - `subagent_batch()` updated to support parallel ACP subagents.
>   - **Implementation**:
>     - Modifies `Subagent` class in `subagent.py` to include `execution_mode="acp"` and `acp_command`.
>     - Implements ACP execution path using `GptmeAcpClient` wrapped in a thread.
>     - Collects streamed text from `session_update` notifications and stores results.
>   - **Testing**:
>     - Adds tests in `test_tools_subagent.py` for ACP mode creation, result storage, and error handling.
>     - Ensures all existing subagent tests pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for bbc929fbb8659a852f27e014109460e2258b1c24. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->