### PR TITLE
feat(cli): add --review flag for self-review pass after main run

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -720,7 +720,7 @@ def main(
                 config.chat.model,
                 config.chat.stream,
                 no_confirm=no_confirm,
-                interactive=False,
+                interactive=interactive,
                 show_hidden=show_hidden,
                 tool_allowlist=config.chat.tools,
                 tool_format=config.chat.tool_format,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,6 +71,17 @@ def test_review_flag_help(runner: CliRunner):
     assert "--review" in result.output
 
 
+@pytest.mark.slow
+@pytest.mark.requires_api
+def test_review_flag_executes(args: list[str], runner: CliRunner):
+    """--review flag should trigger a second review pass after the main run."""
+    args.extend(["--review", "--no-confirm", "write 'hello' to hello.txt"])
+    result = runner.invoke(cli.main, args)
+    print(result.output)
+    assert "Review pass" in result.output
+    assert result.exit_code == 0
+
+
 def test_version(runner: CliRunner):
     result = runner.invoke(cli.main, ["--version"])
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary

- Adds `--review` flag to `gptme` CLI: self-review pass appended after the main conversation
- After `chat()` returns, injects a follow-up prompt asking the assistant to check and fix its work  
- Reuses the same logdir (continues the conversation in-place), runs non-interactively

## Motivation

Implements the Cook CLI `review` primitive natively in gptme:

```bash
gptme --review 'write fib.py'
# equivalent to: gptme 'write fib.py' && gptme --resume 'review your work'
```

## Test plan

- [x] `test_review_flag_help` — `--review` appears in `--help` output
- [x] All 17 existing non-API CLI tests pass
- [x] mypy clean

## Related

- Cook-inspired composable workflow operators (idea #28)
- Sister PR: `--repeat N` flag (#1703)