### PR TITLE
fix(tests): use fully-qualified model names to prevent test pollution

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,9 +231,10 @@ def temp_file():
 @pytest.fixture(autouse=True)
 def init_():
     # Pass MODEL from env explicitly to avoid picking up stale config.chat.model
-    # values left by server tests (e.g. "gpt-4o-mini" from test_v2_chat_config).
-    # When _init_done is reset per-test, init_model() re-runs and would otherwise
-    # read the contaminated config instead of the test environment's MODEL.
+    # values left by server tests. When _init_done is reset per-test, init_model()
+    # re-runs and would otherwise read the contaminated config instead of the test
+    # environment's MODEL. Server tests now use fully-qualified model names
+    # (e.g. "openai/gpt-4o-mini") to prevent provider validation errors.
     model = os.environ.get("MODEL")
     init(model, interactive=False, tool_allowlist=None, tool_format="markdown")
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -262,7 +262,7 @@ def test_v2_interrupt(v2_conv, client: FlaskClient):
 
 def test_v2_chat_config_saved_on_conversation_create(client: FlaskClient):
     """Test that the chat config is saved on conversation create."""
-    input_config = ChatConfig(model="gpt-4o")
+    input_config = ChatConfig(model="openai/gpt-4o")
     input_config.tools = [t.name for t in get_toolchain(None) if not t.is_mcp]
     input_config.mcp = MCPConfig()
     conversation_id = create_conversation(client, input_config)["conversation_id"]
@@ -289,12 +289,12 @@ def test_v2_chat_config_saved_on_conversation_create(client: FlaskClient):
 
 def test_v2_chat_config_saved_separately_for_each_conversation(client: FlaskClient):
     """Test that the chat config is saved separately for each conversation."""
-    input_config_1 = ChatConfig(model="gpt-4o")
+    input_config_1 = ChatConfig(model="openai/gpt-4o")
     input_config_1.tools = [t.name for t in get_toolchain(None) if not t.is_mcp]
     input_config_1.mcp = MCPConfig()
     conversation_id_1 = create_conversation(client, input_config_1)["conversation_id"]
 
-    input_config_2 = ChatConfig(model="gpt-4o-mini")
+    input_config_2 = ChatConfig(model="openai/gpt-4o-mini")
     input_config_2.tools = [t.name for t in get_toolchain(None) if not t.is_mcp]
     input_config_2.mcp = MCPConfig()
     conversation_id_2 = create_conversation(client, input_config_2)["conversation_id"]
@@ -312,7 +312,7 @@ def test_v2_chat_config_saved_separately_for_each_conversation(client: FlaskClie
 
 def test_v2_chat_config_get_works(client: FlaskClient):
     """Test that the chat config get endpoint works."""
-    input_config = ChatConfig(model="gpt-4o")
+    input_config = ChatConfig(model="openai/gpt-4o")
     input_config.tools = [t.name for t in get_toolchain(None) if not t.is_mcp]
     input_config.mcp = MCPConfig()
     conversation_id = create_conversation(client, input_config)["conversation_id"]
@@ -326,7 +326,7 @@ def test_v2_chat_config_get_works(client: FlaskClient):
 
 def test_v2_chat_config_update_works(client: FlaskClient):
     """Test that the chat config update endpoint works."""
-    input_config = ChatConfig(model="gpt-4o")
+    input_config = ChatConfig(model="openai/gpt-4o")
     input_config.tools = [t.name for t in get_toolchain(None) if not t.is_mcp]
     input_config.mcp = MCPConfig()
     conversation_id = create_conversation(client, input_config)["conversation_id"]
@@ -335,7 +335,7 @@ def test_v2_chat_config_update_works(client: FlaskClient):
     config = ChatConfig.from_dict(response.get_json())
     assert config.to_dict() == input_config.to_dict()
 
-    input_config.model = "gpt-4o-mini"
+    input_config.model = "openai/gpt-4o-mini"
     response = client.patch(
         f"/api/v2/conversations/{conversation_id}/config", json=input_config.to_dict()
     )


### PR DESCRIPTION
## Summary

- Server v2 config tests used bare model names (`"gpt-4o-mini"`, `"gpt-4o"`) that polluted global config state
- When other server v2 test files ran after these tests in the full suite, they hit `ValueError: Provider 'gpt-4o-mini' requires specifying a model` errors  
- Fix: use fully-qualified names (`"openai/gpt-4o"`, `"openai/gpt-4o-mini"`) consistently

This is a follow-up to #1757 which partially addressed test isolation but didn't catch this remaining pollution source.

## Test plan

- [x] All 21 server v2 tests pass when run together
- [x] Config-specific tests pass with qualified model names
- [x] ruff and mypy checks pass
- [ ] Full CI suite confirms no more pollution errors