### PR TITLE
feat(cli): add --repeat N flag for running prompt N times independently

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -719,12 +719,21 @@ def main(
             else:
                 run_logdir = logdir
 
+            # When --workspace @log, isolate each run's workspace under its own logdir
+            run_workspace = (
+                run_logdir / "workspace"
+                if workspace == "@log"
+                else config.chat.workspace
+            )
+            if workspace == "@log" and repeat > 1:
+                run_workspace.mkdir(parents=True, exist_ok=True)
+
             try:
                 chat(
                     prompt_msgs,
                     initial_msgs,
                     run_logdir,
-                    config.chat.workspace,
+                    run_workspace,
                     config.chat.model,
                     config.chat.stream,
                     no_confirm,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,6 +155,41 @@ def test_repeat_flag_creates_separate_logdirs(
         assert any("run-2" in n for n in log_names)
 
 
+def test_repeat_flag_workspace_log_isolation(
+    name: str, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """--repeat 2 --workspace @log should give each run its own workspace."""
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        monkeypatch.setenv("XDG_DATA_HOME", str(data_dir))
+        result = runner.invoke(
+            cli.main,
+            [
+                "--name",
+                name,
+                "--non-interactive",
+                "--repeat",
+                "2",
+                "--workspace",
+                "@log",
+                "/exit",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        logs_dir = data_dir / "gptme" / "logs"
+        assert logs_dir.exists(), f"logs dir was not created: {logs_dir}"
+        # Each run should have its own workspace under its own logdir
+        run1_dirs = [p for p in logs_dir.iterdir() if "run-1" in p.name]
+        run2_dirs = [p for p in logs_dir.iterdir() if "run-2" in p.name]
+        assert run1_dirs, "no run-1 logdir found"
+        assert run2_dirs, "no run-2 logdir found"
+        # Workspaces must be in separate logdirs (not the same path)
+        run1_workspace = run1_dirs[0] / "workspace"
+        run2_workspace = run2_dirs[0] / "workspace"
+        assert run1_workspace != run2_workspace
+
+
 def test_command_doctor(args: list[str], runner: CliRunner):
     args.append("/doctor")
     result = runner.invoke(cli.main, args)


### PR DESCRIPTION
## Summary

Adds a `--repeat N` flag to the gptme CLI, inspired by [Cook CLI's](https://github.com/rjcorwin/cook) `x3` operator.

- `--repeat N` runs the same prompt N times, each in a separate conversation
- Each run gets its own logdir (`{name}-run-1`, `{name}-run-2`, etc.)
- Random names get fresh random IDs per run  
- Progress indicator shows `Run X/N → logdir-name`
- A graceful `/exit` from one run continues remaining runs (only non-zero exits abort)
- `--repeat 0` is rejected with a clear validation error

**Example usage:**
```bash
# Generate 3 independent haiku drafts
gptme --repeat 3 "write a haiku about the sea"

# Run 5 independent non-interactive attempts at a task
gptme --name experiment --repeat 5 --non-interactive "solve this problem"
```

## Motivation

This is the simplest of the "Cook-inspired composable workflow operators" — run the same prompt N independent times. Useful for:
- Generating multiple independent outputs to compare/pick the best
- Batch generation tasks where you want N diverse results
- Testing prompt reliability across multiple runs

Cook's `cook "work" x3` maps to `gptme --repeat 3 "work"`. gptme's advantage: each run has its own conversation log in git, model-agnostic.

## Test plan

- [x] `test_repeat_flag_help` — `--repeat` appears in `--help` output
- [x] `test_repeat_flag_invalid` — `--repeat 0` is rejected
- [x] `test_repeat_flag_creates_separate_logdirs` — `--repeat 2` creates two separate logdirs with `run-1` and `run-2` suffixes, progress indicators appear in output
- [x] All 19 existing non-API CLI tests pass