### PR TITLE
fix(skills): address remaining quality issues in dependency declarations

### DIFF
--- a/gptme/lessons/installer.py
+++ b/gptme/lessons/installer.py
@@ -489,6 +489,20 @@ def list_installed() -> list[InstalledSkill]:
     return list(manifest.skills.values())
 
 
+def _extract_depends(fm: dict) -> list[str]:
+    """Extract and normalise the ``depends`` field from parsed SKILL.md frontmatter.
+
+    Handles ``str``, ``list``, ``None`` (YAML null), and other scalars gracefully.
+    """
+    raw = fm.get("depends", [])
+    if isinstance(raw, str):
+        raw = [raw]
+    elif not isinstance(raw, list):
+        # YAML null parses as None; other scalars (int, float) are also invalid
+        raw = []
+    return [d for d in raw if isinstance(d, str) and d.strip()]
+
+
 def check_dependencies(
     skill_names: list[str] | None = None,
 ) -> list[dict[str, str]]:
@@ -500,6 +514,9 @@ def check_dependencies(
     Returns:
         List of dicts with unsatisfied dependencies:
         [{"skill": "my-skill", "depends": "missing-dep"}, ...]
+
+    Raises:
+        KeyError: If any name in ``skill_names`` is not a known installed skill.
     """
     from .index import LessonIndex
 
@@ -517,6 +534,12 @@ def check_dependencies(
     missing: list[dict[str, str]] = []
 
     if skill_names is not None:
+        unknown = [n for n in skill_names if n not in available]
+        if unknown:
+            raise KeyError(
+                f"Unknown skill(s): {', '.join(sorted(unknown))}. "
+                "Check installed skills with `gptme --list-skills`."
+            )
         targets = skill_names
     else:
         # Include all known skills: indexed + manifest-only
@@ -532,20 +555,19 @@ def check_dependencies(
             continue
         # Find the skill in index or manifest
         deps: list[str] = []
+        found_in_index = False
         for item in index.lessons:
             if item.metadata.name == skill_name:
                 deps = item.metadata.depends
+                found_in_index = True
                 break
-        if not deps and skill_name in manifest.skills:
+        if not found_in_index and skill_name in manifest.skills:
             # Check manifest entry's SKILL.md
             skill_path = Path(manifest.skills[skill_name].install_path)
             skill_md = _find_skill_md(skill_path)
             if skill_md:
                 fm = _parse_skill_frontmatter(skill_md)
-                raw = fm.get("depends", [])
-                if isinstance(raw, str):
-                    raw = [raw]
-                deps = [d for d in raw if isinstance(d, str) and d.strip()]
+                deps = _extract_depends(fm)
 
         missing.extend(
             {"skill": skill_name, "depends": dep}
@@ -586,35 +608,39 @@ def dependency_graph() -> dict[str, list[str]]:
             skill_md = _find_skill_md(skill_path)
             if skill_md:
                 fm = _parse_skill_frontmatter(skill_md)
-                raw = fm.get("depends", [])
-                if isinstance(raw, str):
-                    raw = [raw]
-                deps = [d for d in raw if isinstance(d, str) and d.strip()]
+                deps = _extract_depends(fm)
                 if deps:
                     graph[name] = deps
 
-    # Detect circular dependencies (simple depth-first check)
+    # Detect circular dependencies (iterative DFS — no recursion limit risk)
     cycles: list[str] = []
-
-    def _has_cycle(node: str, visited: set[str], stack: set[str]) -> bool:
-        visited.add(node)
-        stack.add(node)
-        for dep in graph.get(node, []):
-            if dep not in visited:
-                if _has_cycle(dep, visited, stack):
-                    return True
-            elif dep in stack:
-                cycle = f"{node} -> {dep}"
-                cycles.append(cycle)
-                logger.warning(f"Circular dependency detected: {cycle}")
-                return True
-        stack.discard(node)
-        return False
-
     visited: set[str] = set()
-    for skill in graph:
-        if skill not in visited:
-            _has_cycle(skill, visited, set())
+
+    for start in graph:
+        if start in visited:
+            continue
+        stack: list[tuple[str, int]] = [(start, 0)]
+        path: set[str] = set()
+        while stack:
+            node, idx = stack.pop()
+            if idx == 0:
+                if node in path:
+                    # Back-edge — cycle detected
+                    cycle = f"{stack[-1][0]} -> {node}" if stack else node
+                    cycles.append(cycle)
+                    logger.warning(f"Circular dependency detected: {cycle}")
+                    continue
+                if node in visited:
+                    continue
+                visited.add(node)
+                path.add(node)
+            deps = graph.get(node, [])
+            if idx < len(deps):
+                # Push current node back with incremented index, then push child
+                stack.append((node, idx + 1))
+                stack.append((deps[idx], 0))
+            else:
+                path.discard(node)
 
     if cycles:
         raise ValueError(f"Circular dependencies detected: {', '.join(cycles)}")

--- a/gptme/lessons/parser.py
+++ b/gptme/lessons/parser.py
@@ -358,6 +358,9 @@ def parse_lesson(path: Path) -> Lesson:
                         raw_depends = frontmatter.get("depends", [])
                         if isinstance(raw_depends, str):
                             raw_depends = [raw_depends]
+                        elif not isinstance(raw_depends, list):
+                            # YAML null → None, or other scalars
+                            raw_depends = []
                         depends = [
                             d for d in raw_depends if isinstance(d, str) and d.strip()
                         ]

--- a/gptme/prompts.py
+++ b/gptme/prompts.py
@@ -1086,7 +1086,7 @@ def prompt_skills_summary(
                 depends_attr = ""
                 if skill.metadata.depends:
                     depends_attr = (
-                        f" depends={quoteattr(' '.join(skill.metadata.depends))}"
+                        f" depends={quoteattr(', '.join(skill.metadata.depends))}"
                     )
                 skill_entries.append(
                     f"  <skill name={name} path={path}{depends_attr}>{desc}</skill>"

--- a/tests/test_skill_installer.py
+++ b/tests/test_skill_installer.py
@@ -634,3 +634,118 @@ metadata:
         assert any(m["skill"] == "test-skill" for m in missing), (
             f"Manifest-only skill not checked: {missing}"
         )
+
+    def test_check_dependencies_raises_on_unknown_skill(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """check_dependencies() should raise KeyError for unknown skill names."""
+        from gptme.lessons.index import LessonIndex
+
+        fake_index = LessonIndex.__new__(LessonIndex)
+        fake_index.lessons = []
+        monkeypatch.setattr("gptme.lessons.index.LessonIndex", lambda: fake_index)
+        monkeypatch.setattr(
+            "gptme.lessons.installer.get_manifest", lambda: SkillManifest()
+        )
+
+        with pytest.raises(KeyError, match="Unknown skill"):
+            check_dependencies(["nonexistent-skill"])
+
+    def test_check_dependencies_explicit_skill_names(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """check_dependencies() with explicit names returns satisfied deps."""
+        from gptme.lessons.index import LessonIndex
+        from gptme.lessons.parser import parse_lesson
+
+        skill = tmp_path / "has-dep"
+        skill.mkdir()
+        (skill / "SKILL.md").write_text(
+            "---\nname: has-dep\ndescription: D\ndepends:\n  - other\n---\n# D\n"
+        )
+        other = tmp_path / "other"
+        other.mkdir()
+        (other / "SKILL.md").write_text("---\nname: other\ndescription: O\n---\n# O\n")
+
+        parsed_dep = parse_lesson(skill / "SKILL.md")
+        parsed_other = parse_lesson(other / "SKILL.md")
+
+        fake_index = LessonIndex.__new__(LessonIndex)
+        fake_index.lessons = [parsed_dep, parsed_other]
+        monkeypatch.setattr("gptme.lessons.index.LessonIndex", lambda: fake_index)
+        monkeypatch.setattr(
+            "gptme.lessons.installer.get_manifest", lambda: SkillManifest()
+        )
+
+        # All deps satisfied — should return empty
+        missing = check_dependencies(["has-dep"])
+        assert missing == []
+
+    def test_depends_null_does_not_crash_check_dependencies(
+        self, tmp_path: Path, skill_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """depends: null (YAML) should not crash check_dependencies."""
+        from gptme.lessons.index import LessonIndex
+
+        install_skill(str(skill_dir))
+
+        fake_index = LessonIndex.__new__(LessonIndex)
+        fake_index.lessons = []
+        monkeypatch.setattr("gptme.lessons.index.LessonIndex", lambda: fake_index)
+
+        # Patch SKILL.md to have depends: null
+        installed_md = get_skills_dir() / "test-skill" / "SKILL.md"
+        installed_md.write_text(
+            "---\nname: test-skill\ndescription: Test\ndepends:\n---\n# Test\n"
+        )
+
+        # Should not crash — depends: (bare) parses as None in YAML
+        missing = check_dependencies()
+        assert isinstance(missing, list)
+
+    def test_depends_null_does_not_crash_dependency_graph(
+        self, tmp_path: Path, skill_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """depends: null (YAML) should not crash dependency_graph."""
+        from gptme.lessons.index import LessonIndex
+
+        install_skill(str(skill_dir))
+
+        fake_index = LessonIndex.__new__(LessonIndex)
+        fake_index.lessons = []
+        monkeypatch.setattr("gptme.lessons.index.LessonIndex", lambda: fake_index)
+
+        installed_md = get_skills_dir() / "test-skill" / "SKILL.md"
+        installed_md.write_text(
+            "---\nname: test-skill\ndescription: Test\ndepends:\n---\n# Test\n"
+        )
+
+        # Should not crash
+        graph = dependency_graph()
+        assert isinstance(graph, dict)
+
+    def test_depends_null_does_not_crash_parse_lesson(self, tmp_path: Path):
+        """depends: null should not crash parse_lesson."""
+        from gptme.lessons.parser import parse_lesson
+
+        skill = tmp_path / "null-dep"
+        skill.mkdir()
+        (skill / "SKILL.md").write_text(
+            "---\nname: null-dep\ndescription: Null\ndepends:\n---\n# Null\n"
+        )
+
+        parsed = parse_lesson(skill / "SKILL.md")
+        assert parsed.metadata.depends == []
+
+    def test_depends_integer_does_not_crash_parse_lesson(self, tmp_path: Path):
+        """depends: 42 should not crash parse_lesson."""
+        from gptme.lessons.parser import parse_lesson
+
+        skill = tmp_path / "int-dep"
+        skill.mkdir()
+        (skill / "SKILL.md").write_text(
+            "---\nname: int-dep\ndescription: Int\ndepends: 42\n---\n# Int\n"
+        )
+
+        parsed = parse_lesson(skill / "SKILL.md")
+        assert parsed.metadata.depends == []


### PR DESCRIPTION
## Summary

Follow-up to #1722. The squash merge only captured the initial PR state — the Greptile-prompted fix commits on the feature branch never reached master. This PR brings all those fixes.

**Bugs fixed:**
- `depends: null` (bare YAML key) crashed `check_dependencies()` and `dependency_graph()` with `TypeError: 'NoneType' object is not iterable`
- `depends: 42` (non-iterable scalar) crashed `parse_lesson()` the same way
- `check_dependencies(["unknown-skill"])` silently returned `[]` instead of raising — now raises `KeyError`
- `if not deps` ambiguity in `check_dependencies()`: indexed skill with empty depends incorrectly fell through to manifest lookup — replaced with explicit `found_in_index` flag
- Recursive `_has_cycle()` susceptible to `RecursionError` on deep chains — converted to iterative DFS
- XML depends delimiter used space-join vs plain-text comma-join — standardized on comma-separated
- Extracted `_extract_depends()` helper to eliminate 3x code duplication

**Tests:** 6 new regression tests (51 total in test_skill_installer.py), all passing.

## Test plan
- [x] All 51 skill installer tests pass locally
- [ ] CI green