### PR TITLE
feat(server): add GPTME_USE_ACP_DEFAULT config for server-side ACP opt-in

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -234,17 +234,23 @@ class SessionManager:
 # ------------------------------
 
 
-def _get_use_acp_default(workspace: Path) -> bool:
+def _get_use_acp_default() -> bool:
     """Return the server-wide default for ACP mode.
 
     Checks the ``GPTME_USE_ACP_DEFAULT`` environment variable (or its bare
-    form ``USE_ACP_DEFAULT``) via :meth:`Config.get_env_bool`.  When set to a
-    truthy value (``1``, ``true``, ``yes``, ``on``), new sessions that don't
-    explicitly pass ``use_acp`` in the step request will use ACP mode by
+    form ``USE_ACP_DEFAULT``) directly from the process environment.  When set
+    to a truthy value (``1``, ``true``, ``yes``, ``on``), new sessions that
+    don't explicitly pass ``use_acp`` in the step request will use ACP mode by
     default.
+
+    Reads ``os.environ`` directly rather than going through
+    :meth:`Config.from_workspace` to avoid clearing the shared
+    ``_get_project_config_cached`` LRU cache on every step request.
     """
-    config = Config.from_workspace(workspace=workspace)
-    return config.get_env_bool("USE_ACP_DEFAULT", default=False) or False
+    val = os.environ.get("GPTME_USE_ACP_DEFAULT") or os.environ.get("USE_ACP_DEFAULT")
+    if val is None:
+        return False
+    return val.lower() in ("1", "true", "yes", "on")
 
 
 def _append_and_notify(manager: LogManager, session: ConversationSession, msg: Message):
@@ -975,7 +981,7 @@ def api_conversation_step(conversation_id: str):
     # ACP opt-in: sticky once enabled for a session.
     # Default can be set server-wide via GPTME_USE_ACP_DEFAULT=true env var.
     # Validate type explicitly to avoid truthy string surprises (e.g. "false").
-    _acp_default = _get_use_acp_default(chat_config.workspace)
+    _acp_default = _get_use_acp_default()
     use_acp = req_json.get("use_acp", _acp_default)
     if not isinstance(use_acp, bool):
         return (

--- a/tests/test_acp_session_runtime.py
+++ b/tests/test_acp_session_runtime.py
@@ -707,8 +707,12 @@ def test_explicit_use_acp_false_overrides_default(
     assert sess.use_acp is False
 
 
-def test_without_env_var_default_remains_false(client: FlaskClient, tmp_path):
+def test_without_env_var_default_remains_false(
+    monkeypatch, client: FlaskClient, tmp_path
+):
     """Without GPTME_USE_ACP_DEFAULT, use_acp should default to False (non-ACP)."""
+    monkeypatch.delenv("GPTME_USE_ACP_DEFAULT", raising=False)
+    monkeypatch.delenv("USE_ACP_DEFAULT", raising=False)
     conv = _make_v2_conversation(client)
     conversation_id = conv["conversation_id"]
     session_id = conv["session_id"]


### PR DESCRIPTION
## Summary

- Adds `GPTME_USE_ACP_DEFAULT` env var to enable ACP (process-per-session) mode as the server default
- When set to `true`/`1`/`yes`/`on`, new step requests use ACP mode unless the client explicitly sends `use_acp=False`
- Uses existing `Config.get_env_bool()` infrastructure for parsing

This is Phase 1 of making ACP the default execution path, as outlined in the process-per-session architecture task (gptme#1534).

## Test plan

- [x] `test_use_acp_default_env_var_enables_acp` — env var enables ACP when `use_acp` omitted from request
- [x] `test_explicit_use_acp_false_overrides_default` — explicit `use_acp=False` overrides env default
- [x] `test_without_env_var_default_remains_false` — backward compatible (no env var = no ACP)
- [x] All 21 ACP tests pass (18 existing + 3 new)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `GPTME_USE_ACP_DEFAULT` env var to set ACP mode as default in server, with tests for various scenarios.
> 
>   - **Behavior**:
>     - Adds `GPTME_USE_ACP_DEFAULT` environment variable to enable ACP mode by default in `api_conversation_step()` in `api_v2_sessions.py`.
>     - If set to a truthy value, new sessions default to ACP mode unless `use_acp=False` is explicitly specified.
>     - Uses `Config.get_env_bool()` for environment variable parsing.
>   - **Tests**:
>     - `test_use_acp_default_env_var_enables_acp`: Verifies ACP mode is enabled by default when the environment variable is set.
>     - `test_explicit_use_acp_false_overrides_default`: Confirms explicit `use_acp=False` overrides the default.
>     - `test_without_env_var_default_remains_false`: Ensures default behavior remains unchanged without the environment variable.
>     - All 21 ACP tests pass, including 3 new tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for 6e564e9d046ed7451fcbac389ce0e1d35f7401c7. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->