### PR TITLE
refactor(message): nest token fields under `usage` in MessageMetadata

### DIFF
--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -16,7 +16,7 @@ from httpx import RemoteProtocolError
 from pydantic import BaseModel  # fmt: skip
 
 from ..constants import TEMPERATURE, TOP_P
-from ..message import Message, MessageMetadata, msgs2dicts
+from ..message import Message, MessageMetadata, UsageData, msgs2dicts
 from ..telemetry import record_llm_request
 from ..tools.base import ToolSpec
 from .models import ModelMeta, get_model
@@ -138,16 +138,21 @@ def _record_usage(
         cache_read_tokens=cache_read_tokens,
     )
 
+    # Build nested usage data
+    usage_data: UsageData = {}
+    if input_tokens is not None:
+        usage_data["input_tokens"] = input_tokens
+    if output_tokens is not None:
+        usage_data["output_tokens"] = output_tokens
+    if cache_read_tokens is not None:
+        usage_data["cache_read_tokens"] = cache_read_tokens
+    if cache_creation_tokens is not None:
+        usage_data["cache_creation_tokens"] = cache_creation_tokens
+
     # Return MessageMetadata for attachment to Message
     metadata: MessageMetadata = {"model": model}
-    if input_tokens is not None:
-        metadata["input_tokens"] = input_tokens
-    if output_tokens is not None:
-        metadata["output_tokens"] = output_tokens
-    if cache_read_tokens is not None:
-        metadata["cache_read_tokens"] = cache_read_tokens
-    if cache_creation_tokens is not None:
-        metadata["cache_creation_tokens"] = cache_creation_tokens
+    if usage_data:
+        metadata["usage"] = usage_data
     if cost > 0:
         metadata["cost"] = cost
     return metadata

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -13,7 +13,7 @@ from typing_extensions import NotRequired
 
 from ..config import Config, get_config
 from ..constants import TEMPERATURE, TOP_P
-from ..message import Message, MessageMetadata, msgs2dicts
+from ..message import Message, MessageMetadata, UsageData, msgs2dicts
 from ..telemetry import _calculate_llm_cost, record_llm_request
 from ..tools import ToolSpec
 from .models import (
@@ -155,14 +155,19 @@ def _record_usage(usage, model: str) -> MessageMetadata | None:
         cache_read_tokens=cache_read_tokens,
     )
 
+    # Build nested usage data
+    usage_data: UsageData = {}
+    if input_tokens is not None:
+        usage_data["input_tokens"] = input_tokens
+    if output_tokens is not None:
+        usage_data["output_tokens"] = output_tokens
+    if cache_read_tokens is not None:
+        usage_data["cache_read_tokens"] = cache_read_tokens
+
     # Return MessageMetadata for attachment to Message
     metadata: MessageMetadata = {"model": model}
-    if input_tokens is not None:
-        metadata["input_tokens"] = input_tokens
-    if output_tokens is not None:
-        metadata["output_tokens"] = output_tokens
-    if cache_read_tokens is not None:
-        metadata["cache_read_tokens"] = cache_read_tokens
+    if usage_data:
+        metadata["usage"] = usage_data
     if cost > 0:
         metadata["cost"] = cost
     return metadata

--- a/gptme/logmanager.py
+++ b/gptme/logmanager.py
@@ -36,7 +36,7 @@ from rich import print
 
 from .config import ChatConfig, get_project_config
 from .dirs import get_logs_dir
-from .message import Message, len_tokens, print_msg
+from .message import Message, _migrate_metadata, len_tokens, print_msg
 from .tools import ToolUse
 from .util.context import enrich_messages_with_context
 from .util.reduce import limit_log, reduce_log
@@ -911,4 +911,7 @@ def _gen_read_jsonl(path: PathLike) -> Generator[Message, None, None]:
             file_hashes = json_data.pop("file_hashes", {})
             if "timestamp" in json_data:
                 json_data["timestamp"] = isoparse(json_data["timestamp"])
+            # Migrate flat metadata format to nested usage format
+            if json_data.get("metadata"):
+                json_data["metadata"] = _migrate_metadata(json_data["metadata"])
             yield Message(**json_data, files=files, file_hashes=file_hashes)

--- a/gptme/message.py
+++ b/gptme/message.py
@@ -28,6 +28,19 @@ from .util.uri import URI, FilePath, parse_file_reference
 logger = logging.getLogger(__name__)
 
 
+class UsageData(TypedDict, total=False):
+    """Token usage data from LLM API responses.
+
+    Nested under ``usage`` in :class:`MessageMetadata` to mirror the structure
+    returned by LLM provider APIs (Anthropic, OpenAI, etc.).
+    """
+
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_creation_tokens: int
+
+
 class MessageMetadata(TypedDict, total=False):
     """
     Metadata stored with each message.
@@ -36,23 +49,54 @@ class MessageMetadata(TypedDict, total=False):
 
     Token/cost fields are populated for assistant messages when telemetry is enabled.
 
-    Uses flat token format (matches cost_tracker and common industry conventions):
+    Token counts are nested under ``usage`` to match LLM API response structure::
+
         {
             "model": "claude-sonnet",
-            "input_tokens": 100,
-            "output_tokens": 50,
-            "cache_read_tokens": 80,
-            "cache_creation_tokens": 10,
-            "cost": 0.005
+            "cost": 0.005,
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_read_tokens": 80,
+                "cache_creation_tokens": 10,
+            }
         }
     """
 
     model: str
-    input_tokens: int
-    output_tokens: int
-    cache_read_tokens: int
-    cache_creation_tokens: int
     cost: float  # Cost in USD
+    usage: UsageData
+
+
+_TOKEN_KEYS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_read_tokens",
+    "cache_creation_tokens",
+)
+
+
+def _migrate_metadata(meta: dict) -> MessageMetadata:
+    """Migrate flat token format to nested ``usage`` format.
+
+    Old format had token fields at the top level alongside ``model`` and ``cost``.
+    New format nests them under ``usage``.  This function detects the old format
+    and converts it, allowing transparent deserialization of old logs.
+    """
+    # Already migrated (or new format)
+    if "usage" in meta or not any(k in meta for k in _TOKEN_KEYS):
+        return MessageMetadata(**meta)
+
+    usage: UsageData = {}
+    remaining: dict = {}
+    for k, v in meta.items():
+        if k in _TOKEN_KEYS:
+            usage[k] = v  # type: ignore[literal-required]
+        else:
+            remaining[k] = v
+    if usage:
+        remaining["usage"] = usage
+    return MessageMetadata(**remaining)
 
 
 def _format_toml_value(value: object) -> str:
@@ -65,10 +109,15 @@ def _format_toml_value(value: object) -> str:
 
 
 def _format_metadata_toml(metadata: MessageMetadata) -> str:
-    """Format metadata as TOML inline table."""
+    """Format metadata as TOML inline table, handling nested ``usage``."""
     meta_items = []
     for k, v in metadata.items():
-        meta_items.append(f'"{k}" = {_format_toml_value(v)}')
+        if k == "usage" and isinstance(v, dict):
+            # Format usage as a nested inline table
+            usage_items = [f'"{uk}" = {_format_toml_value(uv)}' for uk, uv in v.items()]
+            meta_items.append(f'"usage" = {{ {", ".join(usage_items)} }}')
+        else:
+            meta_items.append(f'"{k}" = {_format_toml_value(v)}')
     return f"metadata = {{ {', '.join(meta_items)} }}"
 
 
@@ -181,7 +230,12 @@ class Message:
             d["call_id"] = self.call_id
         # Only serialize metadata if it has content (compact storage)
         if self.metadata:
-            d["metadata"] = dict(self.metadata)
+            meta_dict = dict(self.metadata)
+            # Ensure nested usage dict is also a plain dict (not tomlkit types)
+            usage = meta_dict.get("usage")
+            if isinstance(usage, dict):
+                meta_dict["usage"] = dict(usage)
+            d["metadata"] = meta_dict
         if keys:
             return {k: d[k] for k in keys if k in d}
         return d
@@ -290,10 +344,10 @@ timestamp = "{self.timestamp.isoformat()}"
         assert "message" in t and isinstance(t["message"], dict)
         msg: dict = t["message"]
 
-        # Parse metadata if present
+        # Parse metadata if present (migrate old flat format if needed)
         metadata: MessageMetadata | None = None
         if msg.get("metadata"):
-            metadata = MessageMetadata(**msg["metadata"])
+            metadata = _migrate_metadata(dict(msg["metadata"]))
 
         return cls(
             msg["role"],
@@ -476,7 +530,7 @@ def toml_to_msgs(toml: str) -> list[Message]:
             files=[parse_file_reference(f) for f in msg.get("files", [])],
             file_hashes=dict(msg.get("file_hashes", {})),
             call_id=msg.get("call_id"),
-            metadata=MessageMetadata(**msg["metadata"])
+            metadata=_migrate_metadata(dict(msg["metadata"]))
             if msg.get("metadata")
             else None,
         )

--- a/gptme/util/cost_display.py
+++ b/gptme/util/cost_display.py
@@ -98,10 +98,11 @@ def gather_conversation_costs(messages: list[Message]) -> CostData | None:
                 last_metadata = msg.metadata
                 request_count += 1
 
-            total_input += msg.metadata.get("input_tokens", 0)
-            total_output += msg.metadata.get("output_tokens", 0)
-            total_cache_read += msg.metadata.get("cache_read_tokens", 0)
-            total_cache_created += msg.metadata.get("cache_creation_tokens", 0)
+            usage = msg.metadata.get("usage", {})
+            total_input += usage.get("input_tokens", 0)
+            total_output += usage.get("output_tokens", 0)
+            total_cache_read += usage.get("cache_read_tokens", 0)
+            total_cache_created += usage.get("cache_creation_tokens", 0)
             total_cost += msg.metadata.get("cost", 0.0)
 
     # Check if we have any actual data
@@ -114,18 +115,20 @@ def gather_conversation_costs(messages: list[Message]) -> CostData | None:
 
     # Last request from metadata
     last_request = None
-    if last_metadata and (
-        last_metadata.get("input_tokens", 0) > 0
-        or last_metadata.get("output_tokens", 0) > 0
-        or last_metadata.get("cost", 0) > 0
-    ):
-        last_request = RequestCosts(
-            input_tokens=last_metadata.get("input_tokens", 0),
-            output_tokens=last_metadata.get("output_tokens", 0),
-            cache_read_tokens=last_metadata.get("cache_read_tokens", 0),
-            cache_creation_tokens=last_metadata.get("cache_creation_tokens", 0),
-            cost=last_metadata.get("cost", 0.0),
-        )
+    if last_metadata:
+        last_usage = last_metadata.get("usage", {})
+        if (
+            last_usage.get("input_tokens", 0) > 0
+            or last_usage.get("output_tokens", 0) > 0
+            or last_metadata.get("cost", 0) > 0
+        ):
+            last_request = RequestCosts(
+                input_tokens=last_usage.get("input_tokens", 0),
+                output_tokens=last_usage.get("output_tokens", 0),
+                cache_read_tokens=last_usage.get("cache_read_tokens", 0),
+                cache_creation_tokens=last_usage.get("cache_creation_tokens", 0),
+                cost=last_metadata.get("cost", 0.0),
+            )
 
     # Calculate cache hit rate
     total_input_with_cache = total_input + total_cache_read + total_cache_created

--- a/tests/test_cost_display.py
+++ b/tests/test_cost_display.py
@@ -32,11 +32,13 @@ def test_gather_conversation_costs_zero_metadata():
             role="assistant",
             content="hi",
             metadata={
-                "input_tokens": 0,
-                "output_tokens": 0,
-                "cache_read_tokens": 0,
-                "cache_creation_tokens": 0,
                 "cost": 0.0,
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_read_tokens": 0,
+                    "cache_creation_tokens": 0,
+                },
             },
         ),
     ]
@@ -52,11 +54,13 @@ def test_gather_conversation_costs_single_request():
             role="assistant",
             content="hi there",
             metadata={
-                "input_tokens": 100,
-                "output_tokens": 50,
-                "cache_read_tokens": 20,
-                "cache_creation_tokens": 10,
                 "cost": 0.005,
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cache_read_tokens": 20,
+                    "cache_creation_tokens": 10,
+                },
             },
         ),
     ]
@@ -80,9 +84,8 @@ def test_gather_conversation_costs_multiple_requests():
             role="assistant",
             content="hi",
             metadata={
-                "input_tokens": 100,
-                "output_tokens": 50,
                 "cost": 0.005,
+                "usage": {"input_tokens": 100, "output_tokens": 50},
             },
         ),
         Message(role="user", content="how are you?"),
@@ -90,9 +93,8 @@ def test_gather_conversation_costs_multiple_requests():
             role="assistant",
             content="fine",
             metadata={
-                "input_tokens": 200,
-                "output_tokens": 80,
                 "cost": 0.010,
+                "usage": {"input_tokens": 200, "output_tokens": 80},
             },
         ),
     ]
@@ -110,12 +112,18 @@ def test_gather_conversation_costs_last_request():
         Message(
             role="assistant",
             content="first",
-            metadata={"input_tokens": 100, "output_tokens": 50, "cost": 0.005},
+            metadata={
+                "cost": 0.005,
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            },
         ),
         Message(
             role="assistant",
             content="second",
-            metadata={"input_tokens": 200, "output_tokens": 80, "cost": 0.010},
+            metadata={
+                "cost": 0.010,
+                "usage": {"input_tokens": 200, "output_tokens": 80},
+            },
         ),
     ]
     result = gather_conversation_costs(msgs)
@@ -134,11 +142,13 @@ def test_gather_conversation_costs_cache_hit_rate():
             role="assistant",
             content="cached response",
             metadata={
-                "input_tokens": 50,
-                "output_tokens": 30,
-                "cache_read_tokens": 150,
-                "cache_creation_tokens": 0,
                 "cost": 0.003,
+                "usage": {
+                    "input_tokens": 50,
+                    "output_tokens": 30,
+                    "cache_read_tokens": 150,
+                    "cache_creation_tokens": 0,
+                },
             },
         ),
     ]
@@ -155,12 +165,18 @@ def test_gather_conversation_costs_user_metadata_counted():
         Message(
             role="user",
             content="hello",
-            metadata={"input_tokens": 50, "output_tokens": 0, "cost": 0.001},
+            metadata={
+                "cost": 0.001,
+                "usage": {"input_tokens": 50, "output_tokens": 0},
+            },
         ),
         Message(
             role="assistant",
             content="hi",
-            metadata={"input_tokens": 100, "output_tokens": 30, "cost": 0.005},
+            metadata={
+                "cost": 0.005,
+                "usage": {"input_tokens": 100, "output_tokens": 30},
+            },
         ),
     ]
     result = gather_conversation_costs(msgs)
@@ -179,7 +195,7 @@ def test_gather_conversation_costs_partial_metadata():
         Message(
             role="assistant",
             content="response",
-            metadata={"input_tokens": 100, "output_tokens": 50},
+            metadata={"usage": {"input_tokens": 100, "output_tokens": 50}},
             # No cache_read_tokens, cache_creation_tokens, or cost
         ),
     ]
@@ -247,17 +263,22 @@ def test_gather_conversation_costs_no_last_request_when_zero():
         Message(
             role="assistant",
             content="first",
-            metadata={"input_tokens": 100, "output_tokens": 50, "cost": 0.005},
+            metadata={
+                "cost": 0.005,
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            },
         ),
         Message(
             role="assistant",
             content="second",
             metadata={
-                "input_tokens": 0,
-                "output_tokens": 0,
-                "cache_read_tokens": 0,
-                "cache_creation_tokens": 0,
                 "cost": 0.0,
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_read_tokens": 0,
+                    "cache_creation_tokens": 0,
+                },
             },
         ),
     ]

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -213,30 +213,33 @@ def test_message_metadata():
 
     from gptme.message import Message, MessageMetadata
 
-    # Create message with metadata using flat token format
-    # Per Erik's review: https://github.com/gptme/gptme/pull/943#issuecomment-3633137716
+    # Create message with metadata using nested usage format
     meta: MessageMetadata = {
         "model": "claude-sonnet",
-        "input_tokens": 100,
-        "output_tokens": 50,
-        "cache_read_tokens": 80,
-        "cache_creation_tokens": 10,
         "cost": 0.005,
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_read_tokens": 80,
+            "cache_creation_tokens": 10,
+        },
     }
     msg = Message(role="assistant", content="Hello world", metadata=meta)
 
     # Verify metadata stored correctly
     assert msg.metadata is not None
     assert msg.metadata["model"] == "claude-sonnet"
-    assert msg.metadata["input_tokens"] == 100
-    assert msg.metadata["output_tokens"] == 50
-    assert msg.metadata["cache_read_tokens"] == 80
-    assert msg.metadata["cache_creation_tokens"] == 10
     assert msg.metadata["cost"] == 0.005
+    usage = msg.metadata["usage"]
+    assert usage["input_tokens"] == 100
+    assert usage["output_tokens"] == 50
+    assert usage["cache_read_tokens"] == 80
+    assert usage["cache_creation_tokens"] == 10
 
     # Test JSON/JSONL roundtrip
     d = msg.to_dict()
     assert "metadata" in d
+    assert "usage" in d["metadata"]
     json_str = json.dumps(d)
     json_data = json.loads(json_str)
     from dateutil.parser import isoparse
@@ -249,6 +252,64 @@ def test_message_metadata():
     toml_str = msg.to_toml()
     msg3 = Message.from_toml(toml_str)
     assert msg3.metadata == meta
+
+
+def test_message_metadata_migration():
+    """Test backward-compatible migration from flat to nested usage format."""
+    import json
+
+    from gptme.message import Message, _migrate_metadata
+
+    # Old flat format (as stored in existing logs)
+    flat_meta = {
+        "model": "claude-sonnet",
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cache_read_tokens": 80,
+        "cache_creation_tokens": 10,
+        "cost": 0.005,
+    }
+
+    # Migration should nest token fields under "usage"
+    migrated = _migrate_metadata(flat_meta)
+    assert migrated["model"] == "claude-sonnet"
+    assert migrated["cost"] == 0.005
+    assert "usage" in migrated
+    assert migrated["usage"]["input_tokens"] == 100
+    assert migrated["usage"]["output_tokens"] == 50
+    assert migrated["usage"]["cache_read_tokens"] == 80
+    assert migrated["usage"]["cache_creation_tokens"] == 10
+    # Flat token keys should NOT be at top level
+    assert "input_tokens" not in migrated
+    assert "output_tokens" not in migrated
+
+    # Already-migrated format should pass through unchanged
+    nested_meta = {
+        "model": "claude-sonnet",
+        "cost": 0.005,
+        "usage": {"input_tokens": 100, "output_tokens": 50},
+    }
+    migrated2 = _migrate_metadata(nested_meta)
+    assert migrated2 == nested_meta
+
+    # JSONL round-trip with old flat format should auto-migrate
+    old_json = json.dumps(
+        {
+            "role": "assistant",
+            "content": "Hello",
+            "timestamp": "2025-01-01T00:00:00",
+            "metadata": flat_meta,
+        }
+    )
+    from dateutil.parser import isoparse
+
+    json_data = json.loads(old_json)
+    json_data["timestamp"] = isoparse(json_data["timestamp"])
+    json_data["metadata"] = _migrate_metadata(json_data["metadata"])
+    msg = Message(**json_data)
+    assert msg.metadata is not None
+    assert "usage" in msg.metadata
+    assert msg.metadata["usage"]["input_tokens"] == 100
 
 
 def test_message_metadata_none():


### PR DESCRIPTION
## Summary

- Restructures `MessageMetadata` to nest token count fields (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`) under a `usage` sub-dict
- Matches LLM API response structure (both Anthropic and OpenAI return `usage` as a nested object)
- Keeps `cost` as a top-level derived field alongside `model`
- Adds `_migrate_metadata()` helper for backward-compatible deserialization of old flat-format logs

## Test plan

- [x] `pytest tests/test_message.py tests/test_cost_display.py -x` — all pass
- [x] `pytest tests/test_cost_tracker.py gptme/hooks/tests/test_cost_awareness.py -x` — all pass (no changes needed)
- [x] All pre-commit hooks pass (ruff, mypy, etc.)
- [ ] Manual: load an existing conversation with old-format metadata and verify costs display correctly