### PR TITLE
test(vision): add unit tests for view_image function

### DIFF
--- a/tests/test_tools_vision.py
+++ b/tests/test_tools_vision.py
@@ -167,9 +167,9 @@ class TestViewImageErrors:
         assert "not found" in msg.content.lower()
         assert len(msg.files) == 0
 
-    def test_nonexistent_string_path(self):
+    def test_nonexistent_string_path(self, tmp_path: Path):
         """Non-existent string path should return error message."""
-        msg = view_image("/tmp/absolutely_nonexistent_image_12345.png")
+        msg = view_image(str(tmp_path / "nonexistent.png"))
         assert msg.role == "system"
         assert "not found" in msg.content.lower()
 


### PR DESCRIPTION
## Summary

- Add 14 tests for the `view_image` function in `gptme/tools/vision.py`, which previously had **zero test coverage**
- Tests cover: small images (no scaling), large images (JPEG compression + scaling), PIL Image input, error handling, and format support (JPEG, grayscale, palette)

## Test plan

- [x] All 14 tests pass locally (`pytest tests/test_tools_vision.py -v`)
- [x] mypy passes
- [x] ruff passes
- [ ] CI passes