### PR TITLE
fix: remove 19 type: ignore comments — batch 2

### DIFF
--- a/gptme/context/task_analyzer.py
+++ b/gptme/context/task_analyzer.py
@@ -308,7 +308,7 @@ def classify_task(features: TaskFeatures) -> TaskClassification:
         scores = {k: v / max_score for k, v in scores.items()}
 
     # Select primary type (highest score)
-    primary_type = max(scores, key=scores.get)  # type: ignore[arg-type]
+    primary_type = max(scores, key=lambda k: scores[k])
     confidence = scores[primary_type]
 
     # Secondary types (score > 0.5)

--- a/gptme/hooks/tests/test_markdown_validation.py
+++ b/gptme/hooks/tests/test_markdown_validation.py
@@ -1,6 +1,7 @@
 """Tests for markdown_validation hook."""
 
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -26,7 +27,9 @@ class TestCheckLastLineSuspicious:
         assert pattern is None
 
     def test_none_content(self):
-        is_suspicious, pattern = check_last_line_suspicious(None)  # type: ignore
+        # Verify defensive behavior with invalid input
+        content: Any = None
+        is_suspicious, pattern = check_last_line_suspicious(content)
         assert not is_suspicious
         assert pattern is None
 
@@ -109,7 +112,7 @@ class TestCheckLastLineSuspicious:
         assert "header start" in pattern
 
 
-def _make_manager(messages: list[Message]) -> SimpleNamespace:
+def _make_manager(messages: list[Message]) -> Any:
     """Create a minimal mock LogManager with given messages."""
     return SimpleNamespace(log=Log(messages))
 
@@ -119,25 +122,25 @@ class TestValidateMarkdownOnMessageComplete:
 
     def test_empty_log(self):
         manager = _make_manager([])
-        msgs = list(validate_markdown_on_message_complete(manager))  # type: ignore[arg-type]
+        msgs = list(validate_markdown_on_message_complete(manager))
         assert len(msgs) == 0
 
     def test_user_message_ignored(self):
         """Non-assistant messages should not trigger validation."""
         manager = _make_manager([Message("user", "# Hello\n```\ncode\n```")])
-        msgs = list(validate_markdown_on_message_complete(manager))  # type: ignore[arg-type]
+        msgs = list(validate_markdown_on_message_complete(manager))
         assert len(msgs) == 0
 
     def test_system_message_ignored(self):
         """System messages should not trigger validation."""
         manager = _make_manager([Message("system", "# Some header")])
-        msgs = list(validate_markdown_on_message_complete(manager))  # type: ignore[arg-type]
+        msgs = list(validate_markdown_on_message_complete(manager))
         assert len(msgs) == 0
 
     def test_assistant_message_no_tooluse(self):
         """Assistant message without tool uses should not trigger."""
         manager = _make_manager([Message("assistant", "Just a plain text response")])
-        msgs = list(validate_markdown_on_message_complete(manager))  # type: ignore[arg-type]
+        msgs = list(validate_markdown_on_message_complete(manager))
         assert len(msgs) == 0
 
     def test_assistant_with_clean_save(self):
@@ -146,7 +149,7 @@ class TestValidateMarkdownOnMessageComplete:
             "Saving the file:\n\n```save test.py\ndef hello():\n    print('hello')\n```"
         )
         manager = _make_manager([Message("assistant", content)])
-        msgs = list(validate_markdown_on_message_complete(manager))  # type: ignore[arg-type]
+        msgs = list(validate_markdown_on_message_complete(manager))
         assert len(msgs) == 0
 
     def test_assistant_with_properly_closed_save(self):
@@ -156,7 +159,7 @@ class TestValidateMarkdownOnMessageComplete:
         # the closing backticks came from the parser, not the LLM.
         content = "Saving:\n\n```save test.md\nSome content\n# Cut Off Header\n```"
         manager = _make_manager([Message("assistant", content)])
-        msgs = list(validate_markdown_on_message_complete(manager))  # type: ignore[arg-type]
+        msgs = list(validate_markdown_on_message_complete(manager))
         # The tool use content is "Some content\n# Cut Off Header"
         # check_last_line_suspicious would flag this, but the parser may handle
         # the content differently. Either 0 or 1 warnings is acceptable —
@@ -169,6 +172,6 @@ class TestValidateMarkdownOnMessageComplete:
         suspicious = Message("assistant", "```save f.md\nold\n# Cut\n```")
         safe = Message("assistant", "All done, nothing to save.")
         manager = _make_manager([suspicious, safe])
-        msgs = list(validate_markdown_on_message_complete(manager))  # type: ignore[arg-type]
+        msgs = list(validate_markdown_on_message_complete(manager))
         # Last message is safe (no tool use), so no warning
         assert len(msgs) == 0

--- a/gptme/hooks/tests/test_server_elicit.py
+++ b/gptme/hooks/tests/test_server_elicit.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from gptme.hooks.elicitation import ElicitationRequest, ElicitationResponse
+from gptme.hooks.elicitation import (
+    ElicitationRequest,
+    ElicitationResponse,
+    ElicitationType,
+)
 from gptme.hooks.server_confirm import current_conversation_id, current_session_id
 from gptme.hooks.server_elicit import (
     PendingElicitation,
@@ -31,7 +35,7 @@ def reset_state():
 
 
 def _make_request(
-    type: str = "text",
+    type: ElicitationType = "text",
     prompt: str = "Enter value:",
     options: list[str] | None = None,
     default: str | None = None,
@@ -39,7 +43,7 @@ def _make_request(
 ) -> ElicitationRequest:
     """Create an ElicitationRequest."""
     return ElicitationRequest(
-        type=type,  # type: ignore[arg-type]
+        type=type,
         prompt=prompt,
         options=options,
         default=default,

--- a/gptme/hooks/tests/test_token_awareness.py
+++ b/gptme/hooks/tests/test_token_awareness.py
@@ -101,7 +101,8 @@ class TestAddTokenUsageWarning:
             "gptme.llm.models.get_default_model",
             return_value=_make_model(),
         ):
-            msgs = list(add_token_usage_warning(None, None, None))  # type: ignore[arg-type]
+            log: Any = None
+            msgs = list(add_token_usage_warning(log, None, None))
         assert msgs == []
 
     def test_no_model_yields_nothing(self):

--- a/gptme/hooks/tests/test_workspace_agents.py
+++ b/gptme/hooks/tests/test_workspace_agents.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -399,7 +400,7 @@ class TestStepPreAgents:
         mod._last_scan_time = 0.0
         return
 
-    def _make_manager(self) -> object:
+    def _make_manager(self) -> Any:
         """Create a minimal mock LogManager."""
         from types import SimpleNamespace
 
@@ -407,7 +408,7 @@ class TestStepPreAgents:
 
     def test_no_workspace_no_scan(self) -> None:
         """If workspace was never set (e.g. no session_start), no scan happens."""
-        msgs = list(step_pre_agents(self._make_manager()))  # type: ignore[arg-type]
+        msgs = list(step_pre_agents(self._make_manager()))
         assert len(msgs) == 0
 
     def test_throttled_no_repeat(self) -> None:
@@ -421,7 +422,7 @@ class TestStepPreAgents:
         mod._last_scan_time = time.time()  # Just scanned
 
         with patch("gptme.hooks.workspace_agents.scan_agents") as mock_scan:
-            msgs = list(step_pre_agents(self._make_manager()))  # type: ignore[arg-type]
+            msgs = list(step_pre_agents(self._make_manager()))
             mock_scan.assert_not_called()
             assert len(msgs) == 0
 
@@ -443,7 +444,7 @@ class TestStepPreAgents:
         with patch(
             "gptme.hooks.workspace_agents.scan_agents", return_value=[new_agent]
         ):
-            msgs = list(step_pre_agents(self._make_manager()))  # type: ignore[arg-type]
+            msgs = list(step_pre_agents(self._make_manager()))
             assert len(msgs) == 1
             assert isinstance(msgs[0], Message)
             assert "arrived" in msgs[0].content.lower()
@@ -464,7 +465,7 @@ class TestStepPreAgents:
         mod._last_scan_time = 0.0  # Force rescan
 
         with patch("gptme.hooks.workspace_agents.scan_agents", return_value=[]):
-            msgs = list(step_pre_agents(self._make_manager()))  # type: ignore[arg-type]
+            msgs = list(step_pre_agents(self._make_manager()))
             assert len(msgs) == 1
             assert isinstance(msgs[0], Message)
             assert "departed" in msgs[0].content.lower()
@@ -486,7 +487,7 @@ class TestStepPreAgents:
             stale_reason="zombie",
         )
         with patch("gptme.hooks.workspace_agents.scan_agents", return_value=[stale]):
-            msgs = list(step_pre_agents(self._make_manager()))  # type: ignore[arg-type]
+            msgs = list(step_pre_agents(self._make_manager()))
             # Stale arrivals are tracked but don't produce messages
             assert len(msgs) == 0
 
@@ -502,5 +503,5 @@ class TestStepPreAgents:
             "gptme.hooks.workspace_agents.scan_agents",
             side_effect=OSError("permission denied"),
         ):
-            msgs = list(step_pre_agents(self._make_manager()))  # type: ignore[arg-type]
+            msgs = list(step_pre_agents(self._make_manager()))
             assert len(msgs) == 0

--- a/gptme/logmanager/conversations.py
+++ b/gptme/logmanager/conversations.py
@@ -225,7 +225,9 @@ def rename_conversation(conv_id: str, new_name: str) -> bool:
 
     if "chat" not in config_data:
         config_data.add("chat", tomlkit.table())
-    config_data["chat"]["name"] = new_name  # type: ignore[index]
+    chat_section = config_data["chat"]
+    assert isinstance(chat_section, dict)
+    chat_section["name"] = new_name
 
     with open(config_path, "w") as f:
         tomlkit.dump(config_data, f)

--- a/gptme/logmanager/manager.py
+++ b/gptme/logmanager/manager.py
@@ -21,7 +21,7 @@ if os.name == "nt":
         import msvcrt as _msvcrt
     except ImportError:
         pass
-from collections.abc import Generator
+from collections.abc import Generator, Iterator
 from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
@@ -83,9 +83,9 @@ class Log:
 
     @classmethod
     def read_jsonl(cls, path: PathLike, limit=None) -> "Log":
-        gen = _gen_read_jsonl(path)
+        gen: Iterator[Message] = _gen_read_jsonl(path)
         if limit:
-            gen = islice(gen, limit)  # type: ignore[assignment]
+            gen = islice(gen, limit)
         return Log(list(gen))
 
     def write_jsonl(self, path: PathLike) -> None:


### PR DESCRIPTION
## Summary

Continues the type safety improvements from #1769. Removes 19 `type: ignore` comments across 7 files using proper type fixes instead of suppressions.

**Changes by file:**
- `test_markdown_validation.py`: Return `Any` from mock factory instead of `SimpleNamespace` — removes 8 `type: ignore[arg-type]` from callers
- `test_workspace_agents.py`: Return `Any` from mock factory instead of `object` — removes 6 `type: ignore[arg-type]`
- `test_token_awareness.py`: Use `Any`-typed variable for None defense test — removes 1
- `test_server_elicit.py`: Use `ElicitationType` instead of `str` for type parameter — removes 1
- `task_analyzer.py`: Use `lambda k: scores[k]` instead of `scores.get` as `max()` key — removes 1
- `logmanager/manager.py`: Annotate `gen` as `Iterator[Message]` so `islice` assignment is valid — removes 1
- `logmanager/conversations.py`: Assert `dict` type for tomlkit section before indexing — removes 1

Remaining `type: ignore` count drops from 50 → 31.

## Test plan

- [x] All 107 affected tests pass
- [x] mypy reports 0 issues on all 7 changed files
- [ ] CI passes