### PR TITLE
feat(cli): add --json flag to chats list and chats search

### DIFF
--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -1,12 +1,15 @@
 """CLI commands for chat/conversation management."""
 
+import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import click
 
 from ..dirs import get_logs_dir
 from ..logmanager import LogManager
+from ..logmanager.conversations import ConversationMeta
 from ..message import Message
 from ..tools import get_tools, init_tools
 from ..tools.chats import find_empty_conversations, list_chats, search_chats
@@ -16,6 +19,25 @@ def _ensure_tools():
     """Lazily initialize tools only when needed."""
     if not get_tools():
         init_tools()
+
+
+def _conv_to_dict(conv: ConversationMeta) -> dict:
+    """Serialize a ConversationMeta to a JSON-friendly dict."""
+    return {
+        "id": conv.id,
+        "name": conv.name,
+        "path": conv.path,
+        "created": datetime.fromtimestamp(conv.created, tz=timezone.utc).isoformat(),
+        "modified": datetime.fromtimestamp(conv.modified, tz=timezone.utc).isoformat(),
+        "messages": conv.messages,
+        "branches": conv.branches,
+        "workspace": conv.workspace,
+        "agent_name": conv.agent_name,
+        "model": conv.model,
+        "total_cost": round(conv.total_cost, 4),
+        "total_input_tokens": conv.total_input_tokens,
+        "total_output_tokens": conv.total_output_tokens,
+    }
 
 
 def _format_size(size_bytes: int) -> str:
@@ -39,9 +61,18 @@ def chats():
 @click.option(
     "--summarize", is_flag=True, help="Generate LLM-based summaries for chats"
 )
-def chats_list(limit: int, summarize: bool):
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON.")
+def chats_list(limit: int, summarize: bool, output_json: bool):
     """List conversation logs."""
     _ensure_tools()
+
+    if output_json:
+        from ..logmanager import list_conversations  # fmt: skip
+
+        conversations = list_conversations(limit)
+        click.echo(json.dumps([_conv_to_dict(c) for c in conversations], indent=2))
+        return
+
     if summarize:
         from gptme.init import init  # fmt: skip
 
@@ -61,9 +92,38 @@ def chats_list(limit: int, summarize: bool):
 @click.option(
     "--summarize", is_flag=True, help="Generate LLM-based summaries for chats"
 )
-def chats_search(query: str, limit: int, summarize: bool):
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON.")
+def chats_search(query: str, limit: int, summarize: bool, output_json: bool):
     """Search conversation logs."""
     _ensure_tools()
+
+    if output_json:
+        from ..logmanager import LogManager, list_conversations  # fmt: skip
+        from ..tools.chats import _get_matching_messages  # fmt: skip
+
+        results = []
+        for conv in list_conversations(10 * limit):
+            log_path = Path(conv.path)
+            log_manager = LogManager.load(log_path, lock=False)
+            matching = _get_matching_messages(log_manager, query)
+            if matching:
+                entry = _conv_to_dict(conv)
+                entry["matches"] = len(matching)
+                entry["snippets"] = [
+                    {
+                        "index": idx,
+                        "role": msg.role,
+                        "content": msg.content[:200],
+                    }
+                    for idx, msg in matching[:3]
+                ]
+                results.append(entry)
+                if len(results) >= limit:
+                    break
+
+        click.echo(json.dumps(results, indent=2))
+        return
+
     if summarize:
         from gptme.init import init  # fmt: skip
 

--- a/tests/test_chats_json.py
+++ b/tests/test_chats_json.py
@@ -1,0 +1,249 @@
+"""Tests for --json output on chats list and chats search commands."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from gptme.cli.cmd_chats import _conv_to_dict
+from gptme.cli.util import main
+from gptme.logmanager import ConversationMeta
+from gptme.message import Message
+
+
+def _make_conv(
+    id: str,
+    messages: int = 10,
+    days_ago: int = 0,
+    agent_name: str | None = None,
+    model: str | None = "claude-sonnet-4-6",
+    cost: float = 0.05,
+    input_tokens: int = 1000,
+    output_tokens: int = 500,
+) -> ConversationMeta:
+    """Helper to create test ConversationMeta objects."""
+    now = datetime.now(tz=timezone.utc)
+    ts = (now - timedelta(days=days_ago)).timestamp()
+    return ConversationMeta(
+        id=id,
+        name=f"conv-{id}",
+        path=f"/tmp/fake/{id}/conversation.jsonl",
+        created=ts,
+        modified=ts,
+        messages=messages,
+        branches=1,
+        workspace="/tmp",
+        agent_name=agent_name,
+        model=model,
+        total_cost=cost,
+        total_input_tokens=input_tokens,
+        total_output_tokens=output_tokens,
+    )
+
+
+# --- _conv_to_dict tests ---
+
+
+class TestConvToDict:
+    def test_basic_fields(self):
+        conv = _make_conv("test-1", messages=5, model="gpt-4o", cost=0.123)
+        d = _conv_to_dict(conv)
+        assert d["id"] == "test-1"
+        assert d["name"] == "conv-test-1"
+        assert d["messages"] == 5
+        assert d["model"] == "gpt-4o"
+        assert d["total_cost"] == 0.123
+
+    def test_timestamps_are_iso(self):
+        conv = _make_conv("test-2")
+        d = _conv_to_dict(conv)
+        # Should be valid ISO format
+        datetime.fromisoformat(d["created"])
+        datetime.fromisoformat(d["modified"])
+
+    def test_none_fields(self):
+        conv = _make_conv("test-3", agent_name=None, model=None)
+        d = _conv_to_dict(conv)
+        assert d["agent_name"] is None
+        assert d["model"] is None
+
+    def test_cost_rounding(self):
+        conv = _make_conv("test-4", cost=0.123456789)
+        d = _conv_to_dict(conv)
+        assert d["total_cost"] == 0.1235
+
+    def test_json_serializable(self):
+        conv = _make_conv("test-5")
+        d = _conv_to_dict(conv)
+        # Must not raise
+        json.dumps(d)
+
+
+# --- chats list --json tests ---
+
+
+class TestChatsListJson:
+    @patch("gptme.logmanager.list_conversations")
+    @patch("gptme.tools.get_tools", return_value=[MagicMock()])
+    def test_list_json_output(self, _mock_tools, mock_list_convs):
+        """Test that --json produces valid JSON array."""
+        mock_list_convs.return_value = [
+            _make_conv("a", messages=20, agent_name="Bob"),
+            _make_conv("b", messages=10),
+        ]
+        runner = CliRunner()
+        result = runner.invoke(main, ["chats", "list", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 2
+        assert data[0]["id"] == "a"
+        assert data[0]["messages"] == 20
+        assert data[0]["agent_name"] == "Bob"
+        assert data[1]["id"] == "b"
+
+    @patch("gptme.logmanager.list_conversations")
+    @patch("gptme.tools.get_tools", return_value=[MagicMock()])
+    def test_list_json_empty(self, _mock_tools, mock_list_convs):
+        """Test --json with no conversations."""
+        mock_list_convs.return_value = []
+        runner = CliRunner()
+        result = runner.invoke(main, ["chats", "list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data == []
+
+    @patch("gptme.logmanager.list_conversations")
+    @patch("gptme.tools.get_tools", return_value=[MagicMock()])
+    def test_list_json_respects_limit(self, _mock_tools, mock_list_convs):
+        """Test that --json respects -n limit."""
+        mock_list_convs.return_value = [_make_conv("a")]
+        runner = CliRunner()
+        result = runner.invoke(main, ["chats", "list", "--json", "-n", "5"])
+        assert result.exit_code == 0
+        mock_list_convs.assert_called_once_with(5)
+
+    @patch("gptme.logmanager.list_conversations")
+    @patch("gptme.tools.get_tools", return_value=[MagicMock()])
+    def test_list_json_includes_token_fields(self, _mock_tools, mock_list_convs):
+        """Test that JSON output includes cost and token fields."""
+        mock_list_convs.return_value = [
+            _make_conv("a", cost=1.23, input_tokens=5000, output_tokens=2000)
+        ]
+        runner = CliRunner()
+        result = runner.invoke(main, ["chats", "list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data[0]["total_cost"] == 1.23
+        assert data[0]["total_input_tokens"] == 5000
+        assert data[0]["total_output_tokens"] == 2000
+
+
+# --- chats search --json tests ---
+
+
+def _make_log_manager_with_messages(messages: list[Message]):
+    """Create a mock LogManager with given messages."""
+    mock = MagicMock()
+    mock.log = messages
+    return mock
+
+
+class TestChatsSearchJson:
+    @patch("gptme.logmanager.LogManager")
+    @patch("gptme.logmanager.list_conversations")
+    @patch("gptme.tools.get_tools", return_value=[MagicMock()])
+    def test_search_json_output(self, _mock_tools, mock_list_convs, mock_lm):
+        """Test that search --json produces valid JSON with matches."""
+        conv = _make_conv("a", messages=5)
+        mock_list_convs.return_value = [conv]
+        mock_lm.load.return_value = _make_log_manager_with_messages(
+            [
+                Message("user", "hello world"),
+                Message("assistant", "hello back"),
+                Message("user", "tell me about python"),
+            ]
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["chats", "search", "hello", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["id"] == "a"
+        assert data[0]["matches"] == 2
+        assert len(data[0]["snippets"]) == 2
+
+    @patch("gptme.logmanager.LogManager")
+    @patch("gptme.logmanager.list_conversations")
+    @patch("gptme.tools.get_tools", return_value=[MagicMock()])
+    def test_search_json_no_results(self, _mock_tools, mock_list_convs, mock_lm):
+        """Test search --json with no matches."""
+        conv = _make_conv("a", messages=5)
+        mock_list_convs.return_value = [conv]
+        mock_lm.load.return_value = _make_log_manager_with_messages(
+            [Message("user", "hello world")]
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["chats", "search", "nonexistent", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data == []
+
+    @patch("gptme.logmanager.LogManager")
+    @patch("gptme.logmanager.list_conversations")
+    @patch("gptme.tools.get_tools", return_value=[MagicMock()])
+    def test_search_json_snippets_truncated(
+        self, _mock_tools, mock_list_convs, mock_lm
+    ):
+        """Test that search snippets are truncated to 200 chars."""
+        long_content = "x" * 500
+        conv = _make_conv("a")
+        mock_list_convs.return_value = [conv]
+        mock_lm.load.return_value = _make_log_manager_with_messages(
+            [Message("user", long_content)]
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["chats", "search", "xxx", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 1
+        assert len(data[0]["snippets"][0]["content"]) == 200
+
+    @patch("gptme.logmanager.LogManager")
+    @patch("gptme.logmanager.list_conversations")
+    @patch("gptme.tools.get_tools", return_value=[MagicMock()])
+    def test_search_json_max_3_snippets(self, _mock_tools, mock_list_convs, mock_lm):
+        """Test that at most 3 snippet previews are returned per conversation."""
+        conv = _make_conv("a")
+        mock_list_convs.return_value = [conv]
+        mock_lm.load.return_value = _make_log_manager_with_messages(
+            [Message("user", f"match {i}") for i in range(10)]
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["chats", "search", "match", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data[0]["matches"] == 10
+        assert len(data[0]["snippets"]) == 3
+
+    @patch("gptme.logmanager.LogManager")
+    @patch("gptme.logmanager.list_conversations")
+    @patch("gptme.tools.get_tools", return_value=[MagicMock()])
+    def test_search_json_snippet_fields(self, _mock_tools, mock_list_convs, mock_lm):
+        """Test that snippets contain expected fields."""
+        conv = _make_conv("a")
+        mock_list_convs.return_value = [conv]
+        mock_lm.load.return_value = _make_log_manager_with_messages(
+            [Message("user", "search term here")]
+        )
+        runner = CliRunner()
+        result = runner.invoke(main, ["chats", "search", "search", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        snippet = data[0]["snippets"][0]
+        assert "index" in snippet
+        assert "role" in snippet
+        assert "content" in snippet
+        assert snippet["role"] == "user"


### PR DESCRIPTION
## Summary

- Adds `--json` output flag to `gptme-util chats list` and `gptme-util chats search`, completing JSON support across all chats subcommands (`stats` and `clean` already had it)
- `list --json` outputs an array of conversation objects with id, name, timestamps, message count, model, cost, and token usage
- `search --json` outputs matching conversations with total match count and up to 3 snippet previews (content truncated to 200 chars)

Enables scripting workflows:
```bash
gptme-util chats list --json | jq '.[] | select(.model != null)'
gptme-util chats search "error" --json | jq '.[].matches'
```

## Test plan

- [x] 14 new unit tests covering `_conv_to_dict` serialization, CLI integration for both list and search, empty results, limit handling, snippet truncation, and field validation
- [x] All 49 chats-related tests pass (14 new + 35 existing)
- [x] Ruff lint + format clean
- [x] mypy clean