### PR TITLE
fix: stats timestamp fallback + add model/token/cost breakdown

### DIFF
--- a/gptme/logmanager.py
+++ b/gptme/logmanager.py
@@ -697,6 +697,7 @@ class ConversationMeta:
     total_cost: float = 0.0
     total_input_tokens: int = 0
     total_output_tokens: int = 0
+    total_cache_read_tokens: int = 0
 
     def format(self, metadata=False) -> str:
         """Format conversation metadata for display."""
@@ -725,6 +726,7 @@ def get_conversations() -> Generator[ConversationMeta, None, None]:
         conv_cost = 0.0
         conv_input_tokens = 0
         conv_output_tokens = 0
+        conv_cache_read_tokens = 0
         with open(conv_fn, "rb") as f:
             for line in f:
                 line = line.strip()
@@ -743,12 +745,14 @@ def get_conversations() -> Generator[ConversationMeta, None, None]:
                             usage = meta.get("usage", {})
                             src = usage or meta
                             # Input = uncached + cache_read + cache_creation
+                            cache_read = src.get("cache_read_tokens", 0) or 0
                             conv_input_tokens += (
                                 (src.get("input_tokens", 0) or 0)
-                                + (src.get("cache_read_tokens", 0) or 0)
+                                + cache_read
                                 + (src.get("cache_creation_tokens", 0) or 0)
                             )
                             conv_output_tokens += src.get("output_tokens", 0) or 0
+                            conv_cache_read_tokens += cache_read
                     except (json.JSONDecodeError, TypeError):
                         pass
         assert len(log) <= 1
@@ -790,6 +794,7 @@ def get_conversations() -> Generator[ConversationMeta, None, None]:
             total_cost=conv_cost,
             total_input_tokens=conv_input_tokens,
             total_output_tokens=conv_output_tokens,
+            total_cache_read_tokens=conv_cache_read_tokens,
         )
 
 

--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -330,6 +330,7 @@ def conversation_stats(since: str | None = None, as_json: bool = False) -> None:
     total_cost = 0.0
     total_input_tokens = 0
     total_output_tokens = 0
+    total_cache_read_tokens = 0
     messages_list: list[int] = []
 
     for conv in get_user_conversations():
@@ -370,6 +371,7 @@ def conversation_stats(since: str | None = None, as_json: bool = False) -> None:
         total_cost += conv.total_cost
         total_input_tokens += conv.total_input_tokens
         total_output_tokens += conv.total_output_tokens
+        total_cache_read_tokens += conv.total_cache_read_tokens
         daily_cost[day] = daily_cost.get(day, 0.0) + conv.total_cost
 
     if total_conversations == 0:
@@ -427,6 +429,7 @@ def conversation_stats(since: str | None = None, as_json: bool = False) -> None:
             "total_cost": round(total_cost, 4),
             "total_input_tokens": total_input_tokens,
             "total_output_tokens": total_output_tokens,
+            "total_cache_read_tokens": total_cache_read_tokens,
             "by_agent": dict(agent_counts.most_common()),
             "by_model": {
                 m: {
@@ -496,8 +499,15 @@ def conversation_stats(since: str | None = None, as_json: bool = False) -> None:
 
     # Token and cost summary
     if total_input_tokens or total_cost:
+        cache_pct = (
+            total_cache_read_tokens / total_input_tokens * 100
+            if total_input_tokens
+            else 0
+        )
         print("\nToken Usage & Cost")
-        print(f"  Input tokens:   {_format_tokens(total_input_tokens):>10s}")
+        print(
+            f"  Input tokens:   {_format_tokens(total_input_tokens):>10s}  ({cache_pct:.0f}% cached)"
+        )
         print(f"  Output tokens:  {_format_tokens(total_output_tokens):>10s}")
         print(
             f"  Total tokens:   {_format_tokens(total_input_tokens + total_output_tokens):>10s}"


### PR DESCRIPTION
Two improvements to `gptme-util chats stats`:

## Fix: timestamp fallback for old messages

Old JSONL messages (pre-timestamp era) lack a `timestamp` field, causing `Message.__init__` to default to `datetime.now()`. This made ~613 old conversations appear as created "today", inflating daily activity counts.

Fix: pre-compute file mtime when reading JSONL and use it as fallback.

## Feature: model, token, and cost breakdown

Extracts model/cost/token metadata from assistant messages during the existing line-counting pass in `get_conversations()` (only JSON-parses lines containing `"metadata"` for efficiency).

New sections in stats output:
- **By Model**: conversations, tokens, and cost per model (top 15)
- **Token Usage & Cost**: aggregate input/output tokens and total cost

Example output:
```
By Model
  openrouter/anthropic/claude-opus-4.5        118 convs       0 tok   $194.92
  claude-opus-4-5                              34 convs       0 tok    $77.35
  openrouter/anthropic/claude-opus-4.6         12 convs   58.4K tok    $23.11

Token Usage & Cost
  Input tokens:        43.2K
  Output tokens:       15.2K
  Total tokens:        58.4K
  Total cost:     $   304.39
```

Note: most older conversations show 0 tokens since usage tracking in message metadata was added recently.