### PR TITLE
feat(tauri): add Windows build support

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -152,7 +152,7 @@ jobs:
           bmp = struct.pack('<IiiHHIIiiII', 40, s, s*2, 1, bpp, 0, px + mask, 0, 0, 0, 0)
           img = bmp + (b'\x00\x80\x00\xff' * s * s) + (b'\x00' * mask)
           hdr = struct.pack('<HHH', 0, 1, 1)
-          entry = struct.pack('<BBBBHHIH', s, s, 0, 0, 1, bpp, len(img), 22)
+          entry = struct.pack('<BBBBHHII', s, s, 0, 0, 1, bpp, len(img), 22)
           open('tauri/src-tauri/icons/icon.ico', 'wb').write(hdr + entry + img)
           "
 
@@ -306,7 +306,7 @@ jobs:
           bmp = struct.pack('<IiiHHIIiiII', 40, s, s*2, 1, bpp, 0, px + mask, 0, 0, 0, 0)
           img = bmp + (b'\x00\x80\x00\xff' * s * s) + (b'\x00' * mask)
           hdr = struct.pack('<HHH', 0, 1, 1)
-          entry = struct.pack('<BBBBHHIH', s, s, 0, 0, 1, bpp, len(img), 22)
+          entry = struct.pack('<BBBBHHII', s, s, 0, 0, 1, bpp, len(img), 22)
           open('tauri/src-tauri/icons/icon.ico', 'wb').write(hdr + entry + img)
           "
 


### PR DESCRIPTION
## Summary

- Adds `windows-latest` to the Tauri CI build matrix (produces NSIS installer)
- Adds `windows-latest` to the sidecar build and release jobs
- Uses `shell: bash` for cross-platform shell command compatibility
- Handles `.exe` extension for Windows sidecar binaries

Closes #1592
Part of ErikBjare/bob#334 (convergent local + managed service app)

## Changes

| File | Change |
|------|--------|
| `.github/workflows/tauri.yml` | Add Windows to build/sidecar/release matrices, add `shell: bash`, handle `.exe` |

## Test plan

- [ ] CI build passes on `windows-latest` (verify Windows NSIS build works)
- [ ] CI build still passes on `macos-latest` and `ubuntu-24.04` (no regression)
- [ ] Sidecar placeholder handles `.exe` on Windows
- [ ] Release job would produce Windows installer on tag push
