### PR TITLE
feat(cli): add `--since` and `--json` flags to `gptme-util chats list`

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -3,9 +3,13 @@ CLI for gptme utility commands.
 """
 
 import io
+import json
 import logging
+import re
 import sys
+import time
 from contextlib import redirect_stderr
+from datetime import datetime, timezone
 from pathlib import Path
 
 import click
@@ -263,6 +267,20 @@ def mcp_search(query: str, registry: str, limit: int):
         click.echo(f"❌ Search failed: {e}")
 
 
+def _parse_since(since_str: str) -> float:
+    """Parse a human-readable duration string into a Unix timestamp cutoff.
+
+    Supports: Nh (hours), Nd (days), Nw (weeks).
+    Returns the timestamp representing ``now - duration``.
+    """
+    m = re.match(r"^(\d+)([hdw])$", since_str)
+    if not m:
+        raise click.BadParameter(f"Invalid duration '{since_str}'. Use e.g. 1h, 2d, 1w")
+    value, unit = int(m.group(1)), m.group(2)
+    multipliers = {"h": 3600, "d": 86400, "w": 604800}
+    return time.time() - value * multipliers[unit]
+
+
 @main.group()
 def chats():
     """Commands for managing chat logs."""
@@ -271,22 +289,57 @@ def chats():
 @chats.command("list")
 @click.option("-n", "--limit", default=20, help="Maximum number of chats to show.")
 @click.option(
+    "--since",
+    type=str,
+    default=None,
+    help="Only show chats modified within duration (e.g. 1h, 2d, 1w).",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+@click.option(
     "--summarize", is_flag=True, help="Generate LLM-based summaries for chats"
 )
-def chats_list(limit: int, summarize: bool):
+def chats_list(limit: int, since: str | None, as_json: bool, summarize: bool):
     """List conversation logs."""
     _ensure_tools()
     if summarize:
         from gptme.init import init  # fmt: skip
 
-        # This isn't the best way to initialize the model for summarization, but it works for now
         init(
             "openai/gpt-4o",
             interactive=False,
             tool_allowlist=[],
             tool_format="markdown",
         )
-    list_chats(max_results=limit, include_summary=summarize)
+
+    since_ts = _parse_since(since) if since else None
+
+    if as_json:
+        from gptme.logmanager import list_conversations  # fmt: skip
+
+        fetch_limit = limit * 10 if since_ts else limit
+        conversations = list_conversations(fetch_limit)
+        if since_ts:
+            conversations = [c for c in conversations if c.modified >= since_ts]
+        conversations = conversations[:limit]
+        result = [
+            {
+                "id": c.id,
+                "name": c.name,
+                "created": datetime.fromtimestamp(c.created, tz=timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z"),
+                "modified": datetime.fromtimestamp(c.modified, tz=timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z"),
+                "messages": c.messages,
+                "branches": c.branches,
+                "workspace": c.workspace,
+            }
+            for c in conversations
+        ]
+        print(json.dumps(result, indent=2))
+    else:
+        list_chats(max_results=limit, include_summary=summarize, since=since_ts)
 
 
 @chats.command("search")

--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -2,13 +2,18 @@
 List, search, and summarize past conversation logs.
 """
 
+from __future__ import annotations
+
 import logging
 import re
 import textwrap
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
-from ..message import Message
+if TYPE_CHECKING:
+    from ..logmanager import ConversationMeta
+    from ..message import Message
+
 from .base import ToolSpec, ToolUse
 
 logger = logging.getLogger(__name__)
@@ -27,26 +32,41 @@ def _get_matching_messages(
 
 
 def list_chats(
-    max_results: int = 5, metadata=False, include_summary: bool = False
-) -> None:
+    max_results: int = 5,
+    metadata=False,
+    include_summary: bool = False,
+    since: float | None = None,
+) -> list[ConversationMeta]:
     """
     List recent chat conversations and optionally summarize them using an LLM.
 
     Args:
-        max_results (int): Maximum number of conversations to display.
-        include_summary (bool): Whether to include a summary of each conversation.
-            If True, uses an LLM to generate a comprehensive summary.
-            If False, uses a simple strategy showing snippets of the first and last messages.
+        max_results: Maximum number of conversations to display.
+        include_summary: Whether to include a summary of each conversation.
+        since: Only include conversations modified after this Unix timestamp.
+
+    Returns:
+        List of matching ConversationMeta objects.
     """
     from ..llm import summarize  # fmt: skip
-    from ..logmanager import LogManager, list_conversations  # fmt: skip
+    from ..logmanager import (  # fmt: skip
+        LogManager,
+        list_conversations,
+    )
 
-    conversations = list_conversations(max_results)
+    # Fetch more when filtering by time, since many may be excluded
+    fetch_limit = max_results * 10 if since else max_results
+    conversations = list_conversations(fetch_limit)
+
+    if since:
+        conversations = [c for c in conversations if c.modified >= since]
+        conversations = conversations[:max_results]
+
     if not conversations:
         print("No conversations found.")
-        return
+        return []
 
-    print(f"Recent conversations (showing up to {max_results}):")
+    print(f"Recent conversations (showing {len(conversations)}):")
     for i, conv in enumerate(conversations, 1):
         if metadata:
             print()  # Add a newline between conversations
@@ -62,6 +82,8 @@ def list_chats(
                 f"\n    Summary:\n{textwrap.indent(summary.content, '    > ', predicate=lambda _: True)}"
             )
             print()
+
+    return conversations
 
 
 def search_chats(

--- a/tests/test_chats_list.py
+++ b/tests/test_chats_list.py
@@ -1,0 +1,203 @@
+"""Tests for the chats list command (--since and --json flags)."""
+
+import json
+import time
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from gptme.cli.util import _parse_since, chats_list
+from gptme.logmanager import ConversationMeta
+
+# --- Helpers ---
+
+
+def _make_conv(
+    id: str,
+    messages: int = 5,
+    created: float = 1000.0,
+    modified: float = 2000.0,
+) -> ConversationMeta:
+    return ConversationMeta(
+        id=id,
+        name=id,
+        path=f"/tmp/fake/{id}/conversation.jsonl",
+        created=created,
+        modified=modified,
+        messages=messages,
+        branches=1,
+        workspace="/tmp/workspace",
+    )
+
+
+# --- Unit tests for _parse_since ---
+
+
+def test_parse_since_hours():
+    """Parse hour durations."""
+    now = time.time()
+    result = _parse_since("1h")
+    assert abs(result - (now - 3600)) < 2
+
+
+def test_parse_since_days():
+    """Parse day durations."""
+    now = time.time()
+    result = _parse_since("3d")
+    assert abs(result - (now - 3 * 86400)) < 2
+
+
+def test_parse_since_weeks():
+    """Parse week durations."""
+    now = time.time()
+    result = _parse_since("2w")
+    assert abs(result - (now - 2 * 604800)) < 2
+
+
+def test_parse_since_invalid():
+    """Invalid duration raises BadParameter."""
+    from click import BadParameter
+
+    with pytest.raises(BadParameter, match="Invalid duration"):
+        _parse_since("invalid")
+
+
+def test_parse_since_invalid_unit():
+    """Unknown unit raises BadParameter."""
+    from click import BadParameter
+
+    with pytest.raises(BadParameter, match="Invalid duration"):
+        _parse_since("5x")
+
+
+# --- CLI integration tests ---
+
+
+@pytest.fixture
+def mock_conversations():
+    """Create mock conversations with varying timestamps."""
+    now = time.time()
+    return [
+        _make_conv("recent", modified=now - 1800),  # 30 min ago
+        _make_conv("today", modified=now - 7200),  # 2 hours ago
+        _make_conv("yesterday", modified=now - 90000),  # ~25 hours ago
+        _make_conv("old", modified=now - 604800),  # 1 week ago
+    ]
+
+
+def test_cli_list_limit(mock_conversations):
+    """--limit restricts number of results."""
+    runner = CliRunner()
+    with (
+        patch(
+            "gptme.logmanager.list_conversations", return_value=mock_conversations[:2]
+        ),
+        patch("gptme.cli.util._ensure_tools"),
+    ):
+        result = runner.invoke(chats_list, ["-n", "2", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 2
+
+
+def test_cli_list_json(mock_conversations):
+    """--json flag outputs valid JSON."""
+    runner = CliRunner()
+    with (
+        patch(
+            "gptme.logmanager.list_conversations", return_value=mock_conversations[:2]
+        ),
+        patch("gptme.cli.util._ensure_tools"),
+    ):
+        result = runner.invoke(chats_list, ["-n", "2", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 2
+        assert data[0]["id"] == "recent"
+        assert "created" in data[0]
+        assert "modified" in data[0]
+        assert "messages" in data[0]
+        assert data[0]["created"].endswith("Z")
+
+
+def test_cli_list_json_empty():
+    """--json with no conversations returns empty array."""
+    runner = CliRunner()
+    with (
+        patch("gptme.logmanager.list_conversations", return_value=[]),
+        patch("gptme.cli.util._ensure_tools"),
+    ):
+        result = runner.invoke(chats_list, ["--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data == []
+
+
+def test_cli_list_since(mock_conversations):
+    """--since filters conversations by modified time."""
+    runner = CliRunner()
+    with (
+        patch("gptme.logmanager.list_conversations", return_value=mock_conversations),
+        patch("gptme.cli.util._ensure_tools"),
+    ):
+        result = runner.invoke(chats_list, ["--since", "3h", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        ids = [c["id"] for c in data]
+        assert "recent" in ids
+        assert "today" in ids
+        assert "yesterday" not in ids
+        assert "old" not in ids
+
+
+def test_cli_list_since_1d(mock_conversations):
+    """--since 1d shows only conversations from last 24 hours."""
+    runner = CliRunner()
+    with (
+        patch("gptme.logmanager.list_conversations", return_value=mock_conversations),
+        patch("gptme.cli.util._ensure_tools"),
+    ):
+        result = runner.invoke(chats_list, ["--since", "1d", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        ids = [c["id"] for c in data]
+        assert "recent" in ids
+        assert "today" in ids
+        assert "yesterday" not in ids
+
+
+def test_cli_list_since_invalid():
+    """Invalid --since value shows error."""
+    runner = CliRunner()
+    with patch("gptme.cli.util._ensure_tools"):
+        result = runner.invoke(chats_list, ["--since", "abc"])
+        assert result.exit_code != 0
+        assert "Invalid duration" in result.output
+
+
+def test_cli_list_json_schema(mock_conversations):
+    """JSON output has expected schema fields."""
+    runner = CliRunner()
+    with (
+        patch(
+            "gptme.logmanager.list_conversations",
+            return_value=[mock_conversations[0]],
+        ),
+        patch("gptme.cli.util._ensure_tools"),
+    ):
+        result = runner.invoke(chats_list, ["--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 1
+        entry = data[0]
+        expected_keys = {
+            "id",
+            "name",
+            "created",
+            "modified",
+            "messages",
+            "branches",
+            "workspace",
+        }
+        assert set(entry.keys()) == expected_keys


### PR DESCRIPTION
## Summary

- Adds `--since <duration>` flag to filter conversations by modification time (e.g. `--since 1h`, `--since 2d`, `--since 1w`)
- Adds `--json` flag for machine-readable JSON output with ISO 8601 timestamps
- Refactors `list_chats()` to return `list[ConversationMeta]` so callers can format output flexibly

## Usage

```bash
# List conversations from last 24 hours
gptme-util chats list --since 1d

# JSON output for scripting (e.g. pipe to jq)
gptme-util chats list --json

# Combine both
gptme-util chats list --since 1w --json -n 50
```

## Test plan

- [x] 12 new tests: duration parsing (5), CLI integration (7)
- [x] Existing chats tests pass (29 tests in test_chats_clean + test_chats_export)
- [x] Pre-commit hooks pass
- [x] Manual testing: `--since`, `--json`, combined flags, error handling