### PR TITLE
test(init): add unit tests for core initialization module

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1092,6 +1092,7 @@ class TestInitModelBuiltinProviders:
             "deepseek",
             "nvidia",
             "local",
+            "openai-subscription",
         ],
     )
     @patch("gptme.init.set_default_model")
@@ -1139,6 +1140,7 @@ class TestInitModelBuiltinProviders:
             "deepseek",
             "nvidia",
             "local",
+            "openai-subscription",
         ],
     )
     @patch("gptme.init.set_default_model")
@@ -1249,15 +1251,22 @@ class TestInitLogging:
         from gptme.init import init_logging
 
         mock_filter = MagicMock()
-        with patch.dict(
-            "sys.modules",
-            {
-                "gptme.util._telemetry": MagicMock(
-                    get_connection_error_filter=MagicMock(return_value=mock_filter)
-                )
-            },
+        with (
+            patch.dict(
+                "sys.modules",
+                {
+                    "gptme.util._telemetry": MagicMock(
+                        get_connection_error_filter=MagicMock(return_value=mock_filter)
+                    )
+                },
+            ),
+            patch("logging.getLogger") as mock_get_logger,
         ):
+            mock_otel_logger = MagicMock()
+            mock_get_logger.return_value = mock_otel_logger
             init_logging(verbose=False)
+            mock_get_logger.assert_any_call("opentelemetry")
+            mock_otel_logger.addFilter.assert_called_once_with(mock_filter)
 
     def test_otel_filter_skipped_when_unavailable(self):
         """When opentelemetry is not installed, filter setup should be silently skipped."""


### PR DESCRIPTION
## Summary

Add **68 unit tests** for `gptme/init.py` — a 177-line core module that had **zero previous test coverage**. This module orchestrates startup initialization for every gptme session (model selection, tools, hooks, commands, logging).

### Test coverage by category

| Category | Tests | What's covered |
|----------|-------|----------------|
| `init()` orchestration | 7 | Double-init guard, subsystem call order, tool_format re-entry, server mode, tool allowlist |
| `init_model()` parsing | 8 | All 11 builtin providers, custom providers, multi-slash models, provider-only, unknown providers |
| `init_model()` config | 5 | config.chat.model, env MODEL fallback, explicit override, interactive prompt, no-model error |
| `init_model()` providers | 22 | Parametrized: each builtin provider recognized + recommended model resolution |
| GPTME_CONTEXT_LENGTH | 6 | Valid override, invalid value, empty string, small values, field preservation |
| Console output | 2 | Model name logging, resolved model logging |
| Interactive mode | 2 | API key prompt in interactive, no prompt in non-interactive |
| `init_logging()` | 9 | Verbose/non-verbose levels, per-library log levels, RichHandler, atexit cleanup, OTel filter |
| Edge cases | 7 | _init_done flag, init order, all tool formats, openai-subscription, double-init warning |

### Key design decisions
- Heavy mocking to test pure logic without side effects (no real API calls, no real config files)
- `_reset_init_done` autouse fixture ensures test isolation for the global guard
- Parametrized tests cover all 11 builtin providers systematically
- Tests verify initialization ORDER (dotenv → model → tools → hooks → commands → tool_format)

## Test plan
- [x] All 68 tests pass locally (~3s)
- [x] Ruff clean (lint + format)
- [x] Mypy clean
- [ ] CI passes