### PR TITLE
fix(util): fix parameter shadowing and add empty-list guards

### DIFF
--- a/gptme/util/cost.py
+++ b/gptme/util/cost.py
@@ -3,6 +3,9 @@ from . import console
 
 
 def _tokens_inout(msgs: list[Message]) -> tuple[int, int]:
+    if not msgs:
+        return 0, 0
+
     from ..llm.models import get_default_model  # fmt: skip
 
     model = get_default_model()
@@ -16,6 +19,8 @@ def _tokens_inout(msgs: list[Message]) -> tuple[int, int]:
 
 
 def _cost(msgs: list[Message]) -> float:
+    if not msgs:
+        return 0.0
     return sum(msg.cost() for msg in msgs[:-1]) + msgs[-1].cost(
         output=msgs[-1].role == "assistant"
     )

--- a/gptme/util/export.py
+++ b/gptme/util/export.py
@@ -5,10 +5,10 @@ from pathlib import Path
 from ..logmanager import Log
 
 
-def replace_or_fail(html: str, old: str, new: str, desc: str = "") -> str:
+def replace_or_fail(content: str, old: str, new: str, desc: str = "") -> str:
     """Replace a string and fail if nothing was replaced"""
-    result = html.replace(old, new)
-    if result == html:
+    result = content.replace(old, new)
+    if result == content:
         raise ValueError(f"Failed to replace {desc or old!r}")
     return result
 


### PR DESCRIPTION
## Summary

- **export.py**: Rename `html` parameter to `content` in `replace_or_fail()` to avoid shadowing the `html` module import (used for `html.escape()` on line 37)
- **cost.py**: Add early-return guards for empty message lists in `_tokens_inout()` and `_cost()` to prevent `IndexError` on `msgs[-1]`

## Test plan

- [x] All 27 cost tests pass
- [x] mypy typecheck passes on both files
- [x] No behavioral change — purely defensive improvements