### PR TITLE
refactor: remove 11 unused type: ignore comments

### DIFF
--- a/gptme/cli/main.py
+++ b/gptme/cli/main.py
@@ -18,7 +18,7 @@ from click.core import ParameterSource
 try:
     from pick import pick
 except ImportError:
-    pick = None  # type: ignore[assignment]
+    pick = None
 
 import gptme
 

--- a/gptme/llm/llm_anthropic.py
+++ b/gptme/llm/llm_anthropic.py
@@ -568,7 +568,7 @@ def stream(
                         logger.warning("Unknown delta type: %s", delta)
                 case "content_block_stop":
                     stop_chunk = cast(anthropic.types.ContentBlockStopEvent, chunk)
-                    stop_block = stop_chunk.content_block  # type: ignore[attr-defined]
+                    stop_block = stop_chunk.content_block
                     if isinstance(stop_block, anthropic.types.TextBlock):
                         pass
                     elif isinstance(stop_block, anthropic.types.ToolUseBlock):
@@ -943,7 +943,7 @@ def _prepare_messages_for_api(
         web_search_tool = _create_web_search_tool(max_uses=max_uses)
         if tools_dict is None:
             tools_dict = []
-        tools_dict.append(web_search_tool)  # type: ignore[arg-type]
+        tools_dict.append(web_search_tool)
         logger.info(f"Anthropic native web search enabled (max_uses={max_uses})")
 
     if tools_dict is not None:
@@ -966,7 +966,7 @@ def _prepare_messages_for_api(
 
         for part in raw_content:
             if isinstance(part, dict):
-                content_parts.append(part)  # type: ignore[arg-type]
+                content_parts.append(part)
             else:
                 content_parts.append({"type": "text", "text": str(part)})
 

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -385,7 +385,7 @@ def _handle_openai_transient_error(e, attempt, max_retries, base_delay):
     try:
         import httpx
     except ImportError:
-        httpx = None  # type: ignore[assignment]
+        httpx = None
 
     # Allow tests to override max_retries via environment variable
     # This breaks out of the retry loop early to prevent test timeouts
@@ -547,7 +547,7 @@ def chat(
 
     response = client.chat.completions.create(
         model=api_model.split("@")[0],
-        messages=messages_dicts,  # type: ignore[arg-type]
+        messages=messages_dicts,
         extra_headers=extra_headers(provider),
         extra_body=extra_body(provider, model_meta),
         **optional_kwargs,
@@ -645,7 +645,7 @@ def stream(
 
     for chunk_raw in client.chat.completions.create(
         model=api_model.split("@")[0],
-        messages=messages_dicts,  # type: ignore[call-overload]
+        messages=messages_dicts,
         stream=True,
         extra_headers=extra_headers(provider),
         extra_body=extra_body(provider, model_meta),

--- a/gptme/logmanager.py
+++ b/gptme/logmanager.py
@@ -872,7 +872,7 @@ def rename_conversation(conv_id: str, new_name: str) -> bool:
 
     if "chat" not in config_data:
         config_data.add("chat", tomlkit.table())
-    config_data["chat"]["name"] = new_name  # type: ignore[index]
+    config_data["chat"]["name"] = new_name
 
     with open(config_path, "w") as f:
         tomlkit.dump(config_data, f)

--- a/gptme/tools/lessons.py
+++ b/gptme/tools/lessons.py
@@ -39,8 +39,8 @@ def _get_ace_components() -> tuple[type | None, type | None]:
         Tuple of (LessonEmbedder class, GptmeHybridMatcher class), or (None, None) if unavailable.
     """
     try:
-        from ace.embedder import LessonEmbedder  # type: ignore[import-not-found]
-        from ace.gptme_integration import (  # type: ignore[import-not-found]
+        from ace.embedder import LessonEmbedder
+        from ace.gptme_integration import (
             GptmeHybridMatcher,
         )
 

--- a/gptme/util/prompt.py
+++ b/gptme/util/prompt.py
@@ -661,4 +661,4 @@ def rich_to_str(text: str | Any, **kwargs) -> str:
     # kwargs.setdefault("force_terminal", True)  # Ensure ANSI codes are generated
     console = Console(file=io.StringIO(), **kwargs)
     console.print(text, end="")
-    return console.file.getvalue()  # type: ignore[attr-defined]
+    return console.file.getvalue()


### PR DESCRIPTION
## Summary
- Removes 11 unused `type: ignore` comments found by `mypy --warn-unused-ignores`
- Follow-up to #1733 which removed 47 unused comments
- Part of Spring Cleaning (#1731)

## Test plan
- [x] `mypy --warn-unused-ignores` reports zero unused ignores
- [x] `mypy` passes with no errors