### PR TITLE
feat(context): show context window utilization in /context command

### DIFF
--- a/gptme/commands/llm.py
+++ b/gptme/commands/llm.py
@@ -269,6 +269,32 @@ def cmd_context(ctx: CommandContext) -> None:
 
     console.log(f"\n[bold]Total Context:[/bold] {total_tokens:,} tokens")
 
+    # Show context window utilization if model info is available
+    if current_model and current_model.context > 0:
+        context_limit = current_model.context
+        remaining = max(0, context_limit - total_tokens)
+        utilization = (total_tokens / context_limit * 100) if context_limit > 0 else 0
+
+        # Color-code utilization: green < 50%, yellow 50-80%, red > 80%
+        if utilization > 80:
+            color = "red"
+        elif utilization > 50:
+            color = "yellow"
+        else:
+            color = "green"
+
+        console.log(
+            f"[bold]Context Window:[/bold] [{color}]{utilization:.0f}%[/{color}] "
+            f"used ({total_tokens:,} / {context_limit:,}), "
+            f"{remaining:,} remaining"
+        )
+        if current_model.max_output:
+            effective_remaining = max(0, remaining - current_model.max_output)
+            console.log(
+                f"[dim]  max output: {current_model.max_output:,} tokens, "
+                f"effective input capacity: {effective_remaining:,}[/dim]"
+            )
+
     if is_approximate:
         console.log(f"[dim](approximate, using {tokenizer_model} tokenizer)[/dim]")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -94,6 +94,15 @@ def test_command_tokens(args: list[str], runner: CliRunner):
     assert result.exit_code == 0
 
 
+def test_command_context(args: list[str], runner: CliRunner):
+    args.append("/context")
+    result = runner.invoke(cli.main, args)
+    assert "/context" in result.output
+    assert "Token Usage by Role:" in result.output
+    assert "Total Context:" in result.output
+    assert result.exit_code == 0
+
+
 def test_command_log(args: list[str], runner: CliRunner):
     args.append("/log")
     result = runner.invoke(cli.main, args)


### PR DESCRIPTION
## Summary

- Show context window utilization in the `/context` command with color-coded percentage (green <50%, yellow 50-80%, red >80%)
- Display remaining token capacity
- Show effective input capacity accounting for `max_output` reservation when model specifies it
- Add test for `/context` command (previously untested)

**Example output:**
```
Token Usage by Role:
  system    :  5,432 ( 45.2%)
  user      :  3,100 ( 25.8%)
  assistant :  3,488 ( 29.0%)

Total Context: 12,020 tokens
Context Window: 6% used (12,020 / 200,000), 187,980 remaining
  max output: 8,192 tokens, effective input capacity: 179,788
```

## Test plan

- [x] New `test_command_context` test passes
- [x] Existing `test_command_tokens` still passes
- [x] mypy typecheck passes
- [x] ruff lint + format passes
- [x] No behavioral change to existing output — only adds new lines
