### PR TITLE
feat(prompts): include git status in workspace prompt

### DIFF
--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -1,4 +1,5 @@
 import logging
+import subprocess
 from collections.abc import Generator
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -14,6 +15,64 @@ if TYPE_CHECKING:
     from ..util.uri import FilePath
 
 logger = logging.getLogger(__name__)
+
+
+def _get_git_status(workspace: Path) -> str | None:
+    """Get git branch and working tree status for the workspace.
+
+    Returns a formatted string with the current branch and any
+    modified/untracked files, or None if not a git repo.
+    """
+    try:
+        # Check if in a git repo
+        result = subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            check=False,
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if result.returncode != 0:
+            return None
+
+        # Get current branch
+        branch_result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            check=False,
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        branch = (
+            branch_result.stdout.strip() if branch_result.returncode == 0 else "unknown"
+        )
+
+        # Get short status (modified/untracked files)
+        status_result = subprocess.run(
+            ["git", "status", "--short"],
+            check=False,
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        status_lines = (
+            status_result.stdout.strip() if status_result.returncode == 0 else ""
+        )
+
+        if status_lines:
+            # Truncate if too many changes (keep it concise)
+            lines = status_lines.splitlines()
+            if len(lines) > 20:
+                shown = "\n".join(lines[:20])
+                status_lines = f"{shown}\n... and {len(lines) - 20} more files"
+            return f"**Branch:** `{branch}`\n\n{md_codeblock('', status_lines)}"
+        return f"**Branch:** `{branch}` (clean)"
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        logger.debug(f"Error getting git status: {e}")
+        return None
 
 
 def find_agent_files_in_tree(
@@ -64,7 +123,6 @@ def prompt_workspace(
 ) -> Generator[Message, None, None]:
     """Generate the workspace context prompt."""
     # TODO: update this prompt if the files change
-    # TODO: include `git status`, and keep it up-to-date
     sections = []
 
     if workspace is None:
@@ -194,6 +252,10 @@ def prompt_workspace(
     # Get tree output if enabled
     if tree_output := get_tree_output(workspace):
         sections.append(f"## Project Structure\n\n{md_codeblock('', tree_output)}\n\n")
+
+    # Get git status (branch + working tree changes)
+    if git_status := _get_git_status(workspace):
+        sections.append(f"## Git Status\n\n{git_status}")
 
     if sections:
         yield Message("system", f"# {title}\n\n" + "\n\n".join(sections))

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -145,3 +145,104 @@ files = ["../outside/secret.txt", "README.md"]
         "secret.txt should NOT be attached (path traversal)"
     )
     assert "../outside/secret.txt" not in content, "Path traversal should be blocked"
+
+
+def test_workspace_git_status_in_git_repo(tmp_path):
+    """Test that git status is included in workspace prompt for git repos."""
+    import subprocess
+
+    from gptme.prompts.workspace import _get_git_status
+
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+
+    # Initialize a git repo on a test branch (avoids master-protection hooks)
+    subprocess.run(
+        ["git", "init", "-b", "test-branch"],
+        cwd=workspace,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=workspace,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=workspace,
+        capture_output=True,
+        check=True,
+    )
+
+    # Clean repo (no commits yet, but git status should still work)
+    result = _get_git_status(workspace)
+    assert result is not None
+    assert "Branch" in result
+
+    # Add a file and check status shows it
+    (workspace / "hello.txt").write_text("hello")
+    result = _get_git_status(workspace)
+    assert result is not None
+    assert "hello.txt" in result
+    assert "Branch" in result
+
+    # Commit and verify clean status
+    subprocess.run(
+        ["git", "add", "hello.txt"], cwd=workspace, capture_output=True, check=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "init", "--no-verify"],
+        cwd=workspace,
+        capture_output=True,
+        check=True,
+    )
+    result = _get_git_status(workspace)
+    assert result is not None
+    assert "(clean)" in result
+    assert "test-branch" in result
+
+
+def test_workspace_git_status_not_git_repo(tmp_path):
+    """Test that git status returns None for non-git directories."""
+    from gptme.prompts.workspace import _get_git_status
+
+    result = _get_git_status(tmp_path)
+    assert result is None
+
+
+def test_workspace_git_status_in_prompt(tmp_path):
+    """Test that git status section appears in workspace prompt messages."""
+    import subprocess
+
+    from gptme.prompts import prompt_workspace
+
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    subprocess.run(
+        ["git", "init", "-b", "test-branch"],
+        cwd=workspace,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=workspace,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=workspace,
+        capture_output=True,
+        check=True,
+    )
+
+    # Add an untracked file so status shows something
+    (workspace / "README.md").write_text("# Test")
+
+    msgs = list(prompt_workspace(workspace))
+    content = "\n".join(msg.content for msg in msgs)
+    assert "Git Status" in content
+    assert "Branch" in content


### PR DESCRIPTION
## Summary

- Adds git branch name and working tree status (modified/untracked files) to the workspace prompt
- Agents get immediate awareness of the repo state at session start without needing to run `git status` manually
- Truncates to 20 files when many changes exist to keep the prompt concise
- Gracefully handles non-git directories and git command failures (timeouts, missing binary)

Resolves the TODO at `workspace.py:67`.

## Test plan

- [x] 3 new tests: git repo with changes, non-git directory, integration with `prompt_workspace()`
- [x] All 10 existing prompt tests still pass
- [x] mypy clean
- [x] ruff clean