### PR TITLE
fix(eval): prevent user workspace config from contaminating eval agent prompts

### DIFF
--- a/gptme/eval/agents/__init__.py
+++ b/gptme/eval/agents/__init__.py
@@ -125,6 +125,8 @@ class GPTMe(Agent):
             tools=tools,
             workspace=self.workspace_dir,
             prompt=self.system_prompt or "full",  # this only replaces the base prompt
+            interactive=False,  # eval agents run non-interactively
+            context_mode="selective",  # skip workspace files to prevent contamination from user's gptme config
         )
 
         # Modify the first (core) system prompt to add eval-specific instruction


### PR DESCRIPTION
## Problem

When running eval agents locally via `_act_local()`, `get_prompt()` was called with `prompt="full"` (default `context_mode`). This caused gptme to include user-level context files from `~/.config/gptme/config.toml` into the eval agent's system prompt via `prompt_workspace()`.

**Concrete example** (found during autoresearch on practical5 eval):
- `~/.config/gptme/config.toml` had `files = ["~/bob/knowledge/infrastructure/vm-setup.md"]`
- This file was injected as `## Selected files` in the eval agent's system prompt
- For the `regex-scrub` task (which should run `scrub.py report.txt`), the agent correctly wrote `scrub.py` but then ran it on `vm-setup.md` instead of `report.txt`
- The agent then created `test.txt` to compensate — resulting in a failed eval

Root cause: `prompt_workspace()` always includes user-level `files` from `~/.config/gptme/config.toml`, regardless of which workspace is passed.

## Fix

Add `context_mode="selective"` to the `get_prompt()` call in `_act_local()`. This skips workspace file injection (both project files and user-level files) while retaining:
- gptme identity and tool descriptions
- Correct workspace path in system info
- The eval task prompt

Also add `interactive=False` since eval agents always run non-interactively (this was already set in `gptme_chat()` but not in `get_prompt()`).

## Impact

Fixes silent eval contamination that could make eval agents operate on injected context files instead of the task's actual input files. Affects all local eval runs where the user has files configured in `~/.config/gptme/config.toml`.

## Test plan

- [x] Fast unit tests pass (`test_no_duplicate_test_names`)
- [x] Import check passes
- [x] Pre-commit checks pass
- Slow eval tests (`@pytest.mark.requires_api`) should still pass — behavior only changes by removing user-injected context