### PR TITLE
fix(precommit): run checks on modified files only in TURN_POST hook

### DIFF
--- a/gptme/tools/precommit.py
+++ b/gptme/tools/precommit.py
@@ -90,7 +90,6 @@ def run_checks_per_file() -> bool:
     Whether to support running pre-commit checks on each modified file immediately after save.
     Not always a good idea for multi-step/multi-file changes, so disabled by default.
     """
-    # TODO: also support checking only modified files in the full run after step complete?
     flag = get_config().get_env("GPTME_CHECK_PER_FILE", "false") or "false"
     return flag.lower() in (
         "1",
@@ -99,8 +98,50 @@ def run_checks_per_file() -> bool:
     )
 
 
-def run_precommit_checks() -> tuple[bool, str | None]:
-    """Run pre-commit checks on modified files and return output if there are issues.
+def _get_modified_files() -> list[str]:
+    """Get list of modified, staged, and untracked files in the git working tree.
+
+    Returns a combined list of:
+    - Modified files (tracked, with unstaged changes)
+    - Staged files (in the index, ready to commit)
+    - Untracked files (new files not yet tracked)
+    """
+    files: set[str] = set()
+    try:
+        # Modified (unstaged) + staged files
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            files.update(result.stdout.strip().splitlines())
+
+        # Untracked files (new files not yet added to git)
+        result = subprocess.run(
+            ["git", "ls-files", "--others", "--exclude-standard"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            files.update(result.stdout.strip().splitlines())
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        logger.debug("Failed to get modified files from git")
+
+    return sorted(files)
+
+
+def run_precommit_checks(*, all_files: bool = True) -> tuple[bool, str | None]:
+    """Run pre-commit checks and return output if there are issues.
+
+    Args:
+        all_files: If True, run on all files (``--all-files``).
+            If False, run only on modified/staged/untracked files.
+            Falls back to ``--all-files`` when no modified files are found.
 
     Pre-commit checks will run if either:
     1. GPTME_CHECK=true is set explicitly, or
@@ -116,8 +157,15 @@ def run_precommit_checks() -> tuple[bool, str | None]:
         logger.debug("Pre-commit checks not enabled")
         return False, None
 
-    # cmd = "pre-commit run --files $(git ls-files -m)"
-    cmd = ["pre-commit", "run", "--all-files"]
+    if all_files:
+        cmd = ["pre-commit", "run", "--all-files"]
+    else:
+        modified = _get_modified_files()
+        if modified:
+            cmd = ["pre-commit", "run", "--files", *modified]
+        else:
+            logger.debug("No modified files found, falling back to --all-files")
+            cmd = ["pre-commit", "run", "--all-files"]
     start_time = time.monotonic()
     logger.info(f"Running pre-commit checks: {' '.join(cmd)}")
     try:
@@ -299,8 +347,8 @@ def run_full_precommit_checks(
         return
 
     try:
-        # Run pre-commit checks on all files
-        success, failed_check_message = run_precommit_checks()
+        # Run pre-commit checks only on modified files (not --all-files)
+        success, failed_check_message = run_precommit_checks(all_files=False)
 
         if not success and failed_check_message:
             yield Message("system", failed_check_message, quiet=False)


### PR DESCRIPTION
## Summary

- The `TURN_POST` hook (`run_full_precommit_checks`) previously ran `pre-commit run --all-files`, which is wasteful in large repos when only a few files were modified during the agent's turn.
- Added `_get_modified_files()` helper that uses `git diff --name-only HEAD` + `git ls-files --others --exclude-standard` to find modified/staged/untracked files.
- `run_precommit_checks()` now accepts `all_files` kwarg; the TURN_POST hook passes `all_files=False` to check only changed files.
- The manual `/pre-commit` command still uses `--all-files` (explicit user action).
- Falls back to `--all-files` if no modified files are detected (defensive).
- Resolves the TODO at the former line 93 about supporting modified-files-only in the full run.

## Test plan

- [x] Imports work (`from gptme.tools.precommit import tool, _get_modified_files`)
- [x] `_get_modified_files()` correctly returns only modified files in a dirty worktree
- [x] mypy passes on the changed file (pre-existing error in `chats.py` is unrelated)
- [x] Pre-commit hooks pass
- [ ] CI passes