### PR TITLE
fix: use diff syntax highlighting for save/append previews

### DIFF
--- a/gptme/hooks/cli_confirm.py
+++ b/gptme/hooks/cli_confirm.py
@@ -208,7 +208,25 @@ def _looks_like_diff(content: str | None) -> bool:
 
     # Avoid false positives on plain markdown/yaml lists (mostly '-' lines).
     # Real diff previews usually have either mixed +/- lines or context lines.
-    return (has_plus and has_minus) or has_context
+    if (has_plus and has_minus) or has_context:
+        return True
+
+    # Accept plus-only diffs (e.g. append to empty file produces all-'+' output
+    # from Patch.diff_minimal). Require every non-empty line to start with '+'
+    # and at least one non-"+ " line to avoid matching markdown/yaml '+' lists.
+    if has_plus and not has_minus:
+        non_empty = [line for line in lines if line.strip()]
+        all_plus = non_empty and all(line.startswith("+") for line in non_empty)
+        # Markdown '+ item' lists always have a space after '+'.  Real diffs from
+        # diff_minimal() use '+content' (no space) for most lines.
+        has_tight_plus = any(
+            line.startswith("+") and (len(line) == 1 or line[1] != " ")
+            for line in non_empty
+        )
+        if all_plus and has_tight_plus:
+            return True
+
+    return False
 
 
 def _get_lang_for_tool(tool: str, content: str | None = None) -> str:

--- a/tests/test_cli_confirm_hook.py
+++ b/tests/test_cli_confirm_hook.py
@@ -46,3 +46,33 @@ def test_get_lang_for_save_uses_diff_when_preview_is_diff() -> None:
 def test_get_lang_for_save_plain_text_fallback() -> None:
     content = "# Notes\n\n- Apples\n- Bananas\n"
     assert _get_lang_for_tool("save", content) == "text"
+
+
+def test_looks_like_diff_plus_only_append() -> None:
+    """Plus-only diffs (append to empty file) should be detected."""
+    content = "+line1\n+line2\n+line3\n"
+    assert _looks_like_diff(content) is True
+
+
+def test_looks_like_diff_plus_only_code_append() -> None:
+    """Plus-only code diffs from Patch.diff_minimal() should be detected."""
+    content = '+def hello():\n+    print("world")'
+    assert _looks_like_diff(content) is True
+
+
+def test_get_lang_for_append_uses_diff_when_preview_is_diff() -> None:
+    """Append tool should detect diff content the same as save."""
+    content = " existing\n+new line\n"
+    assert _get_lang_for_tool("append", content) == "diff"
+
+
+def test_get_lang_for_append_plain_text_fallback() -> None:
+    """Append tool should fall back to text for non-diff content."""
+    content = "Just some plain text to append.\n"
+    assert _get_lang_for_tool("append", content) == "text"
+
+
+def test_get_lang_for_append_plus_only_diff() -> None:
+    """Append to empty file produces plus-only diff — should detect as diff."""
+    content = "+line1\n+line2\n+line3"
+    assert _get_lang_for_tool("append", content) == "diff"


### PR DESCRIPTION
When saving/appending to an existing file, the preview shows a diff but was rendered as plain text (white, no coloring). Patch tool already showed colored diffs.

This detects when the preview content looks like a unified diff and applies `"diff"` syntax highlighting in the CLI confirmation hook, giving save/append the same colored diff preview as patch.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances save/append previews with diff syntax highlighting by detecting diff-like content in `cli_confirm.py`.
> 
>   - **Behavior**:
>     - Detects unified diff-like content in save/append previews and applies `"diff"` syntax highlighting in `cli_confirm_hook()`.
>     - Ensures save/append previews have the same colored diff preview as the patch tool.
>   - **Functions**:
>     - Adds `_looks_like_diff()` to check if content resembles a unified diff.
>     - Modifies `_get_lang_for_tool()` to use `_looks_like_diff()` for determining syntax highlighting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=gptme%2Fgptme&utm_source=github&utm_medium=referral)<sup> for cc288456ca7049a12c39b4751e27d1937e991498. You can [customize](https://app.ellipsis.dev/gptme/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->