### PR TITLE
refactor(prompts): separate dynamic context for better prompt caching

### DIFF
--- a/gptme/prompts/__init__.py
+++ b/gptme/prompts/__init__.py
@@ -229,14 +229,11 @@ def get_prompt(
                 prompt_tools(tools=tools, tool_format=tool_format, model=model)
             )
 
-    # TODO: generate context_cmd outputs separately and put them last in a "dynamic context" section
-    #       with context known not to cache well across conversation starts, so that cache points can be set before and better utilized/changed less frequently.
-    #       probably together with chat history since it's also dynamic/live context.
-    #       as opposed to static (core/system prompt) and semi-static (workspace/project prompt, like files).
-
     # Generate workspace messages separately (if included)
+    # Always exclude context_cmd here — it's collected separately below
+    # for better prompt caching (static/semi-static content first, dynamic last).
     workspace_msgs = (
-        list(prompt_workspace(workspace, include_context_cmd=include_context_cmd))
+        list(prompt_workspace(workspace, include_context_cmd=False))
         if include_workspace and workspace and workspace != agent_path
         else []
     )
@@ -248,12 +245,41 @@ def get_prompt(
                 agent_path,
                 title="Agent Config",
                 include_path=True,
-                include_context_cmd=include_context_cmd,
+                include_context_cmd=False,
             )
         )
         if include_agent_config
         else []
     )
+
+    # Collect dynamic context_cmd outputs separately.
+    # By placing these after all static/semi-static content, we maximize the
+    # prompt prefix that can be cached across conversation starts (core prompt,
+    # workspace files, agent config rarely change; context_cmd changes every session).
+    dynamic_context_msgs: list[Message] = []
+    if include_context_cmd:
+        for ws, title in [
+            (agent_path if include_agent_config else None, "Agent"),
+            (
+                workspace if include_workspace and workspace != agent_path else None,
+                "Project",
+            ),
+        ]:
+            if ws is None:
+                continue
+            ws_project = get_project_config(ws)
+            if (
+                ws_project
+                and ws_project.context_cmd
+                and (
+                    cmd_output := get_project_context_cmd_output(
+                        ws_project.context_cmd, ws
+                    )
+                )
+            ):
+                dynamic_context_msgs.append(
+                    Message("system", f"## {title} computed context\n\n" + cmd_output)
+                )
 
     # Combine core messages into one system prompt
     result = []
@@ -269,8 +295,10 @@ def get_prompt(
     if include_workspace:
         result.extend(workspace_msgs)
 
-    # Generate cross-conversation context if enabled
-    # Add chat history context
+    # Dynamic context last (changes every session, least cacheable)
+    result.extend(dynamic_context_msgs)
+
+    # Chat history (also dynamic)
     result.extend(prompt_chat_history())
 
     # Set hide=True, pinned=True for all messages

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -204,6 +204,44 @@ def test_workspace_git_status_in_git_repo(tmp_path):
     assert "test-branch" in result
 
 
+def test_dynamic_context_after_static(tmp_path):
+    """Test that context_cmd output comes after static workspace content.
+
+    This ordering improves prompt caching: static/semi-static content first
+    (cacheable prefix), dynamic context last (changes every session).
+    """
+    from gptme.prompts import get_prompt
+
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    (workspace / "README.md").write_text("# Test Project")
+    (workspace / "gptme.toml").write_text(
+        '[prompt]\nfiles = ["README.md"]\ncontext_cmd = "echo DYNAMIC_MARKER_123"\n'
+    )
+
+    msgs = get_prompt(
+        get_tools(),
+        prompt="full",
+        workspace=workspace,
+    )
+
+    # Find the indices of workspace file content and dynamic context
+    file_idx = None
+    dynamic_idx = None
+    for i, msg in enumerate(msgs):
+        if "README.md" in msg.content:
+            file_idx = i
+        if "DYNAMIC_MARKER_123" in msg.content:
+            dynamic_idx = i
+
+    assert file_idx is not None, "Should include workspace files"
+    assert dynamic_idx is not None, "Should include context_cmd output"
+    assert dynamic_idx > file_idx, (
+        f"Dynamic context (msg {dynamic_idx}) should come after "
+        f"static workspace files (msg {file_idx})"
+    )
+
+
 def test_workspace_git_status_not_git_repo(tmp_path):
     """Test that git status returns None for non-git directories."""
     from gptme.prompts.workspace import _get_git_status


### PR DESCRIPTION
## Summary

- Moves `context_cmd` output from inside workspace messages to a separate section at the end of the system prompt
- Static/semi-static content (core prompt, agent config, workspace files) now forms a longer cacheable prefix
- Dynamic content (`context_cmd` output, chat history) comes last — only this part invalidates the cache across sessions

**Message ordering (before):**
1. Core system prompt (static)
2. Agent config + context_cmd (mixed static/dynamic)
3. Workspace files + context_cmd (mixed static/dynamic)
4. Chat history (dynamic)

**Message ordering (after):**
1. Core system prompt (static) ← cacheable
2. Agent config (semi-static) ← cacheable
3. Workspace files (semi-static) ← cacheable
4. Dynamic context: context_cmd outputs ← changes every session
5. Chat history ← changes every session

This improves prompt caching efficiency for providers that support prefix caching (Anthropic, OpenAI), since the static prefix is now uninterrupted by dynamic content.

Resolves the TODO at `prompts/__init__.py:232`.

## Test plan

- [x] All 11 prompt tests pass (10 existing + 1 new)
- [x] All 15 context tests pass
- [x] mypy clean
- [x] ruff clean
- [x] New test `test_dynamic_context_after_static` verifies ordering