### PR TITLE
fix(tests): mark test_python tests as slow to fix flaky CI

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -260,6 +260,7 @@ def test_shell_file(args: list[str], runner: CliRunner):
     )
 
 
+@pytest.mark.slow
 def test_python(args: list[str], runner: CliRunner):
     args.append("/py print('yes')")
     result = runner.invoke(cli.main, args)
@@ -267,6 +268,7 @@ def test_python(args: list[str], runner: CliRunner):
     assert result.exit_code == 0
 
 
+@pytest.mark.slow
 def test_python_error(args: list[str], runner: CliRunner):
     args.append("/py raise Exception('yes')")
     result = runner.invoke(cli.main, args)


### PR DESCRIPTION
## Summary
- Mark `test_python` and `test_python_error` as `@pytest.mark.slow` since they initialize IPython which takes ~22s
- The "Test without API keys or extras" CI job uses a 10s timeout for non-slow tests, causing intermittent failures
- `test_block` (which also uses IPython) was already marked slow — these two were missed

## Test plan
- [x] Verified both tests take ~22s locally (well over 10s limit)
- [x] Confirmed `test_block` is already marked slow for the same reason
- [x] Pre-commit hooks pass