### PR TITLE
feat(chat): add GPTME_MAX_STEPS and GPTME_CONTEXT_LENGTH env vars

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -288,6 +288,16 @@ def _process_message_conversation(
 
     Note: Confirmation is now handled within ToolUse.execute() using the hook system.
     """
+    max_steps: int | None = None
+    max_steps_str = os.environ.get("GPTME_MAX_STEPS")
+    if max_steps_str:
+        try:
+            max_steps = int(max_steps_str)
+        except ValueError:
+            logger.warning(
+                f"Invalid GPTME_MAX_STEPS value: {max_steps_str!r}, ignoring"
+            )
+    step_count = 0
 
     while True:
         try:
@@ -349,6 +359,15 @@ def _process_message_conversation(
                     daemon=True,
                 )
                 thread.start()
+
+        # Check step limit (GPTME_MAX_STEPS)
+        step_count += 1
+        if max_steps is not None and step_count >= max_steps:
+            console.log(f"Reached max steps limit ({max_steps}), stopping.")
+            manager.append(
+                Message("system", f"Stopped: reached max steps limit ({max_steps})")
+            )
+            break
 
         # Check if there are any runnable tools left
         last_content = next(

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -1,5 +1,7 @@
 import atexit
 import logging
+import os
+from dataclasses import replace
 from typing import cast
 
 from dotenv import load_dotenv
@@ -115,7 +117,23 @@ def init_model(
     model_full = f"{provider}/{model_name}"
     console.log(f"Using model: [green]{model_full}[/green]")
     init_llm(provider)
-    set_default_model(model_full)
+
+    model_meta = get_model(model_full)
+
+    # Apply GPTME_CONTEXT_LENGTH override (useful for local models with non-standard context)
+    context_length_str = os.environ.get("GPTME_CONTEXT_LENGTH")
+    if context_length_str:
+        try:
+            context_length = int(context_length_str)
+        except ValueError:
+            logger.warning(
+                f"Invalid GPTME_CONTEXT_LENGTH value: {context_length_str!r}, ignoring"
+            )
+        else:
+            model_meta = replace(model_meta, context=context_length)
+            logger.info(f"Context length overridden to {context_length} tokens")
+
+    set_default_model(model_meta)
 
 
 def init_logging(verbose):


### PR DESCRIPTION
## Summary

- **`GPTME_MAX_STEPS`**: Limits the number of response-action steps per prompt. When the limit is reached, a system message is appended and the turn ends. Useful for bounding autonomous runs (e.g. refactoring tasks with local inference).
- **`GPTME_CONTEXT_LENGTH`**: Overrides the model's context window size (in tokens). Applied after model init so it takes precedence. Useful for local models served with non-standard context lengths (e.g. 32k with llama.cpp).

Both are env-var-only to keep the CLI surface clean. Usage:

```bash
# Limit to 10 steps per prompt
GPTME_MAX_STEPS=10 gptme -n 'refactor the auth module'

# Override context length for a local 32k model
GPTME_CONTEXT_LENGTH=32000 gptme -m local/llama-3-8b 'explain this code'
```

Requested by Markus Borg's PhD student for research refactoring runs.

## Test plan
- [x] Existing tests pass
- [x] Pre-commit hooks pass (ruff, mypy, etc.)
- [ ] CI passes