### PR TITLE
fix(eval): correct behavioral scenario count in docstring (28, not 29)

### DIFF
--- a/tests/test_eval_behavioral_solutions.py
+++ b/tests/test_eval_behavioral_solutions.py
@@ -9,7 +9,7 @@ This is critical infrastructure for idea #19 (eval-to-lesson feedback loop):
 before running expensive baseline experiments with real models, we need
 confidence that the checkers correctly identify good work.
 
-Covers all 29 behavioral scenarios:
+Covers all 28 behavioral scenarios:
   git-selective-commit, multi-file-rename, iterative-debug,
   stage-new-files, write-test-suite, test-driven-error-handling,
   merge-conflict-resolution, extract-function-refactor, debug-data-pipeline,


### PR DESCRIPTION
## Summary
- Fix stale docstring count in `tests/test_eval_behavioral_solutions.py`: says 29 but there are 28 behavioral scenarios

## Background
PR #2099 added circuit-breaker as the 26th scenario and was merged ahead of this branch. On rebase, the circuit-breaker scenario in this PR conflicted with #2099's version. Since #2099 used a superior instance-based `APIClient` design (natural test isolation, no conftest.py needed), we keep that version.

The only net change is fixing the docstring count that got incremented incorrectly.