### PR TITLE
feat(cli): add --json flag to tools list and tools info commands

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -445,11 +445,9 @@ def tools_info(
     if as_json:
         d = tool_to_dict(tool)
         # Include full instructions and examples for info output
-        if tool.instructions:
-            d["instructions"] = tool.instructions.strip()
+        d["instructions"] = tool.instructions.strip() if tool.instructions else ""
         examples = tool.get_examples()
-        if examples:
-            d["examples"] = examples.strip()
+        d["examples"] = examples.strip() if examples else ""
         print(json.dumps(d, indent=2))
         return
 

--- a/gptme/util/tool_format.py
+++ b/gptme/util/tool_format.py
@@ -44,28 +44,17 @@ def tool_to_dict(tool: "ToolSpec") -> dict[str, Any]:
 
     Returns a dict with tool metadata suitable for machine consumption.
     """
-    d: dict[str, Any] = {
+    return {
         "name": tool.name,
         "desc": tool.desc,
         "available": tool.is_available,
         "disabled_by_default": tool.disabled_by_default,
         "block_types": tool.block_types,
         "has_execute": bool(tool.execute),
+        "functions": [f.__name__ for f in tool.functions] if tool.functions else [],
+        "commands": list(tool.commands.keys()) if tool.commands else [],
+        "is_mcp": bool(tool.is_mcp),
     }
-
-    # Include function names if the tool exposes callable functions
-    if tool.functions:
-        d["functions"] = [f.__name__ for f in tool.functions]
-
-    # Include command names if the tool registers slash commands
-    if tool.commands:
-        d["commands"] = list(tool.commands.keys())
-
-    # MCP flag
-    if tool.is_mcp:
-        d["is_mcp"] = True
-
-    return d
 
 
 def format_tool_summary(

--- a/tests/test_util_cli.py
+++ b/tests/test_util_cli.py
@@ -165,7 +165,7 @@ def test_tools_list():
     data = json.loads(result.output)
     assert isinstance(data, list)
     assert len(data) > 0
-    # Check required fields
+    # Check required fields (stable schema — all keys always present)
     tool = data[0]
     assert "name" in tool
     assert "desc" in tool
@@ -173,6 +173,12 @@ def test_tools_list():
     assert isinstance(tool["available"], bool)
     assert "block_types" in tool
     assert isinstance(tool["block_types"], list)
+    assert "functions" in tool
+    assert isinstance(tool["functions"], list)
+    assert "commands" in tool
+    assert isinstance(tool["commands"], list)
+    assert "is_mcp" in tool
+    assert isinstance(tool["is_mcp"], bool)
     # Default --available filter: all tools should be available
     assert all(t["available"] for t in data)
 
@@ -202,7 +208,7 @@ def test_tools_info():
     assert result.exit_code != 0  # returns non-zero for not found tool
     assert "not found" in result.output
 
-    # Test JSON output
+    # Test JSON output (stable schema — instructions/examples always present)
     result = runner.invoke(main, ["tools", "info", "shell", "--json"])
     assert result.exit_code == 0
     data = json.loads(result.output)
@@ -213,6 +219,8 @@ def test_tools_info():
     assert len(data["instructions"]) > 0
     assert "examples" in data
     assert isinstance(data["examples"], str)
+    assert "is_mcp" in data
+    assert isinstance(data["is_mcp"], bool)
 
 
 def test_models_list():


### PR DESCRIPTION
## Summary

- Add `--json` flag to `gptme-util tools list` and `gptme-util tools info` for machine-readable output
- `tools list --json` outputs all tools as JSON array with metadata (name, desc, available, disabled_by_default, block_types, functions, commands)
- `tools info <tool> --json` outputs single tool as JSON including full instructions and examples
- `--available/--all` filter works with `--json`
- Suppress `console.log` output during tool init in JSON mode for clean parseable output
- Add `tool_to_dict()` helper in `tool_format.py` for consistent serialization
- Continues the JSON output pattern across all `gptme-util` subcommands (follows #1797 chats, #1799 models)

## Test plan

- [x] `gptme-util tools list --json` produces valid JSON array
- [x] `gptme-util tools list --all --json` includes unavailable tools
- [x] `gptme-util tools info shell --json` produces valid JSON with instructions and examples
- [x] All 10 existing `test_util_cli.py` tests pass
- [x] 2 new tests cover JSON output for both commands
- [x] ruff + mypy clean