### PR TITLE
fix(eval): restore fixture files before running eval checks

### DIFF
--- a/gptme/eval/run.py
+++ b/gptme/eval/run.py
@@ -326,11 +326,18 @@ def execute(
             run_start = time.time()
             env = DockerExecutionEnv() if use_docker else SimpleExecutionEnv()
             try:
-                # Restore original fixture files before running checks.
-                # The model may have overwritten them during generation
-                # (e.g. creating its own test data to verify the script).
-                fixture_files = test.get("files", {})
-                files_for_run = {**files, **fixture_files}
+                # Restore specific input fixture files before running checks.
+                # Some tests provide input files (e.g. old.json/new.json for json-diff)
+                # that the model may accidentally overwrite as a side-effect of testing
+                # its own script. Use `restore_files` in the EvalSpec to list any such
+                # files. Do NOT list files the model is supposed to modify (e.g. hello.py
+                # in hello-patch), as those need to stay modified.
+                restore_files = test.get("restore_files", [])
+                all_fixtures = test["files"]
+                files_for_run = {
+                    **files,
+                    **{k: v for k, v in all_fixtures.items() if k in restore_files},
+                }
                 env.upload(files_for_run)
                 logger.debug(f"Running check: {test['run']}")
                 stdout_run, stderr_run, exit_code = env.run(test["run"])

--- a/gptme/eval/suites/practical7.py
+++ b/gptme/eval/suites/practical7.py
@@ -278,6 +278,7 @@ tests: list["EvalSpec"] = [
     {
         "name": "json-diff",
         "files": {"old.json": _OLD_JSON, "new.json": _NEW_JSON},
+        "restore_files": ["old.json", "new.json"],
         "run": "python diff_json.py old.json new.json",
         "prompt": (
             "Write diff_json.py that compares two JSON files and reports the "

--- a/gptme/eval/types.py
+++ b/gptme/eval/types.py
@@ -116,3 +116,11 @@ class EvalSpec(TypedDict):
     prompt: str
     expect: dict[str, Callable[[ResultContext], bool]]
     tools: NotRequired[list[str]]
+    restore_files: NotRequired[list[str]]
+    """Files to restore to original fixture content before the run phase.
+
+    Use this for input files that the model may overwrite as a side-effect during
+    generation (e.g. creating test data to verify a script), but where the run phase
+    needs the original fixture content. Do NOT list files the model is supposed to
+    modify as the goal of the task.
+    """


### PR DESCRIPTION
## Summary
- Adds `restore_files: list[str]` to `EvalSpec` for tests where input fixture files should be restored before the run phase
- Restores only the specified files (not all fixtures), preserving model modifications to files that are the goal of the task
- Fixes `json-diff` where the model accidentally overwrites `old.json`/`new.json` with test data during generation

## Problem

The original fix restored ALL fixture files before the run phase, which broke `hello-patch` (and similar tests) where the fixture file IS the target the model must modify:
- `hello-patch`: model patches `hello.py` (fixture) — restoring it defeats the task
- `json-diff`: model may overwrite `old.json`/`new.json` (input fixtures) — restoring them is correct

## Fix

Replace blind fixture restoration with an explicit opt-in field `restore_files` in `EvalSpec`. Tests like `json-diff` that use fixture files as *inputs* to a generated script list those files. Tests like `hello-patch` that require modifying a fixture file don't list it.

## Test plan
- [x] Verified `from gptme.eval.run import execute` imports correctly
- [x] Ran `pytest tests/test_eval.py -k "not requires_api"` — 9 passed
- [x] Ruff + mypy passed
- [ ] CI should confirm `hello-patch` no longer regresses