### PR TITLE
fix(server): validate use_acp as boolean in v2 step request

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -960,8 +960,21 @@ def api_conversation_step(conversation_id: str):
 
     stream = req_json.get("stream", chat_config.stream)
 
-    # ACP opt-in: sticky once enabled for a session
-    if req_json.get("use_acp", False) and not session.use_acp:
+    # ACP opt-in: sticky once enabled for a session.
+    # Validate type explicitly to avoid truthy string surprises (e.g. "false").
+    use_acp = req_json.get("use_acp", False)
+    if not isinstance(use_acp, bool):
+        return (
+            flask.jsonify(
+                {
+                    "error": "Invalid 'use_acp' value",
+                    "message": "'use_acp' must be a boolean",
+                }
+            ),
+            400,
+        )
+
+    if use_acp and not session.use_acp:
         from .acp_session_runtime import AcpSessionRuntime
 
         session.use_acp = True

--- a/tests/test_acp_session_runtime.py
+++ b/tests/test_acp_session_runtime.py
@@ -226,6 +226,31 @@ def test_acp_step_emits_events(monkeypatch, client: FlaskClient, tmp_path):
         SessionManager._conversation_sessions[conversation_id].discard("sid-evt")
 
 
+def test_use_acp_step_rejects_non_boolean_flag(client: FlaskClient):
+    """/step should reject non-boolean use_acp values with 400."""
+    conv = _make_v2_conversation(client)
+    conversation_id = conv["conversation_id"]
+    session_id = conv["session_id"]
+
+    # Send a user message first
+    resp = client.post(
+        f"/api/v2/conversations/{conversation_id}",
+        json={"role": "user", "content": "hello"},
+    )
+    assert resp.status_code == 200
+
+    # Non-boolean use_acp should fail validation
+    resp = client.post(
+        f"/api/v2/conversations/{conversation_id}/step",
+        json={"session_id": session_id, "use_acp": "false"},
+    )
+    assert resp.status_code == 400
+
+    data = resp.get_json()
+    assert data is not None
+    assert data.get("error") == "Invalid 'use_acp' value"
+
+
 @pytest.mark.timeout(10)
 def test_use_acp_flag_in_step_request(monkeypatch, client: FlaskClient, tmp_path):
     """Posting use_acp=True to /step should create an ACP runtime and route through it."""


### PR DESCRIPTION
## Summary

Hardens ACP step request parsing by requiring `use_acp` to be a boolean.

Before this change, `/api/v2/conversations/<id>/step` used truthiness:

```python
if req_json.get("use_acp", False) and not session.use_acp:
    ...
```

That meant payloads like `{"use_acp": "false"}` (string) were truthy and could unexpectedly enable sticky ACP mode.

## Changes

- In `gptme/server/api_v2_sessions.py`:
  - Extract `use_acp = req_json.get("use_acp", False)`
  - Validate type explicitly: non-boolean values now return HTTP 400 with clear error message
  - Keep existing sticky ACP behavior unchanged for valid boolean inputs

- In `tests/test_acp_session_runtime.py`:
  - Added `test_use_acp_step_rejects_non_boolean_flag`

## Why

This prevents surprising mode switches caused by malformed JSON payloads and makes the API contract explicit.

## Verification

- `uv run pytest -q tests/test_acp_session_runtime.py`
- `uv run pytest -q tests/test_server_v2_auto_stepping.py tests/test_server_v2_tool_confirmation.py`

All passing locally.

## Related

- `gptme/gptme#1534` (ACP client / server process-isolation track)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure `use_acp` in `/api/v2/conversations/<id>/step` is validated as a boolean, rejecting non-boolean values with HTTP 400.
> 
>   - **Behavior**:
>     - In `api_v2_sessions.py`, `use_acp` is extracted and validated to be a boolean, returning HTTP 400 for non-boolean values.
>     - Existing ACP behavior remains unchanged for valid boolean inputs.
>   - **Tests**:
>     - Added `test_use_acp_step_rejects_non_boolean_flag` in `test_acp_session_runtime.py` to ensure non-boolean `use_acp` values are rejected.
>   - **Misc**:
>     - Updated `/api/v2/conversations/<id>/step` endpoint to handle `use_acp` validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 6090686f0ebe38fe7882a171b610eb90e05b46fd. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->