### PR TITLE
fix(models): add supports_parallel_tool_calls to openrouter/anthropic/claude-sonnet-4-6

### DIFF
--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -524,6 +524,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 15,
             "supports_vision": True,
             "supports_reasoning": True,
+            "supports_parallel_tool_calls": True,
         },
         "meta-llama/llama-3.3-70b-instruct": {
             "context": 128_000,

--- a/tests/test_llm_models.py
+++ b/tests/test_llm_models.py
@@ -364,6 +364,11 @@ class TestSupportsParallelToolCalls:
         model = get_model("openai/gpt-4o")
         assert model.supports_parallel_tool_calls is True
 
+    def test_openrouter_claude_sonnet_4_6_supports_parallel(self):
+        """claude-sonnet-4-6 via OpenRouter should also support parallel tool calls."""
+        model = get_model("openrouter/anthropic/claude-sonnet-4-6")
+        assert model.supports_parallel_tool_calls is True
+
     def test_unknown_model_defaults_to_false(self):
         """Unknown models fall back to False (safe default — don't break things)."""
         model = get_model("unknown-provider/unknown-model")


### PR DESCRIPTION
## Summary

- `anthropic/claude-sonnet-4-6` via OpenRouter was missing `supports_parallel_tool_calls: True`
- This caused `break_on_tooluse` to default to `True` for OpenRouter users, preventing parallel tool calls even though the underlying model supports it
- Added the flag to match the `anthropic` provider entry for the same model
- Added a test to prevent regression

## Root cause

PR #1724 added `supports_parallel_tool_calls` to Anthropic models and established the model-dependent `break_on_tooluse` default. The OpenRouter entry for the same model was overlooked.

## Test plan

- [x] All `TestSupportsParallelToolCalls` tests pass (8/8)
- [x] `openrouter/anthropic/claude-sonnet-4-6` now correctly returns `supports_parallel_tool_calls=True`