### PR TITLE
feat: add MiniMax as a built-in LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ You can find more [Demos][docs-demos] and [Examples][docs-examples] in the [docu
   - Adapts to interactive vs autonomous modes.
   - Extend with your own lessons and [skills][docs-skills].
 - 🤖 **Support for many LLM [providers][docs-providers]**
-  - Anthropic (Claude), OpenAI (GPT), Google (Gemini), xAI (Grok), DeepSeek, and more.
+  - Anthropic (Claude), OpenAI (GPT), Google (Gemini), xAI (Grok), DeepSeek, MiniMax, and more.
   - Use OpenRouter for access to 100+ models, or serve locally with `llama.cpp`.
 - 🌐 **Web UI and REST API**
   - Modern web interface at [chat.gptme.org](https://chat.gptme.org) ([gptme-webui])

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -1,7 +1,7 @@
 Providers
 =========
 
-We support LLMs from several providers, including OpenAI, Anthropic, OpenRouter, Deepseek, Azure, and any OpenAI-compatible server (e.g. ``ollama``, ``llama-cpp-python``).
+We support LLMs from several providers, including OpenAI, Anthropic, OpenRouter, Deepseek, MiniMax, Azure, and any OpenAI-compatible server (e.g. ``ollama``, ``llama-cpp-python``).
 
 .. note::
 
@@ -25,6 +25,7 @@ To select a provider and model, run ``gptme`` with the ``-m``/``--model`` flag s
     gptme "hello" -m gemini/gemini-2.5-flash
     gptme "hello" -m groq/llama-3.3-70b-versatile
     gptme "hello" -m xai/grok-4
+    gptme "hello" -m minimax/MiniMax-M2.7
     gptme "hello" -m local/llama3.2:1b
     gptme "hello" -m gptme/claude-sonnet-4-6
 
@@ -41,6 +42,7 @@ Use the ``[env]`` section in the :ref:`global-config` file to store API keys usi
 - ``XAI_API_KEY="your-api-key"``
 - ``GROQ_API_KEY="your-api-key"``
 - ``DEEPSEEK_API_KEY="your-api-key"``
+- ``MINIMAX_API_KEY="your-api-key"``
 
 .. rubric:: OpenAI Subscription
 

--- a/gptme/llm/__init__.py
+++ b/gptme/llm/__init__.py
@@ -51,6 +51,7 @@ PROVIDER_API_KEYS: dict[str, str] = {
     "groq": "GROQ_API_KEY",
     "xai": "XAI_API_KEY",
     "deepseek": "DEEPSEEK_API_KEY",
+    "minimax": "MINIMAX_API_KEY",
     "azure": "AZURE_OPENAI_API_KEY",
 }
 

--- a/gptme/llm/llm_openai.py
+++ b/gptme/llm/llm_openai.py
@@ -284,6 +284,13 @@ def init(provider: Provider, config: Config):
         clients[provider] = OpenAI(
             api_key=api_key, base_url="https://api.deepseek.com/v1", timeout=timeout
         )
+    elif provider == "minimax":
+        api_key = config.get_env_required("MINIMAX_API_KEY")
+        clients[provider] = OpenAI(
+            api_key=api_key,
+            base_url="https://api.minimax.io/v1",
+            timeout=timeout,
+        )
     elif provider == "nvidia":
         api_key = config.get_env_required("NVIDIA_API_KEY")
         clients[provider] = OpenAI(

--- a/gptme/llm/models.py
+++ b/gptme/llm/models.py
@@ -49,6 +49,7 @@ BuiltinProvider = Literal[
     "groq",
     "xai",
     "deepseek",
+    "minimax",
     "nvidia",
     "local",
 ]
@@ -86,6 +87,7 @@ PROVIDERS_OPENAI = [
     "xai",
     "groq",
     "deepseek",
+    "minimax",
     "nvidia",
     "local",
 ]
@@ -375,6 +377,33 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "max_output": 8192,
             "price_input": 0.55,
             "price_output": 2.19,
+        },
+    },
+    # https://platform.minimaxi.com/document/Models
+    "minimax": {
+        "MiniMax-M2.7": {
+            "context": 1_000_000,
+            "max_output": 131_072,
+            "price_input": 1.0,
+            "price_output": 5.0,
+        },
+        "MiniMax-M2.7-highspeed": {
+            "context": 1_000_000,
+            "max_output": 131_072,
+            "price_input": 0.5,
+            "price_output": 2.5,
+        },
+        "MiniMax-M2.5": {
+            "context": 204_000,
+            "max_output": 131_072,
+            "price_input": 0.8,
+            "price_output": 4.0,
+        },
+        "MiniMax-M2.5-highspeed": {
+            "context": 204_000,
+            "max_output": 131_072,
+            "price_input": 0.4,
+            "price_output": 2.0,
         },
     },
     # https://groq.com/pricing/
@@ -812,6 +841,8 @@ def get_recommended_model(provider: Provider) -> str:  # pragma: no cover
         return "claude-sonnet-4-6"
     if provider == "deepseek":
         return "deepseek-chat"
+    if provider == "minimax":
+        return "MiniMax-M2.7"
     if provider == "groq":
         return "llama-3.3-70b-versatile"
     raise ValueError(
@@ -836,6 +867,8 @@ def get_summary_model(provider: Provider) -> str | None:  # pragma: no cover
         return "claude-haiku-4-5"
     if provider == "deepseek":
         return "deepseek-chat"
+    if provider == "minimax":
+        return "MiniMax-M2.7-highspeed"
     if provider == "xai":
         return "grok-4-1-fast"
     if provider == "local":

--- a/tests/test_llm_minimax.py
+++ b/tests/test_llm_minimax.py
@@ -1,0 +1,187 @@
+"""Tests for MiniMax provider integration."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gptme.llm.models import (
+    MODELS,
+    PROVIDERS,
+    PROVIDERS_OPENAI,
+    ModelMeta,
+    get_model,
+    get_recommended_model,
+    get_summary_model,
+)
+
+
+class TestMiniMaxModels:
+    """Tests for MiniMax model registry entries."""
+
+    def test_minimax_in_builtin_providers(self):
+        """MiniMax should be a registered built-in provider."""
+        assert "minimax" in PROVIDERS
+
+    def test_minimax_in_providers_openai(self):
+        """MiniMax should be in PROVIDERS_OPENAI (OpenAI-compatible)."""
+        assert "minimax" in PROVIDERS_OPENAI
+
+    def test_minimax_in_models_dict(self):
+        """MiniMax should have entries in the MODELS dict."""
+        assert "minimax" in MODELS
+        assert len(MODELS["minimax"]) > 0
+
+    def test_minimax_m27_model(self):
+        """MiniMax-M2.7 should be registered with correct metadata."""
+        model = get_model("minimax/MiniMax-M2.7")
+        assert model.provider == "minimax"
+        assert model.model == "MiniMax-M2.7"
+        assert model.context == 1_000_000
+        assert model.max_output == 131_072
+        assert model.price_input > 0
+        assert model.price_output > 0
+
+    def test_minimax_m27_highspeed_model(self):
+        """MiniMax-M2.7-highspeed should be registered with correct metadata."""
+        model = get_model("minimax/MiniMax-M2.7-highspeed")
+        assert model.provider == "minimax"
+        assert model.model == "MiniMax-M2.7-highspeed"
+        assert model.context == 1_000_000
+        assert model.max_output == 131_072
+        # highspeed variant should be cheaper
+        m27 = get_model("minimax/MiniMax-M2.7")
+        assert model.price_input < m27.price_input
+        assert model.price_output < m27.price_output
+
+    def test_minimax_m25_model(self):
+        """MiniMax-M2.5 should be registered with correct metadata."""
+        model = get_model("minimax/MiniMax-M2.5")
+        assert model.provider == "minimax"
+        assert model.model == "MiniMax-M2.5"
+        assert model.context == 204_000
+
+    def test_minimax_m25_highspeed_model(self):
+        """MiniMax-M2.5-highspeed should be registered with correct metadata."""
+        model = get_model("minimax/MiniMax-M2.5-highspeed")
+        assert model.provider == "minimax"
+        assert model.model == "MiniMax-M2.5-highspeed"
+        assert model.context == 204_000
+
+    def test_all_minimax_models_support_streaming(self):
+        """All MiniMax models should support streaming by default."""
+        for model_name in MODELS["minimax"]:
+            model = get_model(f"minimax/{model_name}")
+            assert model.supports_streaming is True
+
+
+class TestMiniMaxRecommended:
+    """Tests for MiniMax recommended/summary model selection."""
+
+    def test_recommended_model(self):
+        """MiniMax recommended model should be MiniMax-M2.7."""
+        result = get_recommended_model("minimax")
+        assert result == "MiniMax-M2.7"
+        # Verify it exists in MODELS
+        assert result in MODELS["minimax"]
+
+    def test_summary_model(self):
+        """MiniMax summary model should be MiniMax-M2.7-highspeed."""
+        result = get_summary_model("minimax")
+        assert result == "MiniMax-M2.7-highspeed"
+
+    def test_provider_only_resolves(self):
+        """Using just 'minimax' should resolve to recommended model."""
+        model = get_model("minimax")
+        assert model.provider == "minimax"
+        assert model.model == "MiniMax-M2.7"
+
+
+class TestMiniMaxProviderInit:
+    """Tests for MiniMax provider client initialization."""
+
+    @patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key-123"})
+    def test_minimax_api_key_in_provider_keys(self):
+        """MINIMAX_API_KEY should be in PROVIDER_API_KEYS."""
+        from gptme.llm import PROVIDER_API_KEYS
+
+        assert "minimax" in PROVIDER_API_KEYS
+        assert PROVIDER_API_KEYS["minimax"] == "MINIMAX_API_KEY"
+
+    @patch("openai.OpenAI")
+    def test_minimax_client_init(self, mock_openai_cls):
+        """MiniMax provider should initialize OpenAI client with correct base_url."""
+        from gptme.llm.llm_openai import clients, init
+
+        mock_config = MagicMock()
+        mock_config.get_env.return_value = None
+        mock_config.get_env_required.return_value = "test-minimax-key"
+
+        # Clear any existing client
+        clients.pop("minimax", None)
+
+        init("minimax", mock_config)
+
+        mock_openai_cls.assert_called_once()
+        call_kwargs = mock_openai_cls.call_args
+        assert call_kwargs.kwargs["api_key"] == "test-minimax-key"
+        assert call_kwargs.kwargs["base_url"] == "https://api.minimax.io/v1"
+
+
+class TestMiniMaxIntegration:
+    """Integration tests for MiniMax provider (require MINIMAX_API_KEY)."""
+
+    @pytest.fixture(autouse=True)
+    def _check_api_key(self):
+        """Skip integration tests if MINIMAX_API_KEY is not set."""
+        import os
+
+        if not os.environ.get("MINIMAX_API_KEY"):
+            pytest.skip("MINIMAX_API_KEY not set")
+
+    def test_minimax_chat_completion(self):
+        """Test basic chat completion with MiniMax provider."""
+        from gptme.llm import init_llm
+        from gptme.llm.llm_openai import chat
+        from gptme.message import Message
+
+        init_llm("minimax")
+        messages = [
+            Message(role="system", content="You are a helpful assistant."),
+            Message(role="user", content="Say hello in one word."),
+        ]
+        response, metadata = chat(messages, "minimax/MiniMax-M2.7", tools=None)
+        assert response
+        assert len(response) > 0
+
+    def test_minimax_streaming(self):
+        """Test streaming with MiniMax provider."""
+        from gptme.llm import init_llm
+        from gptme.llm.llm_openai import stream
+        from gptme.message import Message
+
+        init_llm("minimax")
+        messages = [
+            Message(role="system", content="You are a helpful assistant."),
+            Message(role="user", content="Say hello in one word."),
+        ]
+        chunks = list(stream(messages, "minimax/MiniMax-M2.7", tools=None))
+        assert len(chunks) > 0
+        full_response = "".join(chunks)
+        assert len(full_response) > 0
+
+    def test_minimax_highspeed_model(self):
+        """Test chat completion with MiniMax-M2.7-highspeed model."""
+        from gptme.llm import init_llm
+        from gptme.llm.llm_openai import chat
+        from gptme.message import Message
+
+        init_llm("minimax")
+        messages = [
+            Message(role="system", content="You are a helpful assistant."),
+            Message(role="user", content="What is 2+2? Answer with just the number."),
+        ]
+        response, metadata = chat(
+            messages, "minimax/MiniMax-M2.7-highspeed", tools=None
+        )
+        assert response
+        assert "4" in response


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimaxi.com/) as a first-class OpenAI-compatible LLM provider, following the same pattern as existing providers (DeepSeek, Groq, xAI, etc.).

### Changes

- **Provider registration**: Added `"minimax"` to `BuiltinProvider` type and `PROVIDERS_OPENAI` list
- **Model registry**: Registered 4 models with context window, pricing, and output limits:
  - `MiniMax-M2.7` (1M context, recommended default)
  - `MiniMax-M2.7-highspeed` (1M context, summary model)
  - `MiniMax-M2.5` (204K context)
  - `MiniMax-M2.5-highspeed` (204K context)
- **API key management**: Added `MINIMAX_API_KEY` to `PROVIDER_API_KEYS` for auto-detection
- **Client initialization**: OpenAI client with `https://api.minimax.io/v1` base URL
- **Documentation**: Updated README, providers docs with MiniMax usage examples
- **Tests**: 13 unit tests + 3 integration tests in `tests/test_llm_minimax.py`

### Usage

```sh
export MINIMAX_API_KEY="your-api-key"
gptme "hello" -m minimax/MiniMax-M2.7
gptme "hello" -m minimax  # uses default MiniMax-M2.7
```

### Files changed (6)

| File | Change |
|------|--------|
| `gptme/llm/models.py` | Add minimax to BuiltinProvider, PROVIDERS_OPENAI, MODELS, recommended/summary |
| `gptme/llm/__init__.py` | Add MINIMAX_API_KEY to PROVIDER_API_KEYS |
| `gptme/llm/llm_openai.py` | Add minimax client initialization |
| `README.md` | Mention MiniMax in providers list |
| `docs/providers.rst` | Add MiniMax usage example and API key docs |
| `tests/test_llm_minimax.py` | 13 unit + 3 integration tests |

## Test plan

- [x] All 13 unit tests pass (`pytest tests/test_llm_minimax.py -k 'not Integration'`)
- [x] All 3 integration tests pass with MINIMAX_API_KEY set
- [x] All 47 existing `test_llm_models.py` tests still pass
- [ ] CI passes

---

MiniMax offers OpenAI-compatible chat completion APIs, making this a minimal integration that follows the exact same pattern as DeepSeek, xAI, and other existing providers.