### PR TITLE
test(auth): add 55 unit tests for LLM auth helpers

### DIFF
--- a/tests/test_llm_auth.py
+++ b/tests/test_llm_auth.py
@@ -117,7 +117,7 @@ class TestGetServerToken:
         original = gptme.server.auth._server_token
         try:
             gptme.server.auth._server_token = None
-            with patch.dict(os.environ, {}, clear=True):
+            with patch.dict(os.environ, {}):
                 os.environ.pop("GPTME_SERVER_TOKEN", None)
                 token = gptme.server.auth.get_server_token()
                 assert token is not None
@@ -131,7 +131,7 @@ class TestGetServerToken:
         original = gptme.server.auth._server_token
         try:
             gptme.server.auth._server_token = None
-            with patch.dict(os.environ, {}, clear=True):
+            with patch.dict(os.environ, {}):
                 os.environ.pop("GPTME_SERVER_TOKEN", None)
                 token1 = gptme.server.auth.get_server_token()
                 token2 = gptme.server.auth.get_server_token()
@@ -551,12 +551,18 @@ class TestIsPortAvailable:
     def test_available_port(self):
         from gptme.llm.llm_openai_subscription import _is_port_available
 
-        # Find a port that's likely available
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(("127.0.0.1", 0))
-            port = s.getsockname()[1]
-        # Port should be free now that the socket is closed
-        assert _is_port_available(port) is True
+        # Hold one socket to get a free port number, then check a different
+        # OS-assigned port while this socket is still open — avoids TOCTOU.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as held:
+            held.bind(("127.0.0.1", 0))
+            held_port = held.getsockname()[1]
+            # Obtain a second free port by letting the OS pick another one
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+                probe.bind(("127.0.0.1", 0))
+                free_port = probe.getsockname()[1]
+            # probe is released; held keeps it from being reused immediately
+            assert free_port != held_port
+            assert _is_port_available(free_port) is True
 
     def test_unavailable_port(self):
         from gptme.llm.llm_openai_subscription import _is_port_available
@@ -633,7 +639,7 @@ class TestGptmeProviderEdgeCases:
         with patch("gptme.llm.llm_gptme._get_token_path", return_value=token_path):
             assert _load_token() is None
 
-    def test_url_normalization_trailing_slash(self, tmp_path: Path):
+    def test_url_normalization_trailing_slash(self):
         """server_url with trailing slash should normalize correctly."""
         from gptme.llm.llm_gptme import get_base_url
 
@@ -645,7 +651,7 @@ class TestGptmeProviderEdgeCases:
         with patch("gptme.llm.llm_gptme._load_token", return_value=token_data):
             assert get_base_url(config) == "https://custom.gptme.ai/v1"
 
-    def test_url_normalization_already_has_v1_slash(self, tmp_path: Path):
+    def test_url_normalization_already_has_v1_slash(self):
         """server_url already ending in /v1/ should not double-suffix."""
         from gptme.llm.llm_gptme import get_base_url
 


### PR DESCRIPTION
## Summary

- Adds 55 unit tests covering previously untested LLM authentication helpers
- All tests are pure-function tests (no API calls, no network, fast execution)
- Covers three auth subsystems: server auth, OpenAI subscription OAuth, gptme provider

## Coverage Added

### Server Auth (`gptme/server/auth.py`)
- `is_local_host()`: all localhost variants, external hosts, edge cases
- `generate_token()`: format, length, uniqueness, URL-safety
- `get_server_token()`: env var, auto-generation, caching behavior
- `init_auth()`: local/network/env-disable state transitions
- `require_auth` decorator: invalid scheme, malformed header, cookie auth, query param fallback, header-over-cookie priority

### OpenAI Subscription (`gptme/llm/llm_openai_subscription.py`)
- `_generate_pkce()`: S256 challenge verification per RFC 7636, no padding, uniqueness
- `_decode_jwt_payload()`: valid JWT, invalid formats, padding handling
- `_extract_account_id()`: OpenAI org_id extraction, sub fallback, missing data
- `_get_token_expiry()`: exp claim extraction, graceful fallback on invalid JWT
- `_save_tokens()` / `_load_tokens()`: roundtrip, 0o600 permissions, corrupt JSON, missing fields
- `_is_port_available()`: available and occupied port detection

### gptme Provider (`gptme/llm/llm_gptme.py`)
- Token 60s expiry buffer boundary (within vs outside)
- Missing `expires_at` field handling
- Malformed JSON token file graceful recovery
- URL normalization edge cases (trailing slash, /v1/ suffix)
- Deterministic token path hashing

## Test plan

- [x] All 55 new tests pass locally
- [x] All 26 existing auth tests still pass (no regressions)
- [x] mypy passes
- [x] ruff format passes