### PR TITLE
feat(eval): add count-words and json-filter tests to basic suite

### DIFF
--- a/gptme/eval/suites/basic.py
+++ b/gptme/eval/suites/basic.py
@@ -296,9 +296,9 @@ def check_count_words_file(ctx):
 
 
 def check_count_words_output(ctx):
-    """Output should contain '17' on a line with 'words:'."""
+    """Output should contain '17' as a whole token on a line with 'words:'."""
     for line in ctx.stdout.splitlines():
-        if "words" in line.lower() and "17" in line:
+        if "words" in line.lower() and "17" in line.split():
             return True
     return False
 
@@ -740,7 +740,7 @@ tests: list["EvalSpec"] = [
             "Write a Python script wordcount.py that reads words.txt and prints "
             "the total number of words on a single line like: 'words: N'"
         ),
-        "tools": ["save", "shell"],
+        "tools": ["read", "save", "shell"],
         "expect": {
             "file exists": check_count_words_file,
             "correct output": check_count_words_output,


### PR DESCRIPTION
## Summary

- Adds `count-words` eval test: agent writes `wordcount.py` from scratch to read `words.txt` and print the word count in `words: N` format (17 words expected)
- Adds `json-filter` eval test: agent writes `filter.py` to read `data.json` and print names with `score >= 80`, sorted alphabetically (Alice, Carol, Eve)

Both tests cover common real-world scripting tasks — file I/O and JSON data filtering — that aren't yet represented in the basic suite.

## Test plan

- [ ] Verify Python syntax is valid (done locally: `ast.parse` passes)
- [ ] Run `gptme-eval --suite basic --tests count-words json-filter` to confirm agents pass the new evals
- [ ] Check that existing tests are unaffected