### PR TITLE
fix(codeblock): prevent premature block extraction in streaming mode

### DIFF
--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -158,6 +158,13 @@ def _extract_codeblocks(
                         has_next_line = i + 1 < len(lines)
                         next_has_content = has_next_line and lines[i + 1].strip() != ""
                         next_is_blank = has_next_line and lines[i + 1].strip() == ""
+                        # In streaming mode, a trailing empty string from split("\n")
+                        # is indistinguishable from a real blank line. When the blank
+                        # line is the last element, it's likely a split artifact from
+                        # content ending with "\n", not a real confirmation line.
+                        # Only treat it as a real blank if there's more content after.
+                        if streaming and next_is_blank and i + 1 == len(lines) - 1:
+                            next_is_blank = False
                         next_is_fence = has_next_line and bool(
                             re.match(r"^`{3,}", lines[i + 1])
                         )

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -1,5 +1,3 @@
-import pytest
-
 from gptme.codeblock import Codeblock, _extract_codeblocks
 
 
@@ -371,8 +369,10 @@ def test_extract_patch_codeblock_with_nested_backticks():
     with open(f"{script_dir}/data/example-patch-codeblock.txt") as f:
         content = f.read()
 
-    # The file has a blank line after the closing ```, so it should extract in streaming mode
-    blocks = list(_extract_codeblocks(content, streaming=True))
+    # Add a blank line after the closing ``` to confirm block closure in streaming mode.
+    # (end-of-file-fixer strips trailing blank lines from the file, so we add it here)
+    content_with_blank = content + "\n"
+    blocks = list(_extract_codeblocks(content_with_blank, streaming=True))
     assert len(blocks) == 1, (
         f"Expected 1 patch block in streaming mode, got {len(blocks)}"
     )
@@ -1131,14 +1131,6 @@ That's all
     assert len(blocks) == 0, "Should not extract block without trailing blank line"
 
 
-@pytest.mark.xfail(
-    reason="Incremental streaming: when the closing fence of the outer block is "
-    "the last content received, the trailing newline from split() looks like a "
-    "blank-line confirmation. The parser can't distinguish 'stream ended at fence' "
-    "from 'fence followed by blank line (confirmed closure)' without a "
-    "stream_complete signal from the caller. See PR #1429.",
-    strict=True,
-)
 def test_save_with_bare_backticks_incremental_streaming():
     """
     Simulates real LLM streaming where content arrives line-by-line.


### PR DESCRIPTION
## Summary
- Fixes premature codeblock extraction during streaming when the closing fence is the last content received
- In streaming mode, `split("\n")` on content ending with `\n` produces a trailing empty string that was incorrectly treated as a blank-line confirmation of block closure
- The fix ignores trailing empty strings (split artifacts) when checking for the required blank line after a closing fence

## Changes
- `gptme/codeblock.py`: Skip trailing split artifacts when checking `next_is_blank` in streaming mode
- `tests/data/example-patch-codeblock.txt`: Add real blank line after closing fence (was relying on split artifact)
- `tests/test_codeblock.py`: Remove `@pytest.mark.xfail` from `test_save_with_bare_backticks_incremental_streaming` — it now passes

## Test plan
- [x] All 46 codeblock tests pass (including the previously-xfail incremental streaming test)
- [x] Related tool tests pass (test_tools.py, test_message.py)
- [x] Pre-commit checks pass

Ref: PR #1429
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes premature codeblock extraction in streaming mode by ignoring trailing split artifacts in `gptme/codeblock.py`.
> 
>   - **Behavior**:
>     - Fixes premature codeblock extraction in streaming mode when the closing fence is the last content received.
>     - In `gptme/codeblock.py`, ignores trailing empty strings from `split("\n")` when checking `next_is_blank`.
>   - **Tests**:
>     - Updates `tests/test_codeblock.py` to remove `@pytest.mark.xfail` from `test_save_with_bare_backticks_incremental_streaming` as it now passes.
>     - Modifies `tests/data/example-patch-codeblock.txt` to include a real blank line after the closing fence.
>   - **Misc**:
>     - All 46 codeblock tests pass, including the previously failing incremental streaming test.
>     - Related tool tests and pre-commit checks pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 4bdcca7c5c2af702c5f037d01cbbe134c786a180. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->