### PR TITLE
fix(types): resolve mypy errors in chats tool and gh tests

### DIFF
--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -177,7 +177,7 @@ def _format_message_with_context(
         highlighted = f"{prefix}{context}{suffix}"
         highlighted = re.sub(
             re.escape(query),
-            lambda m: f"\033[1;31m{m.group(0)}\033[0m",
+            lambda m: "\033[1;31m" + str(m.group()) + "\033[0m",
             highlighted,
             flags=re.IGNORECASE,
         )

--- a/tests/test_util_gh.py
+++ b/tests/test_util_gh.py
@@ -56,6 +56,7 @@ def test_get_github_pr_content_real():
 
     if content is None:
         pytest.skip("gh CLI not available or request failed")
+    assert content is not None  # help mypy narrow type after skip
 
     # Should have basic PR info
     assert "feat: implement basic lesson system" in content
@@ -79,6 +80,7 @@ def test_get_github_pr_with_suggestions():
 
     if content is None:
         pytest.skip("gh CLI not available or request failed")
+    assert content is not None  # help mypy narrow type after skip
 
     # PR #687 has a suggestion from ellipsis-dev about using logger.exception
     if "```suggestion" in content or "Suggested change:" in content:
@@ -97,6 +99,7 @@ def test_gh_tool_read_pr():
     gh_tool = get_tool("gh")
     if gh_tool is None or gh_tool.execute is None:
         pytest.skip("gh tool not available")
+    assert gh_tool is not None and gh_tool.execute is not None
 
     # Test with a real PR
     result = gh_tool.execute(
@@ -136,6 +139,7 @@ def test_get_github_pr_content_with_unresolved():
 
     if content is None:
         pytest.skip("gh CLI not available or request failed")
+    assert content is not None  # help mypy narrow type after skip
 
     # Should have basic PR info
     assert "gptme-util" in content or "prompts" in content
@@ -156,6 +160,7 @@ def test_gh_tool_read_pr_invalid_url():
     gh_tool = get_tool("gh")
     if gh_tool is None or gh_tool.execute is None:
         pytest.skip("gh tool not available")
+    assert gh_tool is not None and gh_tool.execute is not None
 
     # Test with invalid URL
     result = gh_tool.execute(


### PR DESCRIPTION
## Summary
- **chats.py**: Fix `str-bytes-safe` mypy error in regex highlight lambda — `m.group(0)` in an f-string triggers the check because `re.Match.group()` is typed as potentially returning `bytes`. Wrapped with `str()` to satisfy the type checker while preserving behavior (input is always `str`).
- **test_util_gh.py**: Add `assert ... is not None` after `pytest.skip()` calls to help mypy narrow types. `pytest.skip()` raises but mypy doesn't always track it as `NoReturn`.

Resolves 14 of the 191 mypy errors in `make typecheck` (all non-import-stub errors).

## Test plan
- [x] `uv run mypy tests/test_util_gh.py gptme/tools/chats.py` — clean (no errors beyond missing import stubs)
- [ ] CI passes