### PR TITLE
fix: perplexity search now reads keys from config.local.toml

### DIFF
--- a/gptme/tools/_browser_perplexity.py
+++ b/gptme/tools/_browser_perplexity.py
@@ -3,10 +3,6 @@ Perplexity search backend for the browser tool.
 """
 
 import logging
-import os
-from pathlib import Path
-
-import tomlkit
 
 from ..llm.llm_openai import OPENROUTER_APP_HEADERS
 
@@ -37,32 +33,21 @@ def search_perplexity(query: str) -> str:
                 "Error: OpenAI package not installed. Install with: pip install openai"
             )
 
+        from ..config import get_config
+
+        cfg = get_config()
+
         # Get API key - try Perplexity first, then OpenRouter
-        api_key = os.getenv("PERPLEXITY_API_KEY")
+        api_key = cfg.get_env("PERPLEXITY_API_KEY")
         use_openrouter = False
 
         if not api_key:
-            # Try config file
-            config_path = Path.home() / ".config" / "gptme" / "config.toml"
-            config_env = {}
-            if config_path.exists():
-                with open(config_path) as f:
-                    config = tomlkit.load(f)
-                    config_env = config.get("env", {})
-
-            # Try Perplexity key from config
-            api_key = config_env.get("PERPLEXITY_API_KEY")
-
-            if not api_key:
-                # Try OpenRouter as fallback
-                api_key = os.getenv("OPENROUTER_API_KEY") or config_env.get(
-                    "OPENROUTER_API_KEY"
-                )
-                if api_key:
-                    use_openrouter = True
+            api_key = cfg.get_env("OPENROUTER_API_KEY")
+            if api_key:
+                use_openrouter = True
 
         if not api_key:
-            return "Error: No API key found. Set PERPLEXITY_API_KEY or OPENROUTER_API_KEY environment variable or add it to ~/.config/gptme/config.toml"
+            return "Error: Perplexity search not available. Set PERPLEXITY_API_KEY or OPENROUTER_API_KEY environment variable or add it to ~/.config/gptme/config.toml"
 
         # Create client and search
         headers: dict[str, str] = {}
@@ -107,26 +92,7 @@ def search_perplexity(query: str) -> str:
 
 def has_perplexity_key() -> bool:
     """Check if Perplexity or OpenRouter API key is available."""
-    # Check for Perplexity key
-    if os.getenv("PERPLEXITY_API_KEY"):
-        return True
+    from ..config import get_config
 
-    # Check for OpenRouter key (can be used for Perplexity search)
-    if os.getenv("OPENROUTER_API_KEY"):
-        return True
-
-    # Try config file
-    config_path = Path.home() / ".config" / "gptme" / "config.toml"
-    if config_path.exists():
-        try:
-            with open(config_path) as f:
-                config = tomlkit.load(f)
-                env_config = config.get("env", {})
-                return bool(
-                    env_config.get("PERPLEXITY_API_KEY")
-                    or env_config.get("OPENROUTER_API_KEY")
-                )
-        except Exception:
-            pass
-
-    return False
+    cfg = get_config()
+    return bool(cfg.get_env("PERPLEXITY_API_KEY") or cfg.get_env("OPENROUTER_API_KEY"))


### PR DESCRIPTION
Uses `config.get_env()` instead of manually reading `config.toml`, which properly handles `config.local.toml` merging.

Previously, perplexity search would fail to find API keys stored in `config.local.toml` since it only checked `config.toml` directly.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates `search_perplexity()` and `has_perplexity_key()` in `_browser_perplexity.py` to read API keys from `config.local.toml` using `get_config().get_env()`.
> 
>   - **Behavior**:
>     - `search_perplexity()` now uses `get_config().get_env()` to retrieve API keys, allowing `config.local.toml` to be considered.
>     - `has_perplexity_key()` updated to use `get_config().get_env()` for key retrieval.
>   - **Imports**:
>     - Removed unused imports: `os`, `Path`, and `tomlkit` from `_browser_perplexity.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for e7f7d01e9a8efff12cad61109bf85b1db7a23a62. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->