### PR TITLE
fix(server): replace assertions with explicit error checks in production code

### DIFF
--- a/gptme/server/acp_session_runtime.py
+++ b/gptme/server/acp_session_runtime.py
@@ -199,7 +199,9 @@ class AcpSessionRuntime:
                 proc.kill()
                 proc.wait(timeout=1.0)  # reap zombie after SIGKILL
             except Exception:
-                pass
+                logger.debug(
+                    "Failed to kill ACP subprocess after SIGTERM timeout", exc_info=True
+                )
         finally:
             # Clear references so the runtime is left in a consistent state.
             # Mirrors what close() does asynchronously; prevents accidental reuse.

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -513,9 +513,17 @@ async def _acp_step(
     - Tool confirmations are auto-approved inside the subprocess
     """
 
-    assert session.acp_runtime is not None, (
-        "acp_runtime must be set before calling _acp_step"
-    )
+    # Validate acp_runtime is set (use explicit check, not assert which python -O disables)
+    if session.acp_runtime is None:
+        logger.error(
+            "_acp_step called without acp_runtime for session %s", conversation_id
+        )
+        SessionManager.add_event(
+            conversation_id,
+            {"type": "error", "error": "Internal error: ACP runtime not initialized"},
+        )
+        session.generating = False
+        return
     acp_runtime = session.acp_runtime  # snapshot to avoid TOCTOU races
 
     logdir = get_logs_dir() / conversation_id
@@ -620,14 +628,26 @@ async def _acp_step(
             conversation_id,
         )
 
-        assert final_msg is not None, "pending_user_messages should not be empty"
-        SessionManager.add_event(
-            conversation_id,
-            {
-                "type": "generation_complete",
-                "message": msg2dict(final_msg, manager.workspace),
-            },
-        )
+        if final_msg is None:
+            # Should not happen: pending_user_messages was non-empty above, but
+            # guard explicitly instead of using assert (disabled by python -O).
+            logger.warning(
+                "ACP step produced no final message for conversation %s",
+                conversation_id,
+            )
+            no_msg_event: ErrorEvent = {
+                "type": "error",
+                "error": "ACP step completed but produced no assistant message",
+            }
+            SessionManager.add_event(conversation_id, no_msg_event)
+        else:
+            SessionManager.add_event(
+                conversation_id,
+                {
+                    "type": "generation_complete",
+                    "message": msg2dict(final_msg, manager.workspace),
+                },
+            )
     except Exception as e:
         logger.exception("Error during ACP step: %s", e)
         SessionManager.add_event(conversation_id, {"type": "error", "error": str(e)})
@@ -1234,9 +1254,13 @@ def api_conversation_step(conversation_id: str):
             workspace=chat_config.workspace,
         )
     else:
-        # model is guaranteed non-None here: the `if not model and not session.use_acp`
+        # model should be non-None here: the `if not model and not session.use_acp`
         # check above returns 400 for non-ACP sessions with no model.
-        assert model is not None, "model must be set for non-ACP sessions"
+        # Use explicit check instead of assert (which python -O disables).
+        if model is None:
+            return flask.jsonify(
+                {"error": "Model is required for non-ACP sessions"}
+            ), 400
         # Start step execution in a background thread
         # Model will be set in the worker thread by step()
         _start_step_thread(

--- a/gptme/server/openapi_docs.py
+++ b/gptme/server/openapi_docs.py
@@ -5,6 +5,7 @@ Simple decorator-based approach for existing function routes with automatic infe
 """
 
 import inspect
+import logging
 import re
 from collections.abc import Callable
 from typing import (
@@ -19,6 +20,8 @@ from flask import Blueprint, current_app, jsonify
 from pydantic import BaseModel, Field
 
 from gptme.__version__ import __version__
+
+logger = logging.getLogger(__name__)
 
 # Pydantic Models (auto-generate OpenAPI schemas)
 # -----------------------------------------------
@@ -273,6 +276,9 @@ def _infer_response_type(func: Callable) -> dict[int, type | None]:
 
         return {200: None}
     except Exception:
+        logger.debug(
+            "Failed to infer response type for %s", func.__name__, exc_info=True
+        )
         return {200: None}
 
 
@@ -298,6 +304,9 @@ def _infer_request_body(func: Callable) -> type[BaseModel] | None:
 
         return None
     except Exception:
+        logger.debug(
+            "Failed to infer request body for %s", func.__name__, exc_info=True
+        )
         return None
 
 
@@ -364,7 +373,9 @@ def _infer_parameters(func: Callable, rule_string: str) -> list[dict[str, Any]]:
                     }
                 )
     except Exception:
-        pass
+        logger.debug(
+            "Failed to infer query parameters for %s", func.__name__, exc_info=True
+        )
 
     return parameters
 
@@ -526,8 +537,10 @@ def _generate_schemas(model_classes: set[type[BaseModel]]) -> dict[str, Any]:
                 # Remove $defs from main schema since we've promoted them
                 del schema["$defs"]
 
-        except Exception as e:
-            print(f"Warning: Could not generate schema for {cls.__name__}: {e}")
+        except Exception:
+            logger.warning(
+                "Could not generate schema for %s", cls.__name__, exc_info=True
+            )
 
     return all_schemas
 


### PR DESCRIPTION
## Summary

- Replace 3 `assert` statements in `api_v2_sessions.py` with explicit error checks that raise proper HTTP errors or handle conditions gracefully. Python's `-O` flag disables assertions, making them unreliable for production error handling (see existing pattern at `api.py` line 299).
- Add `logger.debug()` to silent `except Exception: pass` handlers in `acp_session_runtime.py` and `openapi_docs.py` so errors are at least visible when debug logging is enabled.
- Replace a bare `print()` warning in `openapi_docs.py` with `logger.warning()` for consistent logging.

### Changes by file

**`api_v2_sessions.py`**:
- `assert session.acp_runtime is not None` -> explicit None check with error event + early return
- `assert final_msg is not None` -> explicit None check with warning log + error event
- `assert model is not None` -> explicit None check returning 400

**`acp_session_runtime.py`**:
- `except Exception: pass` in `terminate_subprocess_sync()` -> `logger.debug()` with exc_info

**`openapi_docs.py`**:
- Added `logging` import and `logger` instance
- 3 silent `except Exception` handlers -> `logger.debug()` with exc_info
- `print(f"Warning: ...")` -> `logger.warning()` with exc_info

## Test plan
- [x] `pytest tests/test_server.py` passes (16 passed, 1 xfailed)
- [x] `mypy` clean on all changed files (only pre-existing import-not-found errors from missing stubs)
- [x] `ruff format` applied via pre-commit