### PR TITLE
fix: replace bare except clauses and unclosed file handle

### DIFF
--- a/scripts/describe_api.py
+++ b/scripts/describe_api.py
@@ -16,7 +16,8 @@ def main(filenames: list[str]) -> None:
 
     print("Here are API descriptions of the files:")
     for filename in filenames:
-        code = open(filename).read()
+        with open(filename) as f:
+            code = f.read()
         print(f"\n```{filename}\n{describe_api(code).strip()}\n```")
 
 

--- a/tests/test_tools_shell.py
+++ b/tests/test_tools_shell.py
@@ -811,7 +811,7 @@ try:
     devnull_stat = os.stat('/dev/null')
     is_devnull = (stdin_stat.st_dev == devnull_stat.st_dev and
                   stdin_stat.st_ino == devnull_stat.st_ino)
-except:
+except (OSError, AttributeError, ValueError):
     is_devnull = False
 
 if not is_devnull and not sys.stdin.isatty():
@@ -861,7 +861,7 @@ try:
     devnull_stat = os.stat('/dev/null')
     is_devnull = (stdin_stat.st_dev == devnull_stat.st_dev and
                   stdin_stat.st_ino == devnull_stat.st_ino)
-except:
+except (OSError, AttributeError, ValueError):
     is_devnull = False
 
 if not is_devnull and not sys.stdin.isatty():


### PR DESCRIPTION
## Summary
- Replace `except:` with `except (OSError, AttributeError):` in embedded test scripts (`test_tools_shell.py`) — bare excepts catch `SystemExit` and `KeyboardInterrupt` which can mask real issues
- Use context manager for file read in `scripts/describe_api.py` to prevent file descriptor leak

## Test plan
- [x] Relevant tests pass locally (`test_tools_shell.py` stdin/stderr redirect tests)
- [ ] CI passes