### PR TITLE
fix: improve type safety — remove 4 type: ignore comments

### DIFF
--- a/gptme/chat.py
+++ b/gptme/chat.py
@@ -99,7 +99,7 @@ def chat(
     # Use nested if/else for proper mypy type narrowing
     if model is None:
         if default_model is None:
-            raise AssertionError("No model loaded and no model specified")
+            raise ValueError("No model loaded and no model specified")
         model_to_use = default_model.full
     else:
         model_to_use = model
@@ -475,7 +475,7 @@ def step(
     # Use nested if/else for proper mypy type narrowing
     if model is None:
         if default_model is None:
-            raise AssertionError("No model loaded and no model specified")
+            raise ValueError("No model loaded and no model specified")
         model = default_model.full
     if isinstance(log, list):
         log = Log(log)

--- a/gptme/commands/session.py
+++ b/gptme/commands/session.py
@@ -226,7 +226,7 @@ def _edit(
     from ..util.useredit import edit_text_with_editor  # fmt: skip
 
     # generate editable toml of all messages
-    t = msgs_to_toml(reversed(manager.log))  # type: ignore[arg-type]
+    t = msgs_to_toml(reversed(manager.log))
     res = None
     while not res:
         t = edit_text_with_editor(t, "toml")

--- a/gptme/message.py
+++ b/gptme/message.py
@@ -3,6 +3,7 @@ import logging
 import shutil
 import sys
 import textwrap
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Literal, TypedDict
@@ -489,7 +490,7 @@ def print_msg(
         )
 
 
-def msgs_to_toml(msgs: list[Message]) -> str:
+def msgs_to_toml(msgs: Iterable[Message]) -> str:
     """Converts a list of messages to a TOML string, for easy editing by hand in editor to then be parsed back."""
     t = ""
     for msg in msgs:

--- a/gptme/prompts/chat_history.py
+++ b/gptme/prompts/chat_history.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 def use_chat_history_context() -> bool:
     """Check if cross-conversation context is enabled."""
     config = get_config()
-    flag: str = config.get_env("GPTME_CHAT_HISTORY", "")  # type: ignore[assignment]
+    flag = config.get_env("GPTME_CHAT_HISTORY", "") or ""
     return flag.lower() in ("1", "true", "yes")
 
 

--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -438,7 +438,9 @@ def conversation_stats(since: str | None = None, as_json: bool = False) -> None:
                     "input_tokens": model_input_tokens[m],
                     "output_tokens": model_output_tokens[m],
                 }
-                for m in sorted(model_counts, key=model_counts.get, reverse=True)  # type: ignore
+                for m in sorted(
+                    model_counts, key=lambda m: model_counts.get(m, 0), reverse=True
+                )
             },
             "by_day": {
                 (now - timedelta(days=i)).strftime("%Y-%m-%d"): daily_counts.get(
@@ -487,7 +489,9 @@ def conversation_stats(since: str | None = None, as_json: bool = False) -> None:
     known_models = {m: c for m, c in model_counts.items() if m != "unknown"}
     if known_models:
         print("\nBy Model")
-        top_models = sorted(known_models, key=known_models.get, reverse=True)[:15]  # type: ignore[arg-type]
+        top_models = sorted(
+            known_models, key=lambda m: known_models.get(m, 0), reverse=True
+        )[:15]
         for model in top_models:
             count = known_models[model]
             cost = model_cost[model]


### PR DESCRIPTION
## Summary
- Remove 4 `type: ignore` comments by fixing the underlying type issues
- Widen `msgs_to_toml` signature from `list[Message]` to `Iterable[Message]` (it only iterates)
- Replace `AssertionError` with `ValueError` for runtime precondition checks in `chat.py`
- Use explicit lambda for `dict.get` sort keys in `chats.py` to handle Optional return
- Handle Optional config return in `chat_history.py` with `or ""` fallback

## Changes
- `message.py`: `msgs_to_toml(msgs: list[Message])` → `msgs_to_toml(msgs: Iterable[Message])`
- `commands/session.py`: Remove now-unnecessary `type: ignore[arg-type]`
- `chat.py`: `AssertionError` → `ValueError` (2 occurrences)
- `prompts/chat_history.py`: Handle Optional with `or ""` instead of `type: ignore[assignment]`
- `tools/chats.py`: Lambda sort keys instead of bare `dict.get` (2 occurrences)

## Test plan
- [x] All 52 prompt/context tests pass locally
- [x] mypy clean
- [x] ruff clean