### PR TITLE
Add CrowPay tool — payment service for AI agents

### DIFF
--- a/gptme/tools/crowpay.py
+++ b/gptme/tools/crowpay.py
@@ -7,10 +7,11 @@ https://crowpay.ai
 
 import json
 import logging
+import os
 from collections.abc import Generator
 
 from ..message import Message
-from . import ToolSpec, ToolUse
+from . import ToolSpec
 
 logger = logging.getLogger(__name__)
 
@@ -28,25 +29,26 @@ setup
 
 **Authorize an x402 payment (paste the 402 response body):**
 ```crowpay
-authorize crow_sk_... ServiceName "Reason for payment"
+authorize ServiceName "Reason for payment"
 {"x402Version": 2, "resource": {...}, "accepts": [...]}
 ```
 
 **Authorize a credit card payment:**
 ```crowpay
-card crow_sk_... 1000 "OpenAI" "GPT-4 API credits"
+card 1000 "OpenAI" "GPT-4 API credits"
 ```
 
 **Poll for approval status:**
 ```crowpay
-status crow_sk_... approval_id_here
+status approval_id_here
 ```
 
 **Report settlement:**
 ```crowpay
-settle crow_sk_... transaction_id tx_hash
+settle transaction_id tx_hash
 ```
 
+Set your API key via the CROWPAY_API_KEY environment variable, or pass it as the first argument.
 Default spending rules: auto-approve under $5, human approval above, $50/day limit.
 """
 
@@ -60,10 +62,17 @@ setup
 User: Pay for that API call that returned 402
 Assistant: Let me authorize the payment via CrowPay.
 ```crowpay
-authorize crow_sk_abc123 "Weather API" "Fetching forecast for user"
+authorize "Weather API" "Fetching forecast for user"
 {"x402Version": 2, "resource": {"url": "https://nightmarket.ai/api/x402/abc123"}, "accepts": [{"scheme": "exact", "network": "eip155:8453", "amount": "10000", "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", "payTo": "0xSeller", "maxTimeoutSeconds": 60}]}
 ```
 """
+
+
+def _get_api_key(explicit_key: str | None = None) -> str | None:
+    """Get API key from explicit argument or environment variable."""
+    if explicit_key and explicit_key.startswith("crow_sk_"):
+        return explicit_key
+    return os.environ.get("CROWPAY_API_KEY")
 
 
 def _http_post(url: str, body: dict, api_key: str | None = None) -> tuple[int, dict]:
@@ -104,12 +113,16 @@ def _http_get(url: str, api_key: str) -> tuple[int, dict]:
 
 
 def execute_crowpay(
-    code: str, args: list[str], kwargs: dict, confirm: ToolUse.ConfirmFunc
+    code: str | None, args: list[str] | None, kwargs: dict | None
 ) -> Generator[Message, None, None]:
     """Execute a crowpay command."""
+    if not code:
+        yield Message("system", "Usage: setup | authorize <merchant> <reason>\\n<402body> | card <cents> <merchant> <reason> | status <id> | settle <txn_id> <tx_hash>")
+        return
+
     lines = code.strip().split("\n")
     if not lines:
-        yield Message("system", "Usage: setup | authorize <key> <merchant> <reason>\\n<402body> | card <key> <cents> <merchant> <reason> | status <key> <id> | settle <key> <txn_id> <tx_hash>")
+        yield Message("system", "Usage: setup | authorize <merchant> <reason>\\n<402body> | card <cents> <merchant> <reason> | status <id> | settle <txn_id> <tx_hash>")
         return
 
     parts = lines[0].split(maxsplit=4)
@@ -119,18 +132,24 @@ def execute_crowpay(
         if cmd == "setup":
             status, result = _http_post(f"{CROWPAY_BASE_URL}/setup", {})
             if "apiKey" in result:
-                yield Message("system", f"✅ Wallet created!\n\n- **API Key:** `{result['apiKey']}` (save this — shown only once!)\n- **Wallet:** `{result.get('walletAddress', '')}`\n- **Claim URL:** {result.get('claimUrl', '')}\n\nVisit the claim URL to set spending rules. Fund the wallet with USDC on Base.")
+                yield Message("system", f"✅ Wallet created!\n\n- **API Key:** `{result['apiKey']}` (save this — shown only once!)\n- **Wallet:** `{result.get('walletAddress', '')}`\n- **Claim URL:** {result.get('claimUrl', '')}\n\nVisit the claim URL to set spending rules. Fund the wallet with USDC on Base.\n\n**Tip:** Set `CROWPAY_API_KEY` environment variable to avoid passing the key in commands.")
             else:
                 yield Message("system", f"Setup response ({status}):\n```json\n{json.dumps(result, indent=2)}\n```")
 
         elif cmd == "authorize":
-            if len(parts) < 4:
-                yield Message("system", "Usage: authorize <api_key> <merchant> <reason>\\n<402_response_body_json>")
+            # Parse: authorize [api_key] <merchant> <reason>\n<402_body>
+            remaining = parts[1:]
+            api_key = _get_api_key(remaining[0] if remaining else None)
+            if api_key and remaining and remaining[0].startswith("crow_sk_"):
+                remaining = remaining[1:]
+            if len(remaining) < 2:
+                yield Message("system", "Usage: authorize [api_key] <merchant> <reason>\\n<402_response_body_json>")
                 return
-            api_key = parts[1]
-            merchant = parts[2].strip('"')
-            reason = parts[3].strip('"')
-            # Rest of lines = payment required body
+            if not api_key:
+                yield Message("system", "No API key found. Set CROWPAY_API_KEY env var or pass as first argument.")
+                return
+            merchant = remaining[0].strip('"')
+            reason = remaining[1].strip('"')
             payment_body_str = "\n".join(lines[1:])
             payment_required = json.loads(payment_body_str)
 
@@ -142,18 +161,26 @@ def execute_crowpay(
                 sig = base64.b64encode(json.dumps(result).encode()).decode()
                 yield Message("system", f"✅ Payment approved! Retry your request with this header:\n\n`payment-signature: {sig}`")
             elif status == 202:
-                yield Message("system", f"⏳ Needs human approval. Poll with:\n```crowpay\nstatus {api_key} {result.get('approvalId', '')}\n```")
+                approval_id = result.get('approvalId', '')
+                yield Message("system", f"⏳ Needs human approval. Poll with:\n```crowpay\nstatus {approval_id}\n```")
             else:
                 yield Message("system", f"❌ Payment response ({status}):\n```json\n{json.dumps(result, indent=2)}\n```")
 
         elif cmd == "card":
-            if len(parts) < 5:
-                yield Message("system", 'Usage: card <api_key> <amount_cents> <merchant> <reason>')
+            # Parse: card [api_key] <amount_cents> <merchant> <reason>
+            remaining = parts[1:]
+            api_key = _get_api_key(remaining[0] if remaining else None)
+            if api_key and remaining and remaining[0].startswith("crow_sk_"):
+                remaining = remaining[1:]
+            if len(remaining) < 3:
+                yield Message("system", 'Usage: card [api_key] <amount_cents> <merchant> <reason>')
                 return
-            api_key = parts[1]
-            amount = int(parts[2])
-            merchant = parts[3].strip('"')
-            reason = parts[4].strip('"') if len(parts) > 4 else ""
+            if not api_key:
+                yield Message("system", "No API key found. Set CROWPAY_API_KEY env var or pass as first argument.")
+                return
+            amount = int(remaining[0])
+            merchant = remaining[1].strip('"')
+            reason = remaining[2].strip('"')
 
             body = {"amountCents": amount, "merchant": merchant, "reason": reason, "platform": "gptme"}
             status, result = _http_post(f"{CROWPAY_BASE_URL}/authorize/card", body, api_key)
@@ -161,34 +188,54 @@ def execute_crowpay(
             if status == 200:
                 yield Message("system", f"✅ Card payment approved! SPT Token: `{result.get('sptToken', '')}`")
             elif status == 202:
-                yield Message("system", f"⏳ Needs human approval. Poll with:\n```crowpay\nstatus {api_key} {result.get('approvalId', '')}\n```")
+                approval_id = result.get('approvalId', '')
+                yield Message("system", f"⏳ Needs human approval. Poll with:\n```crowpay\nstatus {approval_id}\n```")
             else:
                 yield Message("system", f"❌ Card payment response ({status}):\n```json\n{json.dumps(result, indent=2)}\n```")
 
         elif cmd == "status":
-            if len(parts) < 3:
-                yield Message("system", "Usage: status <api_key> <approval_id>")
+            # Parse: status [api_key] <approval_id>
+            remaining = parts[1:]
+            api_key = _get_api_key(remaining[0] if remaining else None)
+            if api_key and remaining and remaining[0].startswith("crow_sk_"):
+                remaining = remaining[1:]
+            if not remaining:
+                yield Message("system", "Usage: status [api_key] <approval_id>")
                 return
-            api_key = parts[1]
-            approval_id = parts[2]
-            status, result = _http_get(f"{CROWPAY_BASE_URL}/authorize/status?id={approval_id}", api_key)
+            if not api_key:
+                yield Message("system", "No API key found. Set CROWPAY_API_KEY env var or pass as first argument.")
+                return
+            from urllib.parse import urlencode
+            approval_id = remaining[0]
+            url = f"{CROWPAY_BASE_URL}/authorize/status?" + urlencode({"id": approval_id})
+            status, result = _http_get(url, api_key)
             yield Message("system", f"Approval status:\n```json\n{json.dumps(result, indent=2)}\n```")
 
         elif cmd == "settle":
-            if len(parts) < 4:
-                yield Message("system", "Usage: settle <api_key> <transaction_id> <tx_hash>")
+            # Parse: settle [api_key] <transaction_id> <tx_hash>
+            remaining = parts[1:]
+            api_key = _get_api_key(remaining[0] if remaining else None)
+            if api_key and remaining and remaining[0].startswith("crow_sk_"):
+                remaining = remaining[1:]
+            if len(remaining) < 2:
+                yield Message("system", "Usage: settle [api_key] <transaction_id> <tx_hash>")
                 return
-            api_key = parts[1]
-            txn_id = parts[2]
-            tx_hash = parts[3]
+            if not api_key:
+                yield Message("system", "No API key found. Set CROWPAY_API_KEY env var or pass as first argument.")
+                return
+            txn_id = remaining[0]
+            tx_hash = remaining[1]
             status, result = _http_post(f"{CROWPAY_BASE_URL}/settle", {"transactionId": txn_id, "txHash": tx_hash}, api_key)
             yield Message("system", f"Settlement ({status}):\n```json\n{json.dumps(result, indent=2)}\n```")
 
         else:
             yield Message("system", f"Unknown command: {cmd}. Use: setup, authorize, card, status, settle")
 
-    except Exception as e:
+    except (json.JSONDecodeError, ValueError) as e:
         yield Message("system", f"CrowPay error: {e}")
+    except Exception:
+        logger.exception("Unexpected error in CrowPay tool")
+        raise
 
 
 tool: ToolSpec = ToolSpec(
@@ -198,4 +245,5 @@ tool: ToolSpec = ToolSpec(
     examples=examples,
     execute=execute_crowpay,
     block_types=["crowpay"],
+    disabled_by_default=True,
 )


### PR DESCRIPTION
## What this adds

A new `crowpay` tool in `gptme/tools/crowpay.py` that gives gptme agents the ability to pay for APIs and services autonomously — within spending rules set by the wallet owner.

### Commands

- **`setup`** — Create a new agent wallet and API key
- **`authorize <key> <merchant> <reason>`** + 402 body on next line — Authorize an x402 payment (USDC on Base)
- **`card <key> <cents> <merchant> <reason>`** — Authorize a credit card payment
- **`status <key> <approval_id>`** — Poll for human approval status
- **`settle <key> <txn_id> <tx_hash>`** — Report x402 settlement

### How it works

[CrowPay](https://crowpay.ai) provides managed wallets for AI agents with built-in spending rules, human approval workflows, and audit trails. Supports:

- **x402 (USDC on Base)** — for APIs returning HTTP 402 Payment Required (like [Nightmarket](https://nightmarket.ai) services)
- **Credit card (Stripe)** — for merchants, subscriptions, and API credits

No wallet private keys are ever exposed to the agent. Default rules: auto-approve under $5, human approval above, $50/day limit.

### Usage

````
```crowpay
setup
```

```crowpay
authorize crow_sk_abc123 "WeatherAPI" "Fetching forecast"
{"x402Version": 2, "resource": {"url": "..."}, "accepts": [...]}
```
````

Registers as a `ToolSpec` with block type `crowpay`, following gptme's tool conventions. Uses only stdlib — no additional dependencies.