### PR TITLE
fix(tools): use itertext() in _iter_from_xml to prevent content truncation

### DIFF
--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -689,7 +689,9 @@ class ToolUse:
                 for child in tooluse.getchildren():
                     tool_name = child.tag
                     args = list(child.attrib.values())
-                    tool_content = (child.text or "").strip()
+                    # Use itertext() to capture text across child elements
+                    # (handles <, > in code and angle-bracket tokens like <filename>)
+                    tool_content = "".join(child.itertext()).strip()
 
                     # Find the start position of the tool in the original content
                     start_pos = content.find(f"<{tool_name}")
@@ -712,7 +714,9 @@ class ToolUse:
 
                     # Get any other attributes as args (excluding 'name')
                     args = [v for k, v in invoke.attrib.items() if k != "name"]
-                    tool_content = (invoke.text or "").strip()
+                    # Use itertext() to capture text across child elements
+                    # (handles <, > in code and angle-bracket tokens like <filename>)
+                    tool_content = "".join(invoke.itertext()).strip()
 
                     # Find the start position of the invoke in the original content
                     start_pos = content.find(f'<invoke name="{tool_name}"')

--- a/tests/test_xml_format.py
+++ b/tests/test_xml_format.py
@@ -66,3 +66,63 @@ print("Hello, world!")
     assert len(tools) == 1
     assert tools[0].tool == "ipython"
     assert tools[0].content == 'print("Hello, world!")'
+
+
+def test_gptme_xml_format_with_angle_bracket_content():
+    """Test that <toolname> content with angle-bracket tokens is not truncated.
+
+    Regression test: etree.HTMLParser treats <filename> as a child element,
+    so child.text only returns text before the first such tag. Using itertext()
+    preserves the full content.
+    """
+    content = """
+<tool-use>
+<save args="/workspace/scrub.py">
+#!/usr/bin/env python3
+import sys
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <filename>", file=sys.stderr)
+        return 1
+    print(sys.argv[1])
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+</save>
+</tool-use>
+"""
+    tools = list(ToolUse._iter_from_xml(content))
+    assert len(tools) == 1
+    assert tools[0].tool == "save"
+    # The <filename> token causes the HTML parser to create a child element,
+    # but itertext() ensures text AFTER it (in tail) is still captured.
+    # The tag name itself is consumed (acceptable), but the surrounding code is preserved.
+    assert tools[0].content is not None
+    assert "raise SystemExit(main())" in tools[0].content
+
+
+def test_haiku_xml_format_with_angle_bracket_content():
+    """Test Haiku format with angle-bracket tokens in content is not truncated."""
+    content = """
+<function_calls>
+<invoke name="save" args="/workspace/script.py">
+#!/usr/bin/env python3
+import sys
+
+def usage():
+    print("Usage: script.py <input> <output>")
+
+if __name__ == "__main__":
+    usage()
+</invoke>
+</function_calls>
+"""
+    tools = list(ToolUse._iter_from_xml(content))
+    assert len(tools) == 1
+    assert tools[0].tool == "save"
+    # <input> and <output> are HTML void elements so they're consumed by the HTML parser,
+    # but itertext() ensures code AFTER them is still captured (tail text preserved).
+    assert tools[0].content is not None
+    assert 'if __name__ == "__main__":' in tools[0].content


### PR DESCRIPTION
## Problem

When an agent writes a file with XML-like tokens in content (e.g. `<filename>` in a usage string), gptme's XML tool format silently truncates the saved file.

**Root cause**: `_iter_from_xml` uses `child.text` to extract tool content. lxml's `HTMLParser` treats `<filename>` as a child element, so `element.text` only returns text *before* the first such tag — everything after is lost.

**Concrete example**: An agent correctly writes `scrub.py` with:
```python
print(f"Usage: {sys.argv[0]} <filename>", file=sys.stderr)
```
The saved file is truncated at `<filename>` → `SyntaxError` at runtime → eval failure.

## Fix

Replace `child.text` with `"".join(child.itertext()).strip()` in both XML format paths:
- `<tool-use><toolname>...</toolname></tool-use>` (gptme format, line 692)
- `<function_calls><invoke name="toolname">...</invoke></function_calls>` (Haiku format, line 715)

`itertext()` walks all text nodes including *tail* text after child elements, preserving the full content. The angle-bracket token name itself is consumed by the HTML parser (acceptable tradeoff), but all surrounding code is preserved.

## Testing

Added two regression tests:
- `test_gptme_xml_format_with_angle_bracket_content`: `<filename>` token in gptme format
- `test_haiku_xml_format_with_angle_bracket_content`: `<input>`/`<output>` tokens in Haiku format

## Related

Same fix was applied for Gemini `tool_code` codeblock format in commit `3099b4a45`.