### PR TITLE
fix(llm): prevent double-wrapped <think> tags when both reasoning mechanisms fire

### DIFF
--- a/gptme/llm/llm_openai_subscription.py
+++ b/gptme/llm/llm_openai_subscription.py
@@ -607,6 +607,11 @@ def stream(
         raise ValueError(f"Codex API error {response.status_code}: {error_text}")
 
     in_reasoning_block = False
+    # Track whether this stream uses structured reasoning.delta events.
+    # When true, skip <thinking>→<think> text conversion to avoid double-wrapping:
+    # gpt-5.4 can emit BOTH response.reasoning.delta AND raw <thinking> tags in
+    # output_text.delta for the same content, causing <think><think>...</think></think>.
+    seen_reasoning_delta = False
     # Buffer to detect tags split across SSE chunks (max tag length is ~11 chars)
     pending = ""
 
@@ -628,6 +633,7 @@ def stream(
             # Structured reasoning content — wrap in <think> blocks
             delta_text = data.get("delta", "")
             if delta_text:
+                seen_reasoning_delta = True
                 if not in_reasoning_block:
                     # Flush any pending partial-tag buffer before opening think block
                     if pending:
@@ -641,7 +647,10 @@ def stream(
 
         elif event_type == "response.output_text.delta":
             # Text output — close any open reasoning block first, then handle
-            # <thinking> tags that some models emit as plain text
+            # <thinking> tags that some models emit as plain text.
+            # Only convert <thinking> tags when no structured reasoning.delta was seen —
+            # if both mechanisms fire (gpt-5.4 emits both), skip text conversion to
+            # avoid double-wrapping <think><think>...</think></think>.
             if in_reasoning_block:
                 yield "\n</think>\n"
                 in_reasoning_block = False
@@ -652,24 +661,25 @@ def stream(
                 text = pending + delta_text
                 pending = ""
 
-                # Hold back potential partial tag suffix to check in next chunk.
-                # A trailing `<` is buffered because it could be the start of either
-                # `<thinking>` or `</thinking>`; it will be re-evaluated on the next chunk.
-                match_found = False
-                for tag in ("<thinking>", "</thinking>"):
-                    for i in range(len(tag) - 1, 0, -1):
-                        if text.endswith(tag[:i]):
-                            pending = text[-i:]
-                            text = text[:-i]
-                            match_found = True
+                if not seen_reasoning_delta:
+                    # Hold back potential partial tag suffix to check in next chunk.
+                    # A trailing `<` is buffered because it could be the start of either
+                    # `<thinking>` or `</thinking>`; it will be re-evaluated on the next chunk.
+                    match_found = False
+                    for tag in ("<thinking>", "</thinking>"):
+                        for i in range(len(tag) - 1, 0, -1):
+                            if text.endswith(tag[:i]):
+                                pending = text[-i:]
+                                text = text[:-i]
+                                match_found = True
+                                break
+                        if match_found:
                             break
-                    if match_found:
-                        break
 
-                # Convert <thinking>/<\/thinking> to <think>/<\/think>
-                text = text.replace("<thinking>", "<think>").replace(
-                    "</thinking>", "</think>"
-                )
+                    # Convert <thinking>/<\/thinking> to <think>/<\/think>
+                    text = text.replace("<thinking>", "<think>").replace(
+                        "</thinking>", "</think>"
+                    )
                 if text:
                     yield text
 

--- a/tests/test_llm_openai_subscription.py
+++ b/tests/test_llm_openai_subscription.py
@@ -1,0 +1,121 @@
+import json
+from typing import Any
+from unittest.mock import patch
+
+from gptme.llm.llm_openai_subscription import SubscriptionAuth, stream
+from gptme.message import Message
+
+
+class _FakeSSEStreamResponse:
+    def __init__(self, events: list[dict[str, Any]]) -> None:
+        self.status_code = 200
+        self.text = ""
+        self._events = events
+
+    def iter_lines(self):  # type: ignore[no-untyped-def]
+        for event in self._events:
+            yield f"data: {json.dumps(event)}".encode()
+
+
+def _run_stream(events: list[dict[str, Any]]) -> str:
+    auth = SubscriptionAuth(
+        access_token="test-token",
+        refresh_token=None,
+        account_id="test-account",
+        expires_at=9_999_999_999.0,
+    )
+    response = _FakeSSEStreamResponse(events)
+
+    with (
+        patch("gptme.llm.llm_openai_subscription.get_auth", return_value=auth),
+        patch("gptme.llm.llm_openai_subscription.requests.post", return_value=response),
+    ):
+        return "".join(stream([Message(role="user", content="hello")], "gpt-5.4"))
+
+
+def test_stream_wraps_reasoning_and_closes_before_text():
+    output = _run_stream(
+        [
+            {"type": "response.reasoning.delta", "delta": "Need a command"},
+            {"type": "response.output_text.delta", "delta": "Done."},
+            {"type": "response.done"},
+        ]
+    )
+
+    assert output == "<think>\nNeed a command\n</think>\nDone."
+
+
+def test_stream_converts_split_thinking_tags_across_chunks():
+    output = _run_stream(
+        [
+            {"type": "response.output_text.delta", "delta": "Before <thi"},
+            {"type": "response.output_text.delta", "delta": "nking>reason"},
+            {"type": "response.output_text.delta", "delta": "ing</think"},
+            {"type": "response.output_text.delta", "delta": "ing> after"},
+            {"type": "response.done"},
+        ]
+    )
+
+    assert output == "Before <think>reasoning</think> after"
+
+
+def test_stream_ignores_output_text_done_to_avoid_duplicate_text():
+    output = _run_stream(
+        [
+            {"type": "response.output_text.delta", "delta": "Hello"},
+            {"type": "response.output_text.done", "text": "Hello"},
+            {"type": "response.done"},
+        ]
+    )
+
+    assert output == "Hello"
+
+
+def test_stream_closes_reasoning_before_function_call_output():
+    output = _run_stream(
+        [
+            {"type": "response.reasoning.delta", "delta": "Need save"},
+            {
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "function_call",
+                    "name": "save",
+                    "call_id": "call_1",
+                },
+            },
+            {
+                "type": "response.function_call_arguments.delta",
+                "delta": '{"path":"x.txt"}',
+            },
+            {"type": "response.done"},
+        ]
+    )
+
+    assert output == '<think>\nNeed save\n</think>\n\n@save(call_1): {"path":"x.txt"}'
+
+
+def test_stream_no_double_wrap_when_both_mechanisms_fire():
+    """Regression: gpt-5.4 can emit BOTH response.reasoning.delta AND raw <thinking>
+    tags in output_text.delta for the same content. Without the fix this produces
+    nested <think><think>...</think></think> double-wrapping.
+    """
+    output = _run_stream(
+        [
+            # Structured reasoning events — open the <think> block
+            {"type": "response.reasoning.delta", "delta": "Need a command"},
+            # Model ALSO echoes reasoning as raw <thinking> in text output (gpt-5.4 bug).
+            # The text conversion must be skipped to avoid double-wrapping.
+            {
+                "type": "response.output_text.delta",
+                "delta": "<thinking>Need a command</thinking>",
+            },
+            {"type": "response.output_text.delta", "delta": "Done."},
+            {"type": "response.done"},
+        ]
+    )
+
+    # Should produce exactly one <think> block, not nested <think><think>
+    assert "<think><think>" not in output
+    assert output.count("<think>") == 1
+    assert output.count("</think>") == 1
+    assert "Done." in output


### PR DESCRIPTION
## Problem

After #1685, gpt-5.4 still produced malformed output with nested \`<think>\` tags:

\`\`\`
<think>       <think>
The user is asking me to finish...
</think>        </think>
\`\`\`

This caused the autoresearch agent to loop repeatedly outputting thinking without making tool calls (gptme's parser saw the malformed tags and couldn't extract a tool call).

## Root Cause

gpt-5.4 emits reasoning content through **both** mechanisms simultaneously:
1. \`response.reasoning.delta\` SSE events → the #1685 handler wraps in \`<think>\` blocks
2. Raw \`<thinking>\` tags in \`response.output_text.delta\` → the #1685 handler converts to \`<think>\`

When both fire for the same content, both layers apply and produce double-wrapped output.

## Fix

Track \`seen_reasoning_delta\` per stream. When any \`response.reasoning.delta\` event is received, skip the \`<thinking>\`→\`<think>\` text conversion in \`output_text.delta\` — the structured reasoning.delta path is authoritative.

This is mutually exclusive by design:
- Models using \`reasoning.delta\`: \`seen_reasoning_delta=True\`, text conversion skipped
- Models only using \`<thinking>\` tags in text: \`seen_reasoning_delta=False\`, text conversion still applies (unchanged behavior)

## Test

Added \`test_stream_no_double_wrap_when_both_mechanisms_fire\` to the subscription test suite, which fails before this fix and passes after.

Closes #1684 (partial — addresses the thinking-tag leak; other subtasks remain)