### PR TITLE
fix(release): don't block dev releases on flaky API test failures

### DIFF
--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -66,6 +66,8 @@ jobs:
             BASE=$(git merge-base "${LAST_TAG}" HEAD 2>/dev/null || echo "")
             if [ -n "$BASE" ]; then
               COMMITS_SINCE_TAG=$(git rev-list "${BASE}..HEAD" --count)
+            else
+              echo "WARNING: could not find merge-base for ${LAST_TAG} — commit count unavailable, treating as 0."
             fi
           fi
 


### PR DESCRIPTION
## Summary
- Switch CI preflight from check-suites to check-runs API, excluding "API tests" (flaky external deps) and "Scheduled Release" (this workflow's own runs). This was blocking dev releases when e.g. `anthropic/claude-haiku-4-5` API tests failed.
- Fix `LAST_TAG` detection to use `git tag --sort=-version:refname` instead of `git describe --tags --abbrev=0`, which can't find dev release tags on detached commits (version-bump commits aren't pushed to master).
- Use `merge-base` for commit counting to correctly handle detached tag commits.

### Context

Recent dev release failures:
- **March 9**: Skipped — preflight saw `failure` from "API tests with anthropic/claude-haiku-4-5" and blocked the release, even though all core tests passed.
- **March 2**: Failed — changelog was too large because `LAST_TAG` resolved to `v0.31.0` (3 months old) instead of the previous dev tag. This specific issue was fixed in #1567, but the preflight check still used the broken `git describe` approach.

## Test plan
- [ ] Trigger a manual workflow dispatch with `dev` type and verify it passes preflight even if API tests have failures on HEAD
- [ ] Verify the next scheduled run (Monday) creates a dev release successfully