### PR TITLE
feat(doctor): add MCP server health checks

### DIFF
--- a/gptme/cli/doctor.py
+++ b/gptme/cli/doctor.py
@@ -23,7 +23,7 @@ from rich.table import Table
 from rich.text import Text
 
 from ..__version__ import __version__
-from ..config import config_path, get_config
+from ..config import MCPServerConfig, config_path, get_config
 from ..info import get_config_info, get_installed_extras
 from ..llm import list_available_providers
 from ..llm.models import PROVIDERS
@@ -523,6 +523,142 @@ def _check_browser(verbose: bool = False) -> list[CheckResult]:
     return results
 
 
+def _check_mcp(verbose: bool = False) -> list[CheckResult]:
+    """Check MCP server configuration and connectivity."""
+    results: list[CheckResult] = []
+
+    config = get_config()
+
+    # Check if MCP is enabled
+    if not config.mcp.enabled:
+        results.append(
+            CheckResult(
+                name="MCP: Status",
+                status=CheckStatus.SKIPPED,
+                message="MCP not enabled",
+                fix_hint="Add [mcp] enabled = true to gptme.toml",
+            )
+        )
+        return results
+
+    results.append(
+        CheckResult(
+            name="MCP: Status",
+            status=CheckStatus.OK,
+            message=f"Enabled ({len(config.mcp.servers)} server(s) configured)",
+        )
+    )
+
+    if not config.mcp.servers:
+        return results
+
+    # Check each configured server
+    for server_config in config.mcp.servers:
+        if not server_config.enabled:
+            results.append(
+                CheckResult(
+                    name=f"MCP: {server_config.name}",
+                    status=CheckStatus.SKIPPED,
+                    message="Disabled in config",
+                )
+            )
+            continue
+
+        if server_config.is_http:
+            # HTTP server: check URL reachability
+            results.extend(_check_mcp_http_server(server_config, verbose))
+        else:
+            # stdio server: check command exists
+            results.extend(_check_mcp_stdio_server(server_config, verbose))
+
+    return results
+
+
+def _check_mcp_http_server(
+    server_config: MCPServerConfig, verbose: bool = False
+) -> list[CheckResult]:
+    """Check an HTTP-based MCP server."""
+    import urllib.request
+
+    try:
+        req = urllib.request.Request(
+            server_config.url,
+            method="HEAD",
+            headers=server_config.headers or {},
+        )
+        with urllib.request.urlopen(req, timeout=5):
+            pass
+        return [
+            CheckResult(
+                name=f"MCP: {server_config.name}",
+                status=CheckStatus.OK,
+                message="HTTP server reachable",
+                details=server_config.url if verbose else None,
+            )
+        ]
+    except Exception as e:
+        # Accept any HTTP response (even 4xx/5xx) as "reachable"
+        error_str = str(e)
+        if "HTTP Error" in error_str:
+            return [
+                CheckResult(
+                    name=f"MCP: {server_config.name}",
+                    status=CheckStatus.OK,
+                    message="HTTP server reachable",
+                    details=f"{server_config.url} ({error_str})" if verbose else None,
+                )
+            ]
+        return [
+            CheckResult(
+                name=f"MCP: {server_config.name}",
+                status=CheckStatus.ERROR,
+                message=f"Cannot reach server: {e}",
+                details=server_config.url if verbose else None,
+                fix_hint=f"Check that {server_config.url} is accessible",
+            )
+        ]
+
+
+def _check_mcp_stdio_server(
+    server_config: MCPServerConfig, verbose: bool = False
+) -> list[CheckResult]:
+    """Check a stdio-based MCP server."""
+    command = server_config.command
+    if not command:
+        return [
+            CheckResult(
+                name=f"MCP: {server_config.name}",
+                status=CheckStatus.ERROR,
+                message="No command configured",
+                fix_hint="Set 'command' in MCP server config",
+            )
+        ]
+
+    # Check if the command binary exists
+    cmd_path = shutil.which(command)
+    if cmd_path:
+        details = None
+        if verbose:
+            args_str = " ".join(server_config.args) if server_config.args else ""
+            details = f"{cmd_path} {args_str}".strip()
+        return [
+            CheckResult(
+                name=f"MCP: {server_config.name}",
+                status=CheckStatus.OK,
+                message=f"Command '{command}' found",
+                details=details,
+            )
+        ]
+    return [
+        CheckResult(
+            name=f"MCP: {server_config.name}",
+            status=CheckStatus.ERROR,
+            message=f"Command '{command}' not found",
+            fix_hint=f"Install {command} or check PATH",
+        )
+    ]
+
+
 def run_diagnostics(verbose: bool = False) -> tuple[list[CheckResult], dict]:
     """Run all diagnostic checks.
 
@@ -538,6 +674,7 @@ def run_diagnostics(verbose: bool = False) -> tuple[list[CheckResult], dict]:
     all_results.extend(_check_tools(verbose))
     all_results.extend(_check_python_deps(verbose))
     all_results.extend(_check_browser(verbose))
+    all_results.extend(_check_mcp(verbose))
     all_results.extend(_check_permissions(verbose))
 
     # Calculate summary

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -11,6 +11,7 @@ from gptme.cli.doctor import (
     _check_api_keys,
     _check_browser,
     _check_config,
+    _check_mcp,
     _check_permissions,
     _check_python_deps,
     _check_tools,
@@ -18,6 +19,7 @@ from gptme.cli.doctor import (
     main,
     run_diagnostics,
 )
+from gptme.config import MCPConfig, MCPServerConfig
 
 
 class TestCheckStatus:
@@ -552,3 +554,165 @@ class TestCheckApiKeys:
         auth_results = [r for r in results if r.name.startswith("Auth:")]
         assert len(auth_results) == 1
         assert auth_results[0].status == CheckStatus.OK
+
+
+class TestCheckMCP:
+    """Test _check_mcp function."""
+
+    @patch("gptme.cli.doctor.get_config")
+    def test_mcp_disabled(self, mock_config):
+        """Test that disabled MCP is reported as SKIPPED."""
+        mock_config.return_value.mcp = MCPConfig(enabled=False)
+
+        results = _check_mcp()
+        assert len(results) == 1
+        assert results[0].status == CheckStatus.SKIPPED
+        assert "not enabled" in results[0].message.lower()
+
+    @patch("gptme.cli.doctor.get_config")
+    def test_mcp_enabled_no_servers(self, mock_config):
+        """Test MCP enabled but no servers configured."""
+        mock_config.return_value.mcp = MCPConfig(enabled=True, servers=[])
+
+        results = _check_mcp()
+        assert len(results) == 1
+        assert results[0].status == CheckStatus.OK
+        assert "0 server(s)" in results[0].message
+
+    @patch("gptme.cli.doctor.get_config")
+    def test_mcp_disabled_server(self, mock_config):
+        """Test that disabled servers are reported as SKIPPED."""
+        server = MCPServerConfig(name="test-server", enabled=False, command="echo")
+        mock_config.return_value.mcp = MCPConfig(enabled=True, servers=[server])
+
+        results = _check_mcp()
+        assert len(results) == 2  # status + server
+        server_result = results[1]
+        assert server_result.status == CheckStatus.SKIPPED
+        assert "Disabled" in server_result.message
+
+    @patch("shutil.which", return_value="/usr/bin/npx")
+    @patch("gptme.cli.doctor.get_config")
+    def test_mcp_stdio_server_found(self, mock_config, mock_which):
+        """Test that stdio server with available command is OK."""
+        server = MCPServerConfig(
+            name="test-mcp", command="npx", args=["-y", "some-mcp-server"]
+        )
+        mock_config.return_value.mcp = MCPConfig(enabled=True, servers=[server])
+
+        results = _check_mcp()
+        server_result = [r for r in results if "test-mcp" in r.name][0]
+        assert server_result.status == CheckStatus.OK
+        assert "'npx' found" in server_result.message
+
+    @patch("shutil.which", return_value=None)
+    @patch("gptme.cli.doctor.get_config")
+    def test_mcp_stdio_server_not_found(self, mock_config, mock_which):
+        """Test that stdio server with missing command is ERROR."""
+        server = MCPServerConfig(name="test-mcp", command="nonexistent-binary")
+        mock_config.return_value.mcp = MCPConfig(enabled=True, servers=[server])
+
+        results = _check_mcp()
+        server_result = [r for r in results if "test-mcp" in r.name][0]
+        assert server_result.status == CheckStatus.ERROR
+        assert "not found" in server_result.message
+        assert server_result.fix_hint is not None
+
+    @patch("gptme.cli.doctor.get_config")
+    def test_mcp_stdio_server_no_command(self, mock_config):
+        """Test that stdio server with no command is ERROR."""
+        server = MCPServerConfig(name="test-mcp", command="")
+        mock_config.return_value.mcp = MCPConfig(enabled=True, servers=[server])
+
+        results = _check_mcp()
+        server_result = [r for r in results if "test-mcp" in r.name][0]
+        assert server_result.status == CheckStatus.ERROR
+        assert "No command" in server_result.message
+
+    @patch("urllib.request.urlopen")
+    @patch("gptme.cli.doctor.get_config")
+    def test_mcp_http_server_reachable(self, mock_config, mock_urlopen):
+        """Test that reachable HTTP server is OK."""
+        server = MCPServerConfig(name="remote-mcp", url="http://localhost:8080/mcp")
+        mock_config.return_value.mcp = MCPConfig(enabled=True, servers=[server])
+
+        # Mock successful HTTP response
+        mock_urlopen.return_value.__enter__ = lambda s: None
+        mock_urlopen.return_value.__exit__ = lambda s, *a: None
+
+        results = _check_mcp()
+        server_result = [r for r in results if "remote-mcp" in r.name][0]
+        assert server_result.status == CheckStatus.OK
+        assert "reachable" in server_result.message.lower()
+
+    @patch("urllib.request.urlopen", side_effect=ConnectionRefusedError("refused"))
+    @patch("gptme.cli.doctor.get_config")
+    def test_mcp_http_server_unreachable(self, mock_config, mock_urlopen):
+        """Test that unreachable HTTP server is ERROR."""
+        server = MCPServerConfig(name="remote-mcp", url="http://localhost:9999/mcp")
+        mock_config.return_value.mcp = MCPConfig(enabled=True, servers=[server])
+
+        results = _check_mcp()
+        server_result = [r for r in results if "remote-mcp" in r.name][0]
+        assert server_result.status == CheckStatus.ERROR
+        assert "Cannot reach" in server_result.message
+
+    @patch("urllib.request.urlopen")
+    @patch("gptme.cli.doctor.get_config")
+    def test_mcp_http_server_error_status_still_reachable(
+        self, mock_config, mock_urlopen
+    ):
+        """Test that HTTP errors (4xx/5xx) still count as reachable."""
+        from email.message import Message
+        from urllib.error import HTTPError
+
+        server = MCPServerConfig(name="remote-mcp", url="http://localhost:8080/mcp")
+        mock_config.return_value.mcp = MCPConfig(enabled=True, servers=[server])
+
+        mock_urlopen.side_effect = HTTPError(
+            "http://localhost:8080/mcp", 404, "Not Found", Message(), None
+        )
+
+        results = _check_mcp()
+        server_result = [r for r in results if "remote-mcp" in r.name][0]
+        assert server_result.status == CheckStatus.OK
+        assert "reachable" in server_result.message.lower()
+
+    @patch("shutil.which")
+    @patch("gptme.cli.doctor.get_config")
+    def test_mcp_multiple_servers(self, mock_config, mock_which):
+        """Test checking multiple MCP servers."""
+        servers = [
+            MCPServerConfig(name="server-a", command="npx", args=["-y", "mcp-a"]),
+            MCPServerConfig(name="server-b", command="missing-cmd"),
+        ]
+        mock_config.return_value.mcp = MCPConfig(enabled=True, servers=servers)
+
+        def which_side_effect(cmd):
+            return "/usr/bin/npx" if cmd == "npx" else None
+
+        mock_which.side_effect = which_side_effect
+
+        results = _check_mcp()
+        # 1 status + 2 servers
+        assert len(results) == 3
+
+        a_result = [r for r in results if "server-a" in r.name][0]
+        b_result = [r for r in results if "server-b" in r.name][0]
+        assert a_result.status == CheckStatus.OK
+        assert b_result.status == CheckStatus.ERROR
+
+    @patch("shutil.which", return_value="/usr/bin/npx")
+    @patch("gptme.cli.doctor.get_config")
+    def test_mcp_verbose_shows_details(self, mock_config, mock_which):
+        """Test that verbose mode shows command args."""
+        server = MCPServerConfig(
+            name="test-mcp", command="npx", args=["-y", "some-server"]
+        )
+        mock_config.return_value.mcp = MCPConfig(enabled=True, servers=[server])
+
+        results = _check_mcp(verbose=True)
+        server_result = [r for r in results if "test-mcp" in r.name][0]
+        assert server_result.details is not None
+        assert "npx" in server_result.details
+        assert "-y" in server_result.details


### PR DESCRIPTION
## Summary

- Adds MCP server configuration and connectivity checks to `gptme doctor`
- For stdio servers: verifies the command binary exists in PATH
- For HTTP servers: checks URL reachability (treats HTTP errors like 404 as "reachable" since the server is responding)
- Reports disabled MCP or disabled servers as SKIPPED with fix hints
- Verbose mode shows command paths, args, and URLs
- 11 new tests covering all scenarios (disabled, stdio found/missing, HTTP reachable/unreachable, multiple servers, verbose)

Example output with MCP configured:
```
MCP
 ✅  Status     Enabled (2 server(s) configured)
 ✅  my-server  Command 'npx' found
 ❌  broken     Command 'missing-binary' not found
```

## Test plan
- [x] All 48 doctor tests pass (37 existing + 11 new)
- [x] mypy clean
- [x] ruff check + format clean
- [x] Pre-commit hooks pass