### PR TITLE
fix(xml): handle Gemini tool_code codeblock format in XML mode

### DIFF
--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -403,6 +403,52 @@ class ToolSpec:
         return "None"
 
 
+def _extract_tool_code_blocks(content: str) -> list[tuple[str, int]]:
+    """Extract content of ```tool_code blocks, returning (block_content, start_pos) pairs.
+
+    Handles nested code fences (e.g. ```python inside the block) correctly by
+    tracking fence depth rather than using a simple regex that terminates at the
+    first ``` occurrence.
+    """
+    results = []
+    lines = content.split("\n")
+    pos = 0  # Track byte position for start= field
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.rstrip() == "```tool_code":
+            block_start = pos
+            i += 1
+            pos += len(line) + 1  # +1 for the \n
+            depth = 0
+            block_lines: list[str] = []
+            while i < len(lines):
+                inner = lines[i]
+                stripped = inner.strip()
+                if stripped.startswith("```"):
+                    if stripped == "```":
+                        if depth == 0:
+                            # Closing fence of the tool_code block
+                            results.append(("\n".join(block_lines), block_start))
+                            pos += len(inner) + 1
+                            i += 1
+                            break
+                        depth -= 1
+                    else:
+                        # Opening fence with language tag (e.g. ```python)
+                        depth += 1
+                block_lines.append(inner)
+                pos += len(inner) + 1
+                i += 1
+            else:
+                # Unterminated block — skip
+                pass
+        else:
+            pos += len(line) + 1
+            i += 1
+    return results
+
+
 @dataclass(frozen=True)
 class ToolUse:
     tool: str
@@ -745,8 +791,8 @@ class ToolUse:
         # don't suppress other blocks.
         if not has_tool_code_block:
             return
-        for match in re.finditer(r"```tool_code\n(.*?)\n```", content, re.DOTALL):
-            block_content = match.group(1).strip()
+        for block_content, block_start in _extract_tool_code_blocks(content):
+            block_content = block_content.strip()
             if not block_content or not block_content.startswith("<"):
                 continue
             try:
@@ -761,7 +807,7 @@ class ToolUse:
                         tool_name,
                         args,
                         tool_content,
-                        start=match.start(),
+                        start=block_start,
                         _format="xml",
                     )
             except etree.ParseError as e:

--- a/tests/test_xml_format.py
+++ b/tests/test_xml_format.py
@@ -198,3 +198,27 @@ def compare(a: List[int], b: List[int]) -> bool:
     assert "List[int]" in code
     assert "len(a) < len(b)" in code
     assert "a[0] > b[0]" in code
+
+
+def test_gemini_tool_code_nested_backticks():
+    """Test that tool_code blocks containing nested triple-backtick fences are not truncated."""
+    content = """\
+```tool_code
+<save args="README.md">
+# Hello
+
+```python
+print("hi")
+```
+
+More content here.
+</save>
+```"""
+    tools = list(ToolUse._iter_from_xml(content))
+    assert len(tools) == 1
+    assert tools[0].tool == "save"
+    assert tools[0].args == ["README.md"]
+    code = tools[0].content or ""
+    assert "```python" in code
+    assert "print(" in code
+    assert "More content here." in code


### PR DESCRIPTION
## Summary

- Extends `_iter_from_xml` to support a third XML format used by Gemini models
- Gemini outputs tool calls wrapped in ` ```tool_code ` blocks with XML-style tags (`<save args="file.py">content</save>`) rather than `<tool-use>` or `<function_calls>` wrappers
- Previously these were silently ignored, causing tool calls to never execute in XML mode
- Adds 3 new tests to `test_xml_format.py` covering the new format and a no-false-positives case

## Motivation

Discovered via autoresearch eval runs on `practical5` suite: Gemini-2.0-flash-001 in XML mode was writing correct Python code wrapped in `tool_code` blocks, but gptme never executed the save operations, leaving the workspace empty. This caused `data-pipeline` and `regex-scrub` tests to fail despite the model producing correct code.

## Test plan

- [x] `test_gemini_tool_code_format` — verifies `<save args="file.py">` inside tool_code block is parsed
- [x] `test_gemini_tool_code_shell` — verifies `<shell>` inside tool_code block is parsed
- [x] `test_gemini_tool_code_no_false_positives` — plain Python in tool_code block returns no tools
- [x] All existing XML format tests still pass (7/7)