### PR TITLE
fix(tests): fix flaky test_api_conversation_generate mock setup

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 import copy
 import random
+import unittest.mock
 
 import pytest
 
@@ -106,11 +107,6 @@ def test_api_conversation_post(conv, client: FlaskClient):
     assert response.status_code == 200
 
 
-@pytest.mark.slow
-@pytest.mark.requires_api
-@pytest.mark.xfail(
-    reason="sometimes gets {'error': \"'Mock' object is not iterable\"} in CI"
-)
 def test_api_conversation_generate(conv: str, client: FlaskClient):
     # Ask the assistant to generate a test response
     response = client.post(
@@ -119,13 +115,18 @@ def test_api_conversation_generate(conv: str, client: FlaskClient):
     )
     assert response.status_code == 200
 
-    model = m.full if (m := get_default_model()) else get_recommended_model("anthropic")
+    # Mock _stream to return a deterministic iterable response, avoiding
+    # real API calls that previously caused flaky "'Mock' object is not iterable"
+    # errors in CI (the old test was marked xfail for this reason).
+    def mock_stream(messages, model, tools=None):
+        yield "Hello! "
+        yield "This is a test response."
 
-    # Test regular (non-streaming) response
-    response = client.post(
-        f"/api/conversations/{conv}/generate",
-        json={"model": model},
-    )
+    with unittest.mock.patch("gptme.server.api._stream", mock_stream):
+        response = client.post(
+            f"/api/conversations/{conv}/generate",
+            json={"model": "test/mock-model"},
+        )
     assert response.status_code == 200
     data = response.get_data(as_text=True)
     assert data  # Ensure we got some response
@@ -140,6 +141,7 @@ def test_api_conversation_generate(conv: str, client: FlaskClient):
 
     # First message should be the assistant's response
     assert msgs_resps[0]["role"] == "assistant"
+    assert msgs_resps[0]["content"] == "Hello! This is a test response."
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary
- Fix `test_api_conversation_generate` which was marked `@pytest.mark.xfail` due to intermittent `'Mock' object is not iterable` errors in CI
- Replace real API call with a properly mocked `_stream` generator that returns deterministic iterable responses
- Remove `@pytest.mark.xfail`, `@pytest.mark.requires_api`, and `@pytest.mark.slow` since the test no longer needs a real API and runs in ~1.5s

## Root cause
The test made a real LLM API call via the Flask test client. In CI, something in the test environment occasionally replaced `_stream` with a non-iterable `Mock` object, causing `"".join(_stream(...))` to raise `TypeError: 'Mock' object is not iterable`, which the API error handler caught and returned as a JSON error response.

## Fix
Mock `gptme.server.api._stream` with a generator function that yields strings, following the same pattern used by V2 API tests (`test_server_v2_auto_stepping.py`, `test_server_v2_tool_confirmation.py`).

## Test plan
- [x] `test_api_conversation_generate` passes consistently (5/5 runs)
- [x] All 17 `test_server.py` tests pass