### PR TITLE
fix(vision): add webp to allowed image file extensions

### DIFF
--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -753,7 +753,7 @@ def _handle_tools(message_dicts: Iterable[dict]) -> Generator[dict, None, None]:
 
 
 # File extensions allowed for image uploads
-ALLOWED_FILE_EXTS = ["jpg", "jpeg", "png", "gif"]
+ALLOWED_FILE_EXTS = ["jpg", "jpeg", "png", "gif", "webp"]
 
 
 def _process_file(message_dict: dict) -> dict:

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -178,7 +178,7 @@ def _record_usage(usage, model: str) -> MessageMetadata | None:
 # TODO: set quantization: https://openrouter.ai/docs/provider-routing#quantization
 
 
-ALLOWED_FILE_EXTS = ["jpg", "jpeg", "png", "gif"]
+ALLOWED_FILE_EXTS = ["jpg", "jpeg", "png", "gif", "webp"]
 
 
 def _make_response_format(output_schema):

--- a/gptme/llm/utils.py
+++ b/gptme/llm/utils.py
@@ -140,7 +140,7 @@ def process_image_file(
 
     logger = logging.getLogger(__name__)
 
-    ALLOWED_FILE_EXTS = ["jpg", "jpeg", "png", "gif"]
+    ALLOWED_FILE_EXTS = ["jpg", "jpeg", "png", "gif", "webp"]
 
     f = Path(file_path)
     if expand_user:

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -298,6 +298,18 @@ class TestProcessImageFile:
         _, media_type = result
         assert media_type == "image/gif"
 
+    def test_valid_webp_image(self, tmp_path):
+        """WebP images should be supported."""
+        img_file = tmp_path / "photo.webp"
+        img_file.write_bytes(b"RIFF" + b"\x00" * 4 + b"WEBP" + b"\x00" * 100)
+
+        content_parts: list[dict] = []
+        result = process_image_file(str(img_file), content_parts)
+
+        assert result is not None
+        _, media_type = result
+        assert media_type == "image/webp"
+
     def test_unsupported_file_type(self, tmp_path):
         """Non-image file extensions should be rejected."""
         txt_file = tmp_path / "readme.txt"


### PR DESCRIPTION
## Summary
- Add `webp` to `ALLOWED_FILE_EXTS` in `utils.py`, `llm_anthropic.py`, and `llm_openai.py`
- WebP images were silently dropped during LLM message construction with only a warning log, even though context detection (`context.py`, `prompt.py`, `clipboard.py`, `main.js`) already recognized webp
- Both Anthropic and OpenAI APIs support webp natively
- Added `test_valid_webp_image` test (13/13 pass)

## Test plan
- [x] `pytest tests/test_llm_utils.py::TestProcessImageFile` — all 13 tests pass
- [x] Verified `image/webp` is the correct media type (no special-casing needed like jpg→jpeg)