### PR TITLE
fix(eval): close file handle in SWEBenchInfo.save_to_log_dir

### DIFF
--- a/gptme/eval/swebench/info.py
+++ b/gptme/eval/swebench/info.py
@@ -56,4 +56,5 @@ class SWEBenchInfo:
         log_dir = Path(log_dir)
         swe_bench_info_file = log_dir / "swe_bench_info.json"
         swe_bench_info_file.parent.mkdir(parents=True, exist_ok=True)
-        json.dump(self.to_dict(), swe_bench_info_file.open("w"), indent=2)
+        with swe_bench_info_file.open("w") as f:
+            json.dump(self.to_dict(), f, indent=2)


### PR DESCRIPTION
## Summary
- Fix unclosed file descriptor in `SWEBenchInfo.save_to_log_dir()` — the file opened by `.open("w")` was passed directly to `json.dump()` without being closed, leaking the file descriptor
- Changed to use a `with` context manager for proper cleanup

## Test plan
- [x] Existing eval tests pass (this is a correctness fix, not a behavior change)
- [x] File is still written correctly (same `json.dump()` call, just wrapped in `with`)