### PR TITLE
feat(eval): add debug-type-error and find-and-fix eval tests

### DIFF
--- a/gptme/eval/suites/basic.py
+++ b/gptme/eval/suites/basic.py
@@ -204,7 +204,7 @@ def check_extract_exit(ctx):
 
 def check_debug_type_output(ctx):
     """Fixed config should produce Total: 90.0 (sum=100, discount=0.1, total=90.0)."""
-    return "90" in ctx.stdout
+    return "90.0" in ctx.stdout
 
 
 def check_debug_type_exit(ctx):
@@ -244,19 +244,27 @@ def check_find_fix_output(ctx):
 
 
 def check_find_fix_routes(ctx):
-    """routes.py should use fetch_user, not get_user."""
+    """routes.py should use fetch_user, not get_user (calls/imports, not comments)."""
+    import re
+
     content = ctx.files.get("routes.py", "")
     if isinstance(content, bytes):
         content = content.decode()
-    return "fetch_user" in content and "get_user" not in content
+    return "fetch_user" in content and not re.search(
+        r"\bget_user\s*\(|import\s+get_user", content
+    )
 
 
 def check_find_fix_report(ctx):
-    """report.py should use fetch_user, not get_user."""
+    """report.py should use fetch_user, not get_user (calls/imports, not comments)."""
+    import re
+
     content = ctx.files.get("report.py", "")
     if isinstance(content, bytes):
         content = content.decode()
-    return "fetch_user" in content and "get_user" not in content
+    return "fetch_user" in content and not re.search(
+        r"\bget_user\s*\(|import\s+get_user", content
+    )
 
 
 def check_find_fix_exit(ctx):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,9 +334,3 @@ exclude_also = [
 [build-system]
 requires = ["poetry-core>=2.0"]
 build-backend = "poetry.core.masonry.api"
-
-[dependency-groups]
-dev = [
-    "pytest>=9.0.2",
-    "pytest-timeout>=2.4.0",
-]


### PR DESCRIPTION
## Summary
- Add **debug-type-error** eval: agent must diagnose a TypeError from mixed types in a JSON config (strings where numbers expected), then fix the config file. Tests diagnostic reasoning across code + data files.
- Add **find-and-fix** eval: agent must find all callers of a deprecated function across multiple files and update them to use the replacement. Tests multi-file search and coordinated edits.

Both test real-world agent capabilities underrepresented in the existing suite (10 → 12 tests).

## Test plan
- [x] File parses correctly (`ast.parse`)
- [x] All 12 tests load (`from gptme.eval.suites.basic import tests`)
- [x] Check functions verified with simulated `ResultContext` — all pass on correct input
- [x] Expected outputs manually verified (Total: 90.0 for debug-type-error, Profile/User output for find-and-fix)
- [x] Pre-existing test suite unaffected (2 failures are pre-existing API auth issues)