### PR TITLE
fix(shell): decode bytes in final read of background job output

### DIFF
--- a/gptme/tools/shell.py
+++ b/gptme/tools/shell.py
@@ -138,7 +138,10 @@ class BackgroundJob:
                 remaining = self.process.stdout.read()
                 if remaining:
                     with self._buffer_lock:
-                        self._append_to_buffer(self.stdout_buffer, remaining)
+                        self._append_to_buffer(
+                            self.stdout_buffer,
+                            remaining.decode("utf-8", errors="replace"),
+                        )
             except (OSError, ValueError):
                 pass
         if self.process.stderr:
@@ -146,7 +149,10 @@ class BackgroundJob:
                 remaining = self.process.stderr.read()
                 if remaining:
                     with self._buffer_lock:
-                        self._append_to_buffer(self.stderr_buffer, remaining)
+                        self._append_to_buffer(
+                            self.stderr_buffer,
+                            remaining.decode("utf-8", errors="replace"),
+                        )
             except (OSError, ValueError):
                 pass
 


### PR DESCRIPTION
## Summary

Fixes the CI failure in `test_background_job_output`:
```
TypeError: sequence item 0: expected str instance, bytes found
```

## Root Cause

In `BackgroundJob._read_output()`, the "final read after process exits" block calls `process.stdout.read()` / `process.stderr.read()`, which return **bytes** (the process is opened with `subprocess.Popen` in binary mode — no `text=True`).

The loop's `os.read()` calls correctly decode with `.decode("utf-8", errors="replace")`, but the final reads appended raw bytes directly to the `list[str]` buffer. This caused `str.join()` to fail in `get_output()`.

## Fix

Decode both `remaining` values with `.decode("utf-8", errors="replace")` before appending, consistent with how the while-loop handles reads.

## Test

The existing `test_background_job_output` test covers this path — it was the failing test.