### PR TITLE
refactor(server): extract shared code from V1 API module

### DIFF
--- a/gptme/server/__init__.py
+++ b/gptme/server/__init__.py
@@ -2,7 +2,7 @@
 Server for gptme.
 """
 
-from .api import create_app
+from .app import create_app
 from .cli import main
 
 __all__ = ["main", "create_app"]

--- a/gptme/server/api.py
+++ b/gptme/server/api.py
@@ -18,7 +18,6 @@ from pathlib import Path
 import flask
 from dateutil.parser import isoparse
 from flask import current_app, request
-from flask_cors import CORS
 
 from ..commands import execute_cmd
 from ..config import get_config
@@ -28,7 +27,7 @@ from ..llm.models import get_default_model
 from ..logmanager import LogManager, get_user_conversations, prepare_messages
 from ..message import Message
 from ..tools import ToolUse, execute_msg, init_tools
-from ..util.uri import URI
+from .api_v2_common import _abs_to_rel_workspace
 from .auth import require_auth
 from .openapi_docs import (
     ConversationCreateRequest,
@@ -129,21 +128,6 @@ def api_conversations():
     limit = int(request.args.get("limit", 100))
     conversations = list(islice(get_user_conversations(), limit))
     return flask.jsonify(conversations)
-
-
-def _abs_to_rel_workspace(path: str | Path | URI, workspace: Path) -> str:
-    """Convert an absolute path to a relative path.
-
-    URIs are returned as-is since they are not workspace-relative.
-    """
-    # URIs should be returned as-is (they're not workspace-relative)
-    if isinstance(path, URI):
-        return str(path)
-
-    path = Path(path).resolve()
-    if path.is_relative_to(workspace):
-        return str(path.relative_to(workspace))
-    return str(path)
 
 
 @api.route("/api/conversations/<string:logfile>")
@@ -565,67 +549,3 @@ def chat():
 @api.route("/favicon.png")
 def favicon():
     return flask.send_from_directory(media_path, "logo.png")
-
-
-def create_app(cors_origin: str | None = None, host: str = "127.0.0.1") -> flask.Flask:
-    """Create the Flask app.
-
-    Args:
-        cors_origin: CORS origin to allow. Use '*' to allow all origins.
-    """
-    app = flask.Flask(__name__, static_folder=static_path)
-    app.register_blueprint(api)
-
-    # Capture the server's default model from the startup context
-    # This is needed because ContextVar doesn't propagate across request contexts
-    from ..llm.models import get_default_model, set_default_model
-
-    server_default_model = get_default_model()
-    if server_default_model:
-        app.config["SERVER_DEFAULT_MODEL"] = server_default_model
-
-        @app.before_request
-        def propagate_default_model():
-            """Propagate the server's default model to each request's ContextVar."""
-            # Only set if not already set in this context
-            if get_default_model() is None:
-                set_default_model(server_default_model)
-
-    # Register v2 API, workspace API, and tasks API
-    # noreorder
-    from .api_v2 import v2_api  # fmt: skip
-    from .tasks_api import tasks_api  # fmt: skip
-    from .workspace_api import workspace_api  # fmt: skip
-
-    app.register_blueprint(v2_api)
-    app.register_blueprint(workspace_api)
-    app.register_blueprint(tasks_api)
-
-    # Register OpenAPI documentation
-    from .openapi_docs import docs_api  # fmt: skip
-
-    app.register_blueprint(docs_api)
-    logger.info("OpenAPI documentation available at /api/docs/")
-
-    if cors_origin:
-        # Only allow credentials if a specific origin is set (not '*')
-        allow_credentials = cors_origin != "*" if cors_origin else False
-        CORS(
-            app,
-            resources={
-                r"/api/*": {
-                    "origins": cors_origin,
-                    "supports_credentials": allow_credentials,
-                }
-            },
-        )
-
-    # Initialize auth (defaults to local-only, no auth required)
-    from .auth import init_auth  # fmt: skip
-
-    init_auth(host=host, display=False)
-
-    # Server confirmation hook is now registered via init_hooks(server=True)
-    # in server/cli.py
-
-    return app

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -45,9 +45,8 @@ def _validate_conversation_id(
     return None
 
 
-from .api import _abs_to_rel_workspace
 from .api_v2_agents import agents_api
-from .api_v2_common import msg2dict
+from .api_v2_common import _abs_to_rel_workspace, msg2dict
 from .api_v2_sessions import SessionManager, sessions_api
 from .auth import require_auth
 from .openapi_docs import (

--- a/gptme/server/api_v2_common.py
+++ b/gptme/server/api_v2_common.py
@@ -1,5 +1,5 @@
 """
-Common types and utilities for V2 API.
+Common types and utilities for the gptme server API.
 """
 
 from pathlib import Path
@@ -8,7 +8,22 @@ from typing import Literal, TypedDict
 from typing_extensions import NotRequired
 
 from ..message import Message
-from .api import _abs_to_rel_workspace
+from ..util.uri import URI
+
+
+def _abs_to_rel_workspace(path: str | Path | URI, workspace: Path) -> str:
+    """Convert an absolute path to a relative path.
+
+    URIs are returned as-is since they are not workspace-relative.
+    """
+    # URIs should be returned as-is (they're not workspace-relative)
+    if isinstance(path, URI):
+        return str(path)
+
+    path = Path(path).resolve()
+    if path.is_relative_to(workspace):
+        return str(path.relative_to(workspace))
+    return str(path)
 
 
 class MessageDict(TypedDict):

--- a/gptme/server/app.py
+++ b/gptme/server/app.py
@@ -1,0 +1,80 @@
+"""
+Flask application factory for gptme server.
+
+Separated from api.py (V1 endpoints) so that removing V1 later
+is a one-line change (drop the V1 blueprint registration).
+"""
+
+import logging
+
+import flask
+from flask_cors import CORS
+
+from .api import api as v1_api
+from .api import static_path
+
+logger = logging.getLogger(__name__)
+
+
+def create_app(cors_origin: str | None = None, host: str = "127.0.0.1") -> flask.Flask:
+    """Create the Flask app.
+
+    Args:
+        cors_origin: CORS origin to allow. Use '*' to allow all origins.
+    """
+    app = flask.Flask(__name__, static_folder=static_path)
+    app.register_blueprint(v1_api)
+
+    # Capture the server's default model from the startup context
+    # This is needed because ContextVar doesn't propagate across request contexts
+    from ..llm.models import get_default_model, set_default_model
+
+    server_default_model = get_default_model()
+    if server_default_model:
+        app.config["SERVER_DEFAULT_MODEL"] = server_default_model
+
+        @app.before_request
+        def propagate_default_model():
+            """Propagate the server's default model to each request's ContextVar."""
+            # Only set if not already set in this context
+            if get_default_model() is None:
+                set_default_model(server_default_model)
+
+    # Register v2 API, workspace API, and tasks API
+    # noreorder
+    from .api_v2 import v2_api  # fmt: skip
+    from .tasks_api import tasks_api  # fmt: skip
+    from .workspace_api import workspace_api  # fmt: skip
+
+    app.register_blueprint(v2_api)
+    app.register_blueprint(workspace_api)
+    app.register_blueprint(tasks_api)
+
+    # Register OpenAPI documentation
+    from .openapi_docs import docs_api  # fmt: skip
+
+    app.register_blueprint(docs_api)
+    logger.info("OpenAPI documentation available at /api/docs/")
+
+    if cors_origin:
+        # Only allow credentials if a specific origin is set (not '*')
+        allow_credentials = cors_origin != "*" if cors_origin else False
+        CORS(
+            app,
+            resources={
+                r"/api/*": {
+                    "origins": cors_origin,
+                    "supports_credentials": allow_credentials,
+                }
+            },
+        )
+
+    # Initialize auth (defaults to local-only, no auth required)
+    from .auth import init_auth  # fmt: skip
+
+    init_auth(host=host, display=False)
+
+    # Server confirmation hook is now registered via init_hooks(server=True)
+    # in server/cli.py
+
+    return app

--- a/gptme/server/cli.py
+++ b/gptme/server/cli.py
@@ -9,7 +9,7 @@ from gptme.config import set_config_from_workspace
 
 from ..init import init, init_logging
 from ..telemetry import init_telemetry, shutdown_telemetry
-from .api import create_app
+from .app import create_app
 from .auth import get_server_token, init_auth
 from .constants import DEFAULT_FALLBACK_MODEL
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -283,7 +283,7 @@ def server_thread():
         "flask", reason="flask not installed, install server extras (-E server)"
     )
 
-    from gptme.server.api import create_app  # fmt: skip
+    from gptme.server.app import create_app  # fmt: skip
 
     app = create_app()
 
@@ -314,7 +314,7 @@ def server_thread():
 
 @pytest.fixture
 def client():
-    from gptme.server.api import create_app  # fmt: skip
+    from gptme.server.app import create_app  # fmt: skip
 
     app = create_app()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -215,7 +215,7 @@ def test_default_model_propagation():
     # Set a default model before creating the app (simulates server startup with --model)
     # Use a mock model object that matches what get_default_model returns
     from gptme.llm.models import ModelMeta, set_default_model
-    from gptme.server.api import create_app
+    from gptme.server.app import create_app
 
     test_model = ModelMeta(
         provider="openai",

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -194,7 +194,7 @@ class TestAbsToRelWorkspace:
         """URIs should be returned as-is, not converted to paths."""
         from pathlib import Path
 
-        from gptme.server.api import _abs_to_rel_workspace
+        from gptme.server.api_v2_common import _abs_to_rel_workspace
 
         workspace = Path("/tmp/workspace")
         uri = URI("https://example.com/doc.pdf")
@@ -207,7 +207,7 @@ class TestAbsToRelWorkspace:
         """MCP URIs should be returned as-is."""
         from pathlib import Path
 
-        from gptme.server.api import _abs_to_rel_workspace
+        from gptme.server.api_v2_common import _abs_to_rel_workspace
 
         workspace = Path("/tmp/workspace")
         uri = URI("memo://resource/123")
@@ -220,7 +220,7 @@ class TestAbsToRelWorkspace:
         """Regular paths should still be converted to relative."""
         from pathlib import Path
 
-        from gptme.server.api import _abs_to_rel_workspace
+        from gptme.server.api_v2_common import _abs_to_rel_workspace
 
         workspace = Path("/tmp/workspace")
         abs_path = Path("/tmp/workspace/subdir/file.txt")
@@ -233,7 +233,7 @@ class TestAbsToRelWorkspace:
         """Paths outside workspace should be returned as-is."""
         from pathlib import Path
 
-        from gptme.server.api import _abs_to_rel_workspace
+        from gptme.server.api_v2_common import _abs_to_rel_workspace
 
         workspace = Path("/tmp/workspace")
         outside_path = Path("/other/location/file.txt")


### PR DESCRIPTION
## Summary
- Move `_abs_to_rel_workspace()` from `api.py` → `api_v2_common.py` (where it was already imported)
- Move `create_app()` from `api.py` → new `app.py` (it's the app factory, not a V1 endpoint)
- Update all imports in production code and tests

This separates V1 endpoints from shared server infrastructure, making future V1 removal a one-line change (just drop the `app.register_blueprint(v1_api)` call).

Part of Spring Cleaning #1731.

## Test plan
- [x] All 4 `TestAbsToRelWorkspace` tests pass
- [x] `test_default_model_propagation` passes
- [x] mypy clean on changed files
- [x] Import chain verified: `server.__init__` → `app.create_app` works