### PR TITLE
fix(shell): use findall+last for return code parsing (Greptile follow-up from #1672)

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -887,8 +887,11 @@ class ShellSession:
                             logger.debug(
                                 f"Shell: Delimiter detected in line: {line.strip()[:200]}"
                             )
-                            if match := re_returncode.search(line):
-                                return_code = int(match.group(1))
+                            # Use findall+last to avoid matching "ReturnCode:N"
+                            # in command output that precedes the marker.
+                            rc_matches = re_returncode.findall(line)
+                            if rc_matches:
+                                return_code = int(rc_matches[-1])
                             if command.startswith("cd ") and return_code == 0:
                                 ex, pwd, _ = self._run("pwd", output=False)
                                 if ex == 0:
@@ -1058,8 +1061,11 @@ class ShellSession:
                                     f"{last_stdout}"
                                 )
 
-                            if match := re_returncode.search(line):
-                                return_code = int(match.group(1))
+                            # Use findall+last to avoid matching "ReturnCode:N"
+                            # in command output that precedes the marker.
+                            rc_matches = re_returncode.findall(line)
+                            if rc_matches:
+                                return_code = int(rc_matches[-1])
                             # if command is cd, update working directory
                             if command.startswith("cd ") and return_code == 0:
                                 ex, pwd, _ = self._run("pwd", output=False)


### PR DESCRIPTION
## Summary

Follow-up to #1672, addressing the secondary finding from the Greptile review.

**The bug**: When a command outputs text containing `ReturnCode:N` without a trailing newline, the line seen by the parser looks like:
```
ReturnCode:1 ReturnCode:0 END_OF_COMMAND_OUTPUT
```
`re_returncode.search(line)` finds the **first** occurrence (from command output), returning exit code `1` instead of the actual `0`.

**The fix**: Use `findall()` + last element, consistent with the `rfind()` approach already used for prefix extraction. The last `ReturnCode:N` is always the shell-injected marker.

Applied to both `_read_output_unix` and the threading path (`_read_output_windows`).

## Test plan
- [x] All 53 shell tool tests pass (`tests/test_tools_shell.py`)