### PR TITLE
fix(tools): keep tool descriptions within OpenAI's 1024-char limit

### DIFF
--- a/gptme/tools/base.py
+++ b/gptme/tools/base.py
@@ -395,7 +395,7 @@ class ToolSpec:
             return (
                 description
                 + "\n".join(
-                    f"{callable_signature(func)}: {func.__doc__ or 'No description'}"
+                    f"{callable_signature(func)}: {(func.__doc__ or 'No description').splitlines()[0]}"
                     for func in self.functions
                 )
                 + "\n```"

--- a/gptme/tools/gh.py
+++ b/gptme/tools/gh.py
@@ -441,10 +441,7 @@ Line 1
 Line 2
 EOF
 ```
-Never use `--body "text\\nmore text"`:
-- `\\n` in double-quoted strings is literal backslash-n, not a newline.
-- `$` in double-quoted strings triggers variable expansion (e.g. `$42,000` → `,000`).
-The single-quoted `<< 'EOF'` heredoc prevents both issues.
+Never use `--body "..."` (newlines become literal `\\n`, `$` triggers expansion). The heredoc prevents both.
 
 For other operations, use the `shell` tool with the `gh` command."""
 

--- a/gptme/tools/mcp.py
+++ b/gptme/tools/mcp.py
@@ -493,27 +493,15 @@ tool = ToolSpec(
     name="mcp",
     desc="Search, discover, and manage MCP servers",
     instructions="""
-This tool allows you to search for MCP servers in various registries and dynamically load/unload them.
-
-Once loaded, server tools are available as `<server-name>.<tool-name>`.
+Search and manage MCP servers. Once loaded, tools are available as `<server-name>.<tool-name>`.
 
 Search queries the Official MCP Registry (registry.modelcontextprotocol.io).
 
-**Resource Commands** (for servers that expose resources):
-- `resources list <server>` - List available resources from a loaded server
-- `resources read <server> <uri>` - Read a specific resource by URI
-- `templates list <server>` - List resource templates (parameterized resources)
-
-**Prompt Commands** (for servers that expose prompts):
-- `prompts list <server>` - List available prompts from a loaded server
-- `prompts get <server> <name> [args]` - Get a specific prompt, optionally with JSON arguments
-
-**Roots Commands** (for defining operational boundaries):
-- `roots list [server]` - List configured roots (all servers if no server specified)
-- `roots add <server> <uri> [name]` - Add a root to tell the server where it can operate
-- `roots remove <server> <uri>` - Remove a root from a server
-
-Roots are advisory URIs (file paths, HTTP URLs) that help servers understand workspace boundaries.
+Sub-commands for loaded servers:
+- `resources list/read <server> [uri]` - List or read server resources
+- `templates list <server>` - List resource templates
+- `prompts list/get <server> [name] [args]` - List or get prompts
+- `roots list/add/remove <server> [uri] [name]` - Manage operational boundaries (filesystem/URL scope hints)
 """.strip(),
     examples=examples,
     execute=execute_mcp,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -136,6 +136,21 @@ def test_is_supported_lang_tag():
     assert not is_supported_langtag("randomtag")
 
 
+def test_tool_description_length():
+    """Test that all tool descriptions fit within the OpenAI tool API limit (1024 chars)."""
+    init_tools()
+    max_len = 1024
+    over_limit = [
+        (tool.name, len(tool.get_instructions("tool")))
+        for tool in get_tools()
+        if len(tool.get_instructions("tool")) > max_len
+    ]
+    assert not over_limit, (
+        f"Tool descriptions exceed {max_len} chars (will be silently truncated by OpenAI provider): "
+        + ", ".join(f"{name}={length}" for name, length in over_limit)
+    )
+
+
 def test_load_tool():
     """Test loading a tool mid-conversation."""
     clear_tools()


### PR DESCRIPTION
## Problem

Four tools exceed the 1024-char limit for `--tool-format tool` descriptions, causing silent truncation with a `WARNING` in `llm_openai.py`:

```
WARNING  Description for tool `mcp` is too long (1155 > 1024 chars). Truncating...
```

Before this fix:
| Tool | Length |
|------|--------|
| browser | 1622 |
| chats | 1192 |
| mcp | 1155 |
| gh | 1060 |

## Fix

- **`base.py`**: `get_functions_description()` now uses only the first line of each function docstring instead of the full multi-line docstring. This fixes `browser` (1622→654) and `chats` (1192→252), which auto-generate descriptions from their `functions` list. The full docstrings are still available in the source for Python/IDE use.
- **`gh.py`**: Condense verbose heredoc explanation (1060→914).
- **`mcp.py`**: Condense sub-command section from three verbose blocks into a compact list (1155→507).

## Test

Adds `test_tool_description_length()` to `tests/test_tools.py` to catch regressions. All 29 tests pass.

Closes #1697