### PR TITLE
feat(eval): add practical7 suite — ini-to-json, json-diff, changelog-gen

### DIFF
--- a/gptme/eval/suites/practical7.py
+++ b/gptme/eval/suites/practical7.py
@@ -166,10 +166,18 @@ def check_changelog_docs(ctx):
 
 
 def check_changelog_scopes(ctx):
-    """Should include explicit scope notation (e.g. (auth), (api)) in the output."""
-    output = ctx.stdout
-    has_auth_scope = bool(re.search(r"\(auth\)", output, re.IGNORECASE))
-    has_api_scope = bool(re.search(r"\(api\)", output, re.IGNORECASE))
+    """Should include explicit scope notation as bullet-point prefixes (e.g. '- (auth)').
+
+    Anchors to bullet-point lines to prevent raw commit input like 'feat(auth):'
+    from satisfying this check without proper reformatting.
+    """
+    lines = ctx.stdout.strip().split("\n")
+    has_auth_scope = any(
+        re.match(r"^\s*[-*]\s+\(auth\)", line, re.IGNORECASE) for line in lines
+    )
+    has_api_scope = any(
+        re.match(r"^\s*[-*]\s+\(api\)", line, re.IGNORECASE) for line in lines
+    )
     return has_auth_scope and has_api_scope
 
 


### PR DESCRIPTION
## Summary

Adds a practical7 eval suite with 3 new capabilities not tested in earlier suites:

| Test | Capability | Checks |
|------|------------|--------|
| `ini-to-json` | INI config parsing (configparser) + JSON conversion | 5 |
| `json-diff` | Recursive JSON comparison with path-based diff reporting | 6 |
| `changelog-gen` | Conventional commit message parsing + categorized changelog | 6 |

All tests use only Python stdlib (configparser, json, sys, re).

## Design Notes

- **ini-to-json**: Prompt requests `RawConfigParser`/`interpolation=None` to handle logging format strings with `%(levelname)s` without triggering interpolation errors
- **json-diff**: Accepts exit code 0 or 1 (both Unix diff convention and explicit success are valid)
- **changelog-gen**: Check functions anchored to headings (not raw content) to prevent false positives from commit message lines satisfying section checks

## Test plan
- [x] Imports cleanly, no duplicate test names (`_check_no_duplicate_names()` passes)
- [x] All 3 tests have check functions registered in `expect` dict
- [x] No collisions with practical1-6 test names