### PR TITLE
fix(gh): add multi-line comment guidance to prevent literal \n in posts

### DIFF
--- a/gptme/tools/gh.py
+++ b/gptme/tools/gh.py
@@ -439,7 +439,7 @@ To wait for all CI checks to complete:
 The optional commit_sha allows checking a specific commit instead of the PR head.
 This is useful for checking previous commits without waiting for new builds.
 
-For posting multi-line comments, always use `--body-file` with a heredoc to avoid literal \\n in output:
+For posting multi-line comments, always use `--body-file` with a single-quoted heredoc to avoid two bash pitfalls:
 ```shell
 gh issue comment NUM --repo owner/repo --body-file - << 'EOF'
 ## Summary
@@ -448,7 +448,10 @@ Line 1
 Line 2
 EOF
 ```
-Never use `--body "text\\nmore text"` — `\\n` in double-quoted strings is not interpreted as a newline by bash.
+Never use `--body "text\\nmore text"`:
+- `\\n` in double-quoted strings is literal backslash-n, not a newline.
+- `$` in double-quoted strings triggers variable expansion (e.g. `$42,000` → `,000`).
+The single-quoted `<< 'EOF'` heredoc prevents both issues.
 
 For other operations, use the `shell` tool with the `gh` command."""
 


### PR DESCRIPTION
## Summary

When LLMs generate `gh issue comment` commands with `--body "text\nmore text"`, bash does NOT interpret `\n` as a newline in double-quoted strings. This results in literal `\n` characters appearing in GitHub comments.

This was observed in comments posted via gptme with the `openai-subscription` provider (ErikBjare/bob#356).

**Root cause**: LLMs use `\n` as an escape sequence, but in bash double-quoted strings, `\n` is literal backslash-n, not a newline.

**Fix**: Add explicit instructions to use `--body-file` with heredoc for multi-line comment bodies, and add an example showing the correct pattern.

## Changes

- Added guidance in gh tool instructions to use `--body-file` with heredoc
- Added an example for posting multi-line comments
- Added explicit warning about `\n` in double-quoted strings

## Test plan

- [ ] Verify instructions render correctly: `python -c "from gptme.tools.gh import tool; print(tool.instructions)"`
- [ ] Verify example renders correctly: `python -c "from gptme.tools.gh import examples; print(examples('markdown'))"`

Fixes: ErikBjare/bob#356

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue with literal '\n' in GitHub comments by updating `gh.py` to use `--body-file` with heredoc for multi-line comments.
> 
>   - **Behavior**:
>     - Updated `instructions` in `gh.py` to recommend using `--body-file` with heredoc for multi-line comments to avoid literal `\n`.
>     - Added an example in `examples()` in `gh.py` for posting multi-line comments using heredoc.
>     - Added a warning about `\n` in double-quoted strings in `gh.py`.
>   - **Test Plan**:
>     - Verify instructions render correctly using `python -c "from gptme.tools.gh import tool; print(tool.instructions)"`.
>     - Verify example renders correctly using `python -c "from gptme.tools.gh import examples; print(examples('markdown'))"`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 103387589d8d79b9c3c271c1d007550d74dc7cdb. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->