### PR TITLE
test(hooks): add unit tests for hook registry module

### DIFF
--- a/tests/test_hooks_registry.py
+++ b/tests/test_hooks_registry.py
@@ -11,6 +11,8 @@ import threading
 import unittest.mock
 from typing import Any
 
+import pytest
+
 from gptme.hooks.registry import (
     HookRegistry,
     clear_hooks,
@@ -513,8 +515,6 @@ class TestErrorHandling:
             _make_error_hook(SessionCompleteException("done")),
         )
 
-        import pytest
-
         with pytest.raises(SessionCompleteException):
             list(registry.trigger(HookType.STEP_PRE))
 
@@ -566,7 +566,7 @@ class TestAsyncHooks:
 
         messages = list(registry.trigger(HookType.STEP_PRE))
         assert messages == []  # async messages are logged, not yielded
-        event.wait(timeout=2.0)
+        assert event.wait(timeout=2.0), "Async hook did not execute"
 
     def test_async_and_sync_hooks_together(self):
         """Sync hooks yield messages; async hooks run in background."""
@@ -615,7 +615,7 @@ class TestAsyncHooks:
         messages = list(registry.trigger(HookType.STEP_PRE))
         assert messages == []
         # Give thread time to complete
-        error_event.wait(timeout=2.0)
+        assert error_event.wait(timeout=2.0), "Async error hook did not execute"
 
 
 # ── HookRegistry: Priority Sorting (Hook.__lt__) ────────────────────
@@ -690,7 +690,8 @@ class TestClearHooks:
         registry.register("a", HookType.SESSION_START, _make_noop_hook())
         registry.register("b", HookType.SESSION_END, _make_noop_hook())
 
-        registry.hooks.clear()
+        registry.unregister("a")
+        registry.unregister("b")
         assert registry.get_hooks() == []
 
     def test_clear_by_type(self):
@@ -698,7 +699,7 @@ class TestClearHooks:
         registry.register("a", HookType.SESSION_START, _make_noop_hook())
         registry.register("b", HookType.SESSION_END, _make_noop_hook())
 
-        registry.hooks[HookType.SESSION_START] = []
+        registry.unregister("a", HookType.SESSION_START)
         assert len(registry.get_hooks(HookType.SESSION_START)) == 0
         assert len(registry.get_hooks(HookType.SESSION_END)) == 1
 
@@ -713,8 +714,8 @@ class TestModuleAPI:
         """Reset registry before each test."""
         set_registry(HookRegistry())
 
-    def test_get_registry_creates_if_needed(self):
-        """get_registry should create a new registry if none exists."""
+    def test_get_registry_returns_existing(self):
+        """get_registry should return the already-set registry."""
         registry = get_registry()
         assert isinstance(registry, HookRegistry)
 
@@ -911,9 +912,8 @@ class TestEdgeCases:
     def test_trigger_on_empty_hook_list(self):
         """Triggering a type with no hooks registered should return empty."""
         registry = HookRegistry()
-        # Register for one type but trigger another
+        # Register for one type but trigger another (STEP_PRE has no hooks)
         registry.register("a", HookType.SESSION_START, _make_noop_hook())
-        registry.hooks[HookType.STEP_PRE] = []  # explicit empty list
 
         messages = list(registry.trigger(HookType.STEP_PRE))
         assert messages == []


### PR DESCRIPTION
## Summary

- Add **61 unit tests** for `gptme/hooks/registry.py` — previously had zero test coverage
- Tests cover the complete hook registry API: registration, unregistration, triggering, priority ordering, enable/disable, async hooks, StopPropagation, error handling, context-local isolation, and thread safety
- All tests are fast (no network, no LLM calls) — total suite runs in ~1.3s

## Test Coverage

| Category | Tests | What's Covered |
|----------|-------|----------------|
| Registration | 7 | Single/multiple hooks, priority, disabled, async, replacement |
| Unregistration | 4 | By name, by type, all types, nonexistent |
| GetHooks | 3 | Empty, filtered by type, all hooks |
| Enable/Disable | 5 | Toggle, type filter, nonexistent |
| Trigger (sync) | 10 | Messages, priority order, args, disabled skip, aggregation |
| StopPropagation | 3 | From generator, with message, direct return |
| Error handling | 2 | Exception continues, SessionCompleteException propagates |
| Async hooks | 4 | Background execution, no yield, mixed sync+async, errors |
| Priority sorting | 3 | Hook.__lt__, same-priority name sort, three-level |
| Clear hooks | 2 | All, by type |
| Module-level API | 8 | All convenience functions |
| Context isolation | 1 | ContextVar thread isolation |
| Thread safety | 2 | Concurrent registration, concurrent register+unregister |
| Edge cases | 7 | String/bytes/int returns, mixed generators, all-disabled |

## Test plan

- [x] All 61 tests pass locally
- [x] ruff lint + format clean
- [ ] CI passes