### PR TITLE
feat(context): support @-prefix for file/directory references

### DIFF
--- a/gptme/util/context.py
+++ b/gptme/util/context.py
@@ -584,19 +584,27 @@ def _find_potential_paths(content: str) -> list[str]:
         Supports the ``@`` prefix convention (e.g. ``@src/file.py``) used by
         Claude Code and other AI tools to reference files and directories.
         """
-        # Strip leading @ for detection (actual stripping happens in caller)
-        w = word.lstrip("@") if word.startswith("@") else word
+        # Strip one leading @ for detection (actual stripping happens in caller)
+        w = word.removeprefix("@") if word.startswith("@") else word
+
+        def _is_path_like_bare(s: str) -> bool:
+            return (
+                # Absolute/home/relative paths
+                any(s.startswith(p) for p in ["/", "~/", "./"])
+                # URLs
+                or s.startswith("http")
+                # Contains slash (for backtick-wrapped paths)
+                or "/" in s
+                # Files in current directory or subdirectories
+                or any(s.split("/", 1)[0] == file for file in cwd_files)
+            )
+
         return (
-            # @-prefixed reference (must have content after @)
-            (word.startswith("@") and len(w) > 0)
-            # Absolute/home/relative paths
-            or any(w.startswith(s) for s in ["/", "~/", "./"])
-            # URLs
-            or w.startswith("http")
-            # Contains slash (for backtick-wrapped paths)
-            or "/" in w
-            # Files in current directory or subdirectories
-            or any(w.split("/", 1)[0] == file for file in cwd_files)
+            # @-prefixed reference: stripped form must also look like a path
+            # (prevents @username social handles from matching)
+            (word.startswith("@") and _is_path_like_bare(w))
+            # Plain path reference
+            or _is_path_like_bare(w)
         )
 
     def _strip_at_prefix(word: str) -> str:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -138,6 +138,18 @@ def test_find_potential_paths_at_prefix_bare_at():
     assert not any("@" in p or p == "" for p in paths)
 
 
+def test_find_potential_paths_at_prefix_handles(tmp_path, monkeypatch):
+    """Test that @username-style social handles are NOT treated as path references."""
+    monkeypatch.chdir(tmp_path)  # clean dir with no matching files
+    content = "Thanks @alice and @bob, see @charlie for details"
+    paths = _find_potential_paths(content)
+    # Social handles without slash should not be matched
+    assert "alice" not in paths
+    assert "bob" not in paths
+    assert "charlie" not in paths
+    assert "@alice" not in paths
+
+
 def test_include_paths_at_prefix(tmp_path, monkeypatch):
     """Integration test: @file.txt in user prompt → file content included."""
     from gptme.message import Message


### PR DESCRIPTION
## Summary

- Adds support for `@file.py` and `@src/dir/` syntax in user messages, following the convention used by Claude Code, Cursor, Windsurf, and other AI tools
- The `@` prefix is detected in `is_path_like()` and stripped before path resolution, so all existing file inclusion/directory listing works unchanged
- Backward compatible — bare paths (`./file`, `~/path`, `subdir/file`) still work exactly as before

## Changes

- `gptme/util/context.py`: Updated `is_path_like()` to match `@`-prefixed words; added `_strip_at_prefix()` helper
- `tests/test_chat.py`: 4 new tests covering detection, stripping, bare-`@` rejection, and end-to-end `include_paths` integration

## Scope

This is the minimal core of #585 — path detection and inclusion. Future work (tracked in the issue):
- Tab completion on `@` in CLI (fish/bash/zsh)
- Web UI `@`-mention dropdown (gptme-webui#64)
- MCP resource references (`@mcp:server/resource`)

## Test plan

- [x] All existing `_find_potential_paths` tests pass (no regressions)
- [x] New tests: `@src/file.py` detected and stripped to `src/file.py`
- [x] New tests: bare `@` and `bob@` not falsely matched
- [x] Integration: `@config.toml` in user message → file content included
- [x] mypy + ruff pass

Closes #585