### PR TITLE
feat(prompts): auto-load cross-tool AI instruction files

### DIFF
--- a/gptme/prompts/__init__.py
+++ b/gptme/prompts/__init__.py
@@ -23,7 +23,7 @@ from ..util import document_prompt_function
 AGENT_FILES = [
     "AGENTS.md",
     "CLAUDE.md",  # Claude Code
-    "COPILOT.md",  # GitHub Copilot (CLAUDE.md-style convention)
+    "COPILOT.md",  # gptme-invented convention mirroring CLAUDE.md/GEMINI.md
     "GEMINI.md",  # Gemini
     ".github/copilot-instructions.md",  # GitHub Copilot official project instructions
     ".cursorrules",  # Cursor legacy project rules

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -108,12 +108,22 @@ def find_agent_files_in_tree(
     # Reverse: most general (home) first, most specific (target) last
     dirs_to_check.reverse()
 
+    # Files authored for other AI tools — loaded for cross-tool compatibility,
+    # but users should be aware they may contain instructions not intended for gptme.
+    _cross_tool_files = frozenset({".cursorrules", ".windsurfrules"})
+
     for dir_path in dirs_to_check:
         for filename in AGENT_FILES:
             agent_file = dir_path / filename
             if agent_file.exists():
                 resolved = str(agent_file.resolve())
                 if resolved not in _exclude:
+                    if filename in _cross_tool_files:
+                        logger.debug(
+                            "Loading cross-tool instruction file %s"
+                            " (authored for a different AI tool — instructions may not be gptme-compatible)",
+                            agent_file,
+                        )
                     result.append(agent_file)
 
     return result

--- a/tests/test_agents_md_inject.py
+++ b/tests/test_agents_md_inject.py
@@ -19,7 +19,7 @@ from gptme.hooks.agents_md_inject import (
     on_cwd_changed,
 )
 from gptme.message import Message
-from gptme.prompts import _loaded_agent_files_var, find_agent_files_in_tree
+from gptme.prompts import AGENT_FILES, _loaded_agent_files_var, find_agent_files_in_tree
 
 
 def _messages_only(items: list) -> list[Message]:
@@ -181,7 +181,7 @@ class TestFindAgentFiles:
         assert str((project / ".cursorrules").resolve()) in local
         assert str((project / ".windsurfrules").resolve()) in local
         assert str((project / ".github" / "copilot-instructions.md").resolve()) in local
-        assert len(local) == 7
+        assert len(local) == len(AGENT_FILES)
 
 
 class TestOnCwdChanged:


### PR DESCRIPTION
## Summary

- Add `.cursorrules`, `.windsurfrules`, `.github/copilot-instructions.md`, and `COPILOT.md` to the agent instruction files auto-loaded by gptme
- Many projects have instruction files for Cursor, Windsurf/Codeium, or GitHub Copilot that serve the same purpose as `AGENTS.md`/`CLAUDE.md` — gptme now respects them automatically
- Cross-tool compatibility: users switching from or using multiple AI tools get a seamless experience

## Changes

- `gptme/prompts/__init__.py`: Extended `AGENT_FILES` list with 4 new entries
- `gptme/prompts/workspace.py`: Updated `find_agent_files_in_tree()` docstring
- `tests/test_agents_md_inject.py`: Added 5 new tests (`.cursorrules`, `.windsurfrules`, `.github/copilot-instructions.md`, `COPILOT.md`, all-files-together)

## Test plan

- [x] All 16 agent file tests pass (5 new)
- [x] Full fast test suite: 2348 passed, 0 failures
- [x] mypy clean on `gptme/prompts/`
- [ ] Verify CI passes