### PR TITLE
fix(ci): replace bash 4+ lowercase syntax with POSIX-compatible tr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Set environment variables
       run: |
-        echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        echo "OWNER_LC=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')" >>${GITHUB_ENV}
         # Sanitize the ref name to be used as a Docker tag
         REF_NAME="${TAG_INPUT:-${GITHUB_REF_NAME}}"
         SANITIZED_REF_NAME=$(echo "${REF_NAME}" | tr '/' '-')
@@ -205,7 +205,7 @@ jobs:
         TAG="${{ inputs.tag || github.ref_name }}"
         VERSION="${TAG#v}"
         OS_SUFFIX="${{ runner.os }}-${{ runner.arch }}"
-        OS_SUFFIX="${OS_SUFFIX,,}"
+        OS_SUFFIX=$(echo "$OS_SUFFIX" | tr '[:upper:]' '[:lower:]')
         ASSET_BASE="gptme-server-bin-${VERSION}-${OS_SUFFIX}"
         # Include version + lowercase platform in release asset names so scheduled
         # dev releases don't publish ambiguous binaries like `gptme-server-Linux-X64`.

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -50,7 +50,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set environment variables
-      run: echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+      run: echo "OWNER_LC=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')" >>${GITHUB_ENV}
 
     - name: Pull Docker image
       run: |


### PR DESCRIPTION
## Summary
- Replace `${var,,}` (bash 4+) with `$(echo "$var" | tr '[:upper:]' '[:lower:]')` in CI workflows
- Fixes macOS PyInstaller release step which fails on bash 3.2 (macOS default)
- Found and fixed 3 occurrences across `build.yml` and `eval.yml`

Fixes #1805

## Test plan
- [ ] CI passes on this PR (the fix is in workflow files, so the bash syntax is validated by CI itself)
- [ ] Verify macOS release step no longer fails with `bad substitution`