### PR TITLE
feat(eval): add validate-user-input behavioral scenario (27th scenario)

### DIFF
--- a/gptme/eval/suites/behavioral/__init__.py
+++ b/gptme/eval/suites/behavioral/__init__.py
@@ -185,6 +185,7 @@ from .validate_user_input import (  # noqa: F401
     check_custom_exception,
     check_range_validation,
     check_string_sanitization,
+    check_tests_pass,
     check_type_validation,
 )
 from .write_test_suite import (  # noqa: F401

--- a/gptme/eval/suites/behavioral/__init__.py
+++ b/gptme/eval/suites/behavioral/__init__.py
@@ -185,8 +185,10 @@ from .validate_user_input import (  # noqa: F401
     check_custom_exception,
     check_range_validation,
     check_string_sanitization,
-    check_tests_pass,
     check_type_validation,
+)
+from .validate_user_input import (  # noqa: F401
+    check_tests_pass as check_validate_user_input_tests_pass,
 )
 from .write_test_suite import (  # noqa: F401
     check_write_tests_covers_extract_emails,

--- a/gptme/eval/suites/behavioral/__init__.py
+++ b/gptme/eval/suites/behavioral/__init__.py
@@ -181,6 +181,12 @@ from .use_existing_helper import (  # noqa: F401
     check_reuse_uses_normalize,
     check_reuse_utils_unchanged,
 )
+from .validate_user_input import (  # noqa: F401
+    check_custom_exception,
+    check_range_validation,
+    check_string_sanitization,
+    check_type_validation,
+)
 from .write_test_suite import (  # noqa: F401
     check_write_tests_covers_extract_emails,
     check_write_tests_covers_truncate,

--- a/gptme/eval/suites/behavioral/validate_user_input.py
+++ b/gptme/eval/suites/behavioral/validate_user_input.py
@@ -22,9 +22,19 @@ def check_range_validation(ctx):
     content = ctx.files.get("user_service.py", "")
     if isinstance(content, bytes):
         content = content.decode()
-    return "ValueError" in content and any(
-        op in content for op in ["<", ">", "<=", ">="]
-    )
+    if "ValueError" not in content:
+        return False
+    module = parse_python_source(content)
+    if module is None:
+        return False
+    for node in ast.walk(module):
+        if isinstance(node, ast.Compare):
+            for comparator in node.comparators:
+                if isinstance(comparator, ast.Constant) and isinstance(
+                    comparator.value, int
+                ):
+                    return True
+    return False
 
 
 def check_string_sanitization(ctx):

--- a/gptme/eval/suites/behavioral/validate_user_input.py
+++ b/gptme/eval/suites/behavioral/validate_user_input.py
@@ -55,8 +55,6 @@ def check_custom_exception(ctx):
         return False
     for node in ast.walk(module):
         if isinstance(node, ast.Raise):
-            if isinstance(node.exc, ast.Call) and isinstance(node.exc.func, ast.Name):
-                return True
             if isinstance(node.exc, ast.Call):
                 return True
     return False
@@ -143,13 +141,12 @@ def test_valid_edge_cases():
     "run": "python3 -m pytest test_user_service.py -v --tb=short 2>&1",
     "prompt": (
         "The test suite `test_user_service.py` is failing because `create_user()` "
-        "in `user_service.py` does not validate its inputs. Seven tests fail:\\n"
+        "in `user_service.py` does not validate its inputs. Five tests fail:\\n"
         "1. `test_reject_negative_age` — expects ValueError for age < 0\\n"
         "2. `test_reject_unrealistic_age` — expects ValueError for age > 150\\n"
         "3. `test_reject_empty_name` — expects ValueError for empty/whitespace name\\n"
         "4. `test_reject_non_string_name` — expects TypeError for non-string name\\n"
-        "5. `test_reject_non_integer_age` — expects TypeError for non-integer age\\n"
-        "6. `test_valid_edge_cases` — age 0 and 150 should be accepted\\n\\n"
+        "5. `test_reject_non_integer_age` — expects TypeError for non-integer age\\n\\n"
         "Add input validation to `create_user()` in `user_service.py`:\\n"
         "- Type checks: name must be str, age must be int\\n"
         "- Range check: age must be 0-150 (inclusive)\\n"

--- a/gptme/eval/suites/behavioral/validate_user_input.py
+++ b/gptme/eval/suites/behavioral/validate_user_input.py
@@ -14,12 +14,7 @@ def check_type_validation(ctx):
     content = ctx.files.get("user_service.py", "")
     if isinstance(content, bytes):
         content = content.decode()
-    return (
-        "isinstance" in content
-        or "type(" in content
-        or "TypeError" in content
-        or "int(" in content
-    )
+    return "isinstance" in content or "type(" in content or "TypeError" in content
 
 
 def check_range_validation(ctx):

--- a/gptme/eval/suites/behavioral/validate_user_input.py
+++ b/gptme/eval/suites/behavioral/validate_user_input.py
@@ -1,0 +1,168 @@
+"""Behavioral scenario: validate-user-input."""
+
+import ast
+from typing import TYPE_CHECKING
+
+from ._common import parse_python_source
+
+if TYPE_CHECKING:
+    from gptme.eval.types import EvalSpec
+
+
+def check_type_validation(ctx):
+    """Should validate input types (str, int, float checks)."""
+    content = ctx.files.get("user_service.py", "")
+    if isinstance(content, bytes):
+        content = content.decode()
+    return (
+        "isinstance" in content
+        or "type(" in content
+        or "TypeError" in content
+        or "int(" in content
+    )
+
+
+def check_range_validation(ctx):
+    """Should validate numeric ranges (age 0-150, score 0-100, etc.)."""
+    content = ctx.files.get("user_service.py", "")
+    if isinstance(content, bytes):
+        content = content.decode()
+    return "ValueError" in content and any(
+        op in content for op in ["<", ">", "<=", ">="]
+    )
+
+
+def check_string_sanitization(ctx):
+    """Should sanitize or validate string input (strip, length check, etc.)."""
+    content = ctx.files.get("user_service.py", "")
+    if isinstance(content, bytes):
+        content = content.decode()
+    return (
+        "strip" in content
+        or "len(" in content
+        or "whitespace" in content.lower()
+        or "empty" in content.lower()
+    )
+
+
+def check_custom_exception(ctx):
+    """Should raise descriptive exceptions with meaningful messages."""
+    content = ctx.files.get("user_service.py", "")
+    if isinstance(content, bytes):
+        content = content.decode()
+    module = parse_python_source(content)
+    if module is None:
+        return False
+    for node in ast.walk(module):
+        if isinstance(node, ast.Raise):
+            if isinstance(node.exc, ast.Call) and isinstance(node.exc.func, ast.Name):
+                return True
+            if isinstance(node.exc, ast.Call):
+                return True
+    return False
+
+
+def check_tests_pass(ctx):
+    """All tests should pass after adding validation."""
+    return ctx.exit_code == 0 and "failed" not in ctx.stdout.lower()
+
+
+test: "EvalSpec" = {
+    "name": "validate-user-input",
+    "files": {
+        "user_service.py": """\
+\"\"\"User service for managing user profiles.\"\"\"
+
+
+def create_user(name: str, age: int, email: str) -> dict:
+    \"\"\"Create a new user profile.
+
+    Args:
+        name: Full name of the user.
+        age: Age in years.
+        email: Email address.
+
+    Returns:
+        Dict with user info.
+    \"\"\"
+    return {"name": name, "age": age, "email": email}
+""",
+        "test_user_service.py": """\
+import pytest
+from user_service import create_user
+
+
+def test_create_user_valid():
+    \"\"\"Should create user with valid inputs.\"\"\"
+    user = create_user("Alice Smith", 30, "alice@example.com")
+    assert user["name"] == "Alice Smith"
+    assert user["age"] == 30
+    assert user["email"] == "alice@example.com"
+
+
+def test_reject_negative_age():
+    \"\"\"Should reject negative age.\"\"\"
+    with pytest.raises(ValueError):
+        create_user("Bob", -5, "bob@example.com")
+
+
+def test_reject_unrealistic_age():
+    \"\"\"Should reject age above 150.\"\"\"
+    with pytest.raises(ValueError):
+        create_user("Charlie", 200, "charlie@example.com")
+
+
+def test_reject_empty_name():
+    \"\"\"Should reject empty or whitespace-only name.\"\"\"
+    with pytest.raises(ValueError):
+        create_user("", 25, "test@example.com")
+    with pytest.raises(ValueError):
+        create_user("   ", 25, "test@example.com")
+
+
+def test_reject_non_string_name():
+    \"\"\"Should reject non-string name.\"\"\"
+    with pytest.raises(TypeError):
+        create_user(123, 25, "test@example.com")
+
+
+def test_reject_non_integer_age():
+    \"\"\"Should reject non-integer age.\"\"\"
+    with pytest.raises(TypeError):
+        create_user("Dave", "thirty", "dave@example.com")
+
+
+def test_valid_edge_cases():
+    \"\"\"Should accept boundary values.\"\"\"
+    user = create_user("Eve", 0, "eve@example.com")
+    assert user["age"] == 0
+    user = create_user("Frank", 150, "frank@example.com")
+    assert user["age"] == 150
+""",
+    },
+    "run": "python3 -m pytest test_user_service.py -v --tb=short 2>&1",
+    "prompt": (
+        "The test suite `test_user_service.py` is failing because `create_user()` "
+        "in `user_service.py` does not validate its inputs. Seven tests fail:\\n"
+        "1. `test_reject_negative_age` — expects ValueError for age < 0\\n"
+        "2. `test_reject_unrealistic_age` — expects ValueError for age > 150\\n"
+        "3. `test_reject_empty_name` — expects ValueError for empty/whitespace name\\n"
+        "4. `test_reject_non_string_name` — expects TypeError for non-string name\\n"
+        "5. `test_reject_non_integer_age` — expects TypeError for non-integer age\\n"
+        "6. `test_valid_edge_cases` — age 0 and 150 should be accepted\\n\\n"
+        "Add input validation to `create_user()` in `user_service.py`:\\n"
+        "- Type checks: name must be str, age must be int\\n"
+        "- Range check: age must be 0-150 (inclusive)\\n"
+        "- String check: name must not be empty or whitespace-only\\n"
+        "- Use descriptive error messages in ValueError/TypeError\\n\\n"
+        "After implementing, run the tests to verify they all pass."
+    ),
+    "tools": ["shell", "save", "read"],
+    "expect": {
+        "type validation": check_type_validation,
+        "range validation": check_range_validation,
+        "string sanitization": check_string_sanitization,
+        "custom exceptions": check_custom_exception,
+        "all tests pass": check_tests_pass,
+    },
+}

--- a/tests/test_eval_behavioral_solutions.py
+++ b/tests/test_eval_behavioral_solutions.py
@@ -9,7 +9,7 @@ This is critical infrastructure for idea #19 (eval-to-lesson feedback loop):
 before running expensive baseline experiments with real models, we need
 confidence that the checkers correctly identify good work.
 
-Covers all 24 behavioral scenarios:
+Covers all 25 behavioral scenarios:
   git-selective-commit, multi-file-rename, iterative-debug,
   stage-new-files, write-test-suite, test-driven-error-handling,
   merge-conflict-resolution, extract-function-refactor, debug-data-pipeline,
@@ -17,7 +17,8 @@ Covers all 24 behavioral scenarios:
   add-feature-preserve-default, handle-specific-exception,
   fix-security-path-traversal, refactor-for-testability, add-type-hints,
   noisy-worktree-fix, fix-data-mutation, optimize-n-squared, remove-dead-code,
-  fix-mutable-default, add-deprecation-warning, retry-with-backoff
+  fix-mutable-default, add-deprecation-warning, retry-with-backoff,
+  validate-user-input
 """
 
 import subprocess
@@ -796,6 +797,35 @@ def _apply_solution(workspace: Path, scenario_name: str) -> None:
                     response.raise_for_status()
                     return response.json()
                 return retry_with_backoff(_fetch)
+            """)
+        )
+
+    elif scenario_name == "validate-user-input":
+        (workspace / "user_service.py").write_text(
+            textwrap.dedent("""\
+            \"\"\"User service for managing user profiles.\"\"\"
+
+
+            def create_user(name: str, age: int, email: str) -> dict:
+                \"\"\"Create a new user profile.
+
+                Args:
+                    name: Full name of the user.
+                    age: Age in years.
+                    email: Email address.
+
+                Returns:
+                    Dict with user info.
+                \"\"\"
+                if not isinstance(name, str):
+                    raise TypeError(f"name must be a string, got {type(name).__name__}")
+                if not isinstance(age, int):
+                    raise TypeError(f"age must be an integer, got {type(age).__name__}")
+                if not name.strip():
+                    raise ValueError("name must not be empty or whitespace-only")
+                if age < 0 or age > 150:
+                    raise ValueError(f"age must be between 0 and 150, got {age}")
+                return {"name": name, "age": age, "email": email}
             """)
         )
 


### PR DESCRIPTION
## Summary

Adds the 27th behavioral eval scenario: **validate-user-input**.

Tests whether an agent can add proper input validation to a function:
- **Type checks**: name must be `str`, age must be `int` (TypeError)
- **Range checks**: age must be 0-150 inclusive (ValueError)
- **String checks**: name must not be empty/whitespace-only (ValueError)
- **Edge cases**: boundary values (0, 150) should pass

### 5 deterministic checkers
- `check_type_validation` — isinstance/type checks present
- `check_range_validation` — ValueError with comparison operators
- `check_string_sanitization` — strip/len/whitespace checks
- `check_custom_exception` — descriptive exception messages
- `check_tests_pass` — all 7 unit tests pass

### Files
- `gptme/eval/suites/behavioral/validate_user_input.py` — scenario + checkers
- `tests/test_eval_behavioral_solutions.py` — reference solution + docstring update
- `gptme/eval/suites/behavioral/__init__.py` — re-exports

Part of idea #19 (eval-to-lesson feedback loop).

### Test plan
- [x] All 5 checkers verified against reference solution
- [x] Reference solution passes all 7 unit tests
- [x] mypy passes
- [x] ruff format/check passes
