### PR TITLE
feat(lessons): Thompson sampling effectiveness scoring for hybrid matcher

### DIFF
--- a/gptme/lessons/hybrid_matcher.py
+++ b/gptme/lessons/hybrid_matcher.py
@@ -197,7 +197,7 @@ class HybridLessonMatcher(LessonMatcher):
                 semantic_score = self._semantic_score(query_embed, lesson, context)
 
             # Component 3: Effectiveness score
-            # NOTE: Neutral until ACE metadata implemented (Phase 1 schema)
+            # Falls back to 0.5 (neutral) when no TS data is configured or available
             effectiveness_score = 0.5
             if self.config.enable_effectiveness:
                 effectiveness_score = self._effectiveness_score(lesson)

--- a/tests/test_hybrid_lessons.py
+++ b/tests/test_hybrid_lessons.py
@@ -207,3 +207,13 @@ def test_effectiveness_score_default():
     config = HybridConfig(enable_semantic=False)
     matcher = HybridLessonMatcher(config=config)
     assert matcher._ts_posteriors == {}
+    # Verify the fallback path inside _effectiveness_score returns 0.5
+    lesson = Lesson(
+        path=Path("/tmp/lessons/some-lesson.md"),
+        metadata=LessonMetadata(),
+        title="Some Lesson",
+        description="",
+        category="workflow",
+        body="",
+    )
+    assert matcher._effectiveness_score(lesson) == pytest.approx(0.5)


### PR DESCRIPTION
## Summary

- Replaces hardcoded `effectiveness_score = 0.5` in `HybridLessonMatcher` with Thompson sampling posterior means
- Adds `effectiveness_state_file` config option pointing to a bandit state JSON file
- Loads Beta-Bernoulli posteriors at init and uses `alpha/(alpha+beta)` as effectiveness scores
- Matches lessons by filename or relative path (e.g., `workflow/git-workflow.md`)
- Falls back to neutral 0.5 when no TS data is available (backward compatible)
- Adds 4 new tests covering loading, missing files, scoring, and defaults

## Context

Bob's workspace maintains Thompson sampling posteriors for lessons based on session outcomes (productive vs noop). This PR connects those posteriors to gptme's hybrid lesson matcher so lessons are ranked by empirical effectiveness rather than a neutral constant.

Ref: ErikBjare/bob#361

## Test plan

- [x] All 7 hybrid lesson tests pass (3 existing + 4 new)
- [x] mypy passes
- [x] ruff passes
- [ ] CI green
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces Thompson sampling for effectiveness scoring in `HybridLessonMatcher`, replacing hardcoded scores with posterior means from a configurable state file.
> 
>   - **Behavior**:
>     - Replaces hardcoded `effectiveness_score = 0.5` in `HybridLessonMatcher` with Thompson sampling posterior means.
>     - Adds `effectiveness_state_file` config option in `HybridConfig` for bandit state JSON file.
>     - Matches lessons by filename or relative path, defaults to 0.5 if no data.
>   - **Functions**:
>     - Adds `_load_ts_posteriors()` to load posterior means from JSON file.
>     - Updates `_effectiveness_score()` in `HybridLessonMatcher` to use loaded posteriors.
>   - **Tests**:
>     - Adds tests for loading posteriors, handling missing files, scoring with TS, and default behavior in `test_hybrid_lessons.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 910fab918b3b0c6c39d54f92e9aa7edc9c44d4f0. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->