### PR TITLE
feat(doctor): add version check and Playwright browser check

### DIFF
--- a/gptme/cli/doctor.py
+++ b/gptme/cli/doctor.py
@@ -415,30 +415,43 @@ def _check_version(verbose: bool = False) -> list[CheckResult]:
             try:
                 current_v = Version(current)
                 latest_v = Version(latest)
-                is_major = latest_v.major > current_v.major
-                is_minor = latest_v.minor > current_v.minor
-                severity = (
-                    CheckStatus.WARNING if (is_major or is_minor) else CheckStatus.OK
-                )
+                if latest_v <= current_v:
+                    # User is running a newer version than PyPI (pre-release, branch install)
+                    results.append(
+                        CheckResult(
+                            name="Version: gptme",
+                            status=CheckStatus.OK,
+                            message=f"Installed {current} (ahead of PyPI: {latest})",
+                        )
+                    )
+                else:
+                    is_major = latest_v.major > current_v.major
+                    is_minor = latest_v.minor > current_v.minor
+                    if is_major or is_minor:
+                        results.append(
+                            CheckResult(
+                                name="Version: gptme",
+                                status=CheckStatus.WARNING,
+                                message=f"Update available: {current} → {latest}",
+                                fix_hint="pip install --upgrade gptme",
+                            )
+                        )
+                    else:
+                        results.append(
+                            CheckResult(
+                                name="Version: gptme",
+                                status=CheckStatus.OK,
+                                message=f"Installed {current} (latest: {latest})",
+                                details="Patch update available" if verbose else None,
+                            )
+                        )
             except Exception:
-                severity = CheckStatus.WARNING
-
-            if severity == CheckStatus.WARNING:
                 results.append(
                     CheckResult(
                         name="Version: gptme",
                         status=CheckStatus.WARNING,
                         message=f"Update available: {current} → {latest}",
                         fix_hint="pip install --upgrade gptme",
-                    )
-                )
-            else:
-                results.append(
-                    CheckResult(
-                        name="Version: gptme",
-                        status=CheckStatus.OK,
-                        message=f"Installed {current} (latest: {latest})",
-                        details="Patch update available" if verbose else None,
                     )
                 )
     except Exception as e:
@@ -463,10 +476,13 @@ def _check_browser(verbose: bool = False) -> list[CheckResult]:
         return results
 
     # Check if browsers are installed by looking at the standard cache directory
-    # Playwright stores browsers in PLAYWRIGHT_BROWSERS_PATH or ~/.cache/ms-playwright
+    # Playwright stores browsers in PLAYWRIGHT_BROWSERS_PATH or a platform-specific default
     browsers_path = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
     if not browsers_path:
-        browsers_path = str(Path.home() / ".cache" / "ms-playwright")
+        if sys.platform == "darwin":
+            browsers_path = str(Path.home() / "Library" / "Caches" / "ms-playwright")
+        else:
+            browsers_path = str(Path.home() / ".cache" / "ms-playwright")
 
     browsers_dir = Path(browsers_path)
     if browsers_dir.exists():

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -119,6 +119,27 @@ class TestCheckVersion:
             assert "0.31.0" in results[0].message
             assert results[0].fix_hint is not None
 
+    @patch("gptme.cli.doctor.__version__", "0.32.0")
+    def test_current_ahead_of_pypi(self):
+        """Test that installed version newer than PyPI shows OK (no spurious warning)."""
+        import io
+        import json as json_mod
+
+        mock_resp = io.BytesIO(json_mod.dumps({"info": {"version": "0.31.0"}}).encode())
+        mock_cm = patch("urllib.request.urlopen")
+        with (
+            patch("importlib.metadata.version", return_value="0.32.0"),
+            mock_cm as mock_urlopen,
+        ):
+            mock_urlopen.return_value.__enter__ = lambda s: mock_resp
+            mock_urlopen.return_value.__exit__ = lambda s, *a: None
+
+            results = _check_version()
+            assert len(results) == 1
+            assert results[0].status == CheckStatus.OK
+            assert results[0].fix_hint is None
+            assert "0.32.0" in results[0].message
+
     @patch("gptme.cli.doctor.__version__", "0.31.0")
     def test_network_error_graceful(self):
         """Test that network errors are handled gracefully."""


### PR DESCRIPTION
## Summary

Adds two new diagnostic checks to `gptme-doctor`:

- **Version check**: Compares installed version against PyPI latest. Shows warning for minor/major updates, OK for patch updates. Gracefully handles dev installs (skips PyPI) and network errors.
- **Playwright browser check**: When the browser extra is installed, verifies that Playwright browsers are actually available. Common gotcha: users `pip install playwright` but forget `playwright install chromium`.

## Changes

- `gptme/cli/doctor.py`: Added `_check_version()` and `_check_browser()` functions, wired into `run_diagnostics()`
- `tests/test_doctor.py`: 8 new tests (5 for version, 3 for browser)

## Test plan

- [x] All 36 doctor tests pass (including 8 new)
- [x] mypy clean
- [x] ruff clean
- [x] Pre-commit hooks pass