### PR TITLE
fix(codeblock): handle </thinking> end tag from gemini models

### DIFF
--- a/gptme/codeblock.py
+++ b/gptme/codeblock.py
@@ -103,15 +103,19 @@ def _extract_codeblocks(
     This handles nested cases where ``` appears inside string literals or other content.
     """
     # dont extract codeblocks from thinking blocks
-    # (since claude sometimes forgets to close codeblocks in its thinking)
-    think_end = markdown.find("</think>")
-    if think_end != -1:
-        # remove anything before and including </think> if it exists
-        markdown = markdown[think_end + len("</think>") :]
+    # (since claude sometimes forgets to close codeblocks in its thinking,
+    #  and gemini uses </thinking> instead of </think>)
+    for _think_end_tag in ["</thinking>", "</think>"]:
+        _think_end = markdown.find(_think_end_tag)
+        if _think_end != -1:
+            # remove anything before and including the closing thinking tag
+            markdown = markdown[_think_end + len(_think_end_tag) :]
+            break
     else:
-        # if start <think> tag but no end, early exit
-        if "<think>" in markdown:
-            return
+        # if start thinking tag but no end, early exit
+        for _think_start_tag in ["<thinking>", "<think>"]:
+            if _think_start_tag in markdown:
+                return
 
     # speed check (early exit): check if message contains a code block
     # Check for at least 2 fence markers (3+ backticks each)

--- a/tests/test_codeblock.py
+++ b/tests/test_codeblock.py
@@ -1265,3 +1265,37 @@ def test_mismatched_fence_lengths():
     markdown3 = "```text\nline 1\n````"
     blocks3 = Codeblock.iter_from_markdown(markdown3)
     assert len(blocks3) == 0
+
+
+def test_thinking_block_with_closing_thinking_tag():
+    """
+    Gemini uses </thinking> (not </think>) to close thinking blocks.
+    _extract_codeblocks should handle both tags so that save/execute blocks
+    after the thinking block are not swallowed by an unclosed nesting level.
+
+    Regression test for: autoresearch practical5 plateau where gemini-2.0-flash-001
+    wraps reasoning in ```thinking>...</thinking> and the save block after it was
+    never executed because </thinking> was not stripped.
+    """
+    markdown = "```thinking>\nsome model reasoning here\n</thinking>\n```save pipeline.py\nprint('hello')\n```"
+    blocks = list(_extract_codeblocks(markdown))
+    # The save block after </thinking> should be extracted
+    assert len(blocks) == 1
+    assert blocks[0].lang.startswith("save")
+    assert "print('hello')" in blocks[0].content
+
+
+def test_thinking_block_with_closing_think_tag():
+    """Existing </think> tag variant still works after refactor."""
+    markdown = "<think>\nsome thinking\n</think>\n```save result.py\nx = 1\n```"
+    blocks = list(_extract_codeblocks(markdown))
+    assert len(blocks) == 1
+    assert blocks[0].lang.startswith("save")
+    assert "x = 1" in blocks[0].content
+
+
+def test_thinking_block_unclosed_thinking_tag_early_exit():
+    """Unclosed <thinking> tag (no </thinking>) should cause early exit — no blocks extracted."""
+    markdown = "<thinking>\nmodel is still reasoning...\n```save pipeline.py\nprint('hello')\n```"
+    blocks = list(_extract_codeblocks(markdown))
+    assert len(blocks) == 0


### PR DESCRIPTION
## Summary

- Fixes `_extract_codeblocks` to handle `</thinking>` end tag (used by Gemini models) in addition to `</think>` (used by Claude/DeepSeek)
- Also handles `<thinking>` start tag for the unclosed-block early-exit path
- Adds 3 regression tests

## Root cause

Confirmed via autoresearch eval logs: when `gemini-2.0-flash-001` is used as the eval model, it wraps reasoning in backtick-fenced ` ```thinking> ` blocks closing with `</thinking>`. The `_extract_codeblocks` function only stripped `</think>`, so `</thinking>` left the "thinking block" unclosed. Any subsequent ` ```save ` or ` ```python ` block was treated as nested (nesting depth > 0) and never yielded.

**Effect on practical5 evals**: `data-pipeline` and `regex-scrub` always scored 0 with gemini as eval model — the agent generated correct code but the save block was silently swallowed.

## Fix

Check for `</thinking>` before `</think>` (first match wins), and check for both `<thinking>` and `<think>` in the early-exit path for unclosed thinking blocks.

## Test plan

- [x] `test_thinking_block_with_closing_thinking_tag` — gemini-style `</thinking>`, save block is extracted
- [x] `test_thinking_block_with_closing_think_tag` — existing `</think>` behavior preserved  
- [x] `test_thinking_block_unclosed_thinking_tag_early_exit` — unclosed `<thinking>` still causes early exit
- [x] Full `tests/test_codeblock.py` suite: 49/49 passing