### PR TITLE
fix(eval): increase default timeout from 30s to 60s

### DIFF
--- a/gptme/eval/main.py
+++ b/gptme/eval/main.py
@@ -397,7 +397,7 @@ def aggregate_and_display_results(result_files: list[str]):
 @click.option(
     "--timeout",
     "-t",
-    default=30,
+    default=60,
     type=click.IntRange(min=1),
     help="Timeout for code generation (seconds)",
 )


### PR DESCRIPTION
## Summary

- Increase `gptme-eval` default `--timeout` from 30s to 60s
- The 30s default is too tight for slower models (haiku) on multi-file tasks

## Motivation

During harness comparison testing (gptme haiku vs CC sonnet on practical 1-8 suites), the `rename-function` test consistently failed with haiku due to timeout, despite haiku writing a correct solution. The task requires reading multiple files and making several targeted edits — which haiku completes successfully at 60s but not at 30s.

The CC eval agent already uses a 600s default. This change brings gptme eval closer to realistic expectations while keeping a reasonable upper bound for CI.

## Test plan
- [ ] Run `gptme-eval rename-function -m anthropic/claude-haiku-4-5@tool` with new default — should pass
- [ ] Existing CI tests unchanged (none assert specific timeout default)