### PR TITLE
fix(tests): replace pytest-mock mocker fixture with unittest.mock

### DIFF
--- a/tests/test_tools_subagent.py
+++ b/tests/test_tools_subagent.py
@@ -1149,8 +1149,10 @@ def test_subprocess_mode_with_profile():
     assert captured_cmd[profile_idx + 1] == "explorer"
 
 
-def test_create_subagent_thread_warns_on_unknown_profile_tools(mocker, tmp_path):
+def test_create_subagent_thread_warns_on_unknown_profile_tools(tmp_path):
     """Warn when profile includes unknown tool names and keep known ones + complete."""
+    from unittest.mock import patch
+
     from gptme.message import Message
     from gptme.profiles import Profile
     from gptme.tools.base import ToolSpec
@@ -1167,35 +1169,36 @@ def test_create_subagent_thread_warns_on_unknown_profile_tools(mocker, tmp_path)
         ToolSpec(name="shell", desc=""),
     ]
 
-    mocker.patch("gptme.profiles.get_profile", return_value=profile)
-    mocker.patch("gptme.tools.subagent.get_tools", return_value=tools)
-    mocker.patch("gptme.executor.prepare_execution_environment")
-    mock_prompt = mocker.patch("gptme.prompts.get_prompt", return_value=[])
-    mock_chat = mocker.patch("gptme.chat")
-    mock_warn = mocker.patch("gptme.tools.subagent.logger.warning")
+    with (
+        patch("gptme.profiles.get_profile", return_value=profile),
+        patch("gptme.tools.subagent.get_tools", return_value=tools),
+        patch("gptme.executor.prepare_execution_environment"),
+        patch("gptme.prompts.get_prompt", return_value=[]) as mock_prompt,
+        patch("gptme.chat") as mock_chat,
+        patch("gptme.tools.subagent.logger.warning") as mock_warn,
+    ):
+        _create_subagent_thread(
+            prompt="test",
+            logdir=tmp_path,
+            model=None,
+            context_mode="full",
+            context_include=None,
+            workspace=tmp_path,
+            profile_name="test",
+        )
 
-    _create_subagent_thread(
-        prompt="test",
-        logdir=tmp_path,
-        model=None,
-        context_mode="full",
-        context_include=None,
-        workspace=tmp_path,
-        profile_name="test",
-    )
+        mock_warn.assert_called_once()
+        assert "unknown tools" in mock_warn.call_args.args[0]
+        assert "reead" in mock_warn.call_args.args[2]
 
-    mock_warn.assert_called_once()
-    assert "unknown tools" in mock_warn.call_args.args[0]
-    assert "reead" in mock_warn.call_args.args[2]
+        # Ensure tools passed to prompt are filtered to allowed + complete fallback
+        filtered_tools = mock_prompt.call_args.args[0]
+        filtered_names = {t.name for t in filtered_tools}
+        assert filtered_names == {"read", "complete"}
 
-    # Ensure tools passed to prompt are filtered to allowed + complete fallback
-    filtered_tools = mock_prompt.call_args.args[0]
-    filtered_names = {t.name for t in filtered_tools}
-    assert filtered_names == {"read", "complete"}
-
-    # Ensure chat got the user prompt message
-    prompt_msgs = mock_chat.call_args.args[0]
-    assert prompt_msgs == [Message("user", "test")]
+        # Ensure chat got the user prompt message
+        prompt_msgs = mock_chat.call_args.args[0]
+        assert prompt_msgs == [Message("user", "test")]
 
 
 # --- ACP Mode Tests ---


### PR DESCRIPTION
## Summary

- Replace `mocker` fixture (from `pytest-mock`) with `unittest.mock.patch` context managers in `test_create_subagent_thread_warns_on_unknown_profile_tools`
- `pytest-mock` is declared in `pyproject.toml` but not in `uv.lock`, causing a fixture-not-found ERROR when running tests via `uv run pytest`
- Other tests in the same file already use `unittest.mock` — this change makes the pattern consistent

Closes #1673

## Test plan
- [x] `uv run --with pytest pytest tests/test_tools_subagent.py::test_create_subagent_thread_warns_on_unknown_profile_tools` passes
- [ ] CI passes