### PR TITLE
fix(lessons): guard against zero-norm embeddings and clean up dead code

### DIFF
--- a/gptme/lessons/hybrid_matcher.py
+++ b/gptme/lessons/hybrid_matcher.py
@@ -358,10 +358,13 @@ class HybridLessonMatcher(LessonMatcher):
         lesson_text = f"{lesson.title}\n{lesson.body[:500]}"  # Limit to first 500 chars
         lesson_embed = self.embedder.encode(lesson_text, convert_to_numpy=True)
 
-        # Cosine similarity
+        # Cosine similarity (guard against zero-norm embeddings)
+        query_norm = np.linalg.norm(query_embed)
+        lesson_norm = np.linalg.norm(lesson_embed)
+        if query_norm == 0.0 or lesson_norm == 0.0:
+            return 0.0
         similarity = float(
-            np.dot(query_embed, lesson_embed)
-            / (np.linalg.norm(query_embed) * np.linalg.norm(lesson_embed))
+            np.dot(query_embed, lesson_embed) / (query_norm * lesson_norm)
         )
 
         # Normalize from [-1, 1] to [0, 1]

--- a/gptme/lessons/index.py
+++ b/gptme/lessons/index.py
@@ -442,23 +442,6 @@ class LessonIndex:
 
         return results
 
-    def find_by_keywords(self, keywords: list[str]) -> list[Lesson]:
-        """Find lessons matching any of the given keywords.
-
-        Args:
-            keywords: List of keywords to match
-
-        Returns:
-            List of matching lessons
-        """
-        results = [
-            lesson
-            for lesson in self.lessons
-            if any(kw in lesson.metadata.keywords for kw in keywords)
-        ]
-
-        return results
-
     def get_by_category(self, category: str) -> list[Lesson]:
         """Get all lessons in a category.
 

--- a/gptme/tools/lessons.py
+++ b/gptme/tools/lessons.py
@@ -275,27 +275,25 @@ def auto_include_lessons_hook(
     # Get session stats and check if we've hit the limit
     stats = _get_session_stats()
 
+    # Get messages from log
+    messages = manager.log.messages
+
+    # Get lessons already included (also used to initialize stats on resume)
+    included_lessons = _get_included_lessons_from_log(messages)
+
     # Initialize stats from log if empty (e.g., when resuming a conversation)
-    if not stats.unique_lessons:
-        included_in_log = _get_included_lessons_from_log(manager.log.messages)
-        if included_in_log:
-            stats.unique_lessons.update(included_in_log)
-            stats.total_matched = len(included_in_log)
-            logger.debug(
-                f"Initialized session stats from log: {len(included_in_log)} lessons"
-            )
+    if not stats.unique_lessons and included_lessons:
+        stats.unique_lessons.update(included_lessons)
+        stats.total_matched = len(included_lessons)
+        logger.debug(
+            f"Initialized session stats from log: {len(included_lessons)} lessons"
+        )
 
     if len(stats.unique_lessons) >= max_lessons:
         logger.debug(
             f"Session lesson limit reached ({len(stats.unique_lessons)}/{max_lessons})"
         )
         return
-
-    # Get messages from log
-    messages = manager.log.messages
-
-    # Get lessons already included
-    included_lessons = _get_included_lessons_from_log(messages)
 
     # Extract message content from recent user and assistant messages
     message_content = _extract_message_content(messages)

--- a/tests/test_hybrid_lessons.py
+++ b/tests/test_hybrid_lessons.py
@@ -364,3 +364,34 @@ def test_effectiveness_score_matches_explicit_lesson_id(tmp_path):
     )
 
     assert matcher._effectiveness_score(lesson) == pytest.approx(0.8)
+
+
+@pytest.mark.skipif(not HYBRID_AVAILABLE, reason="Hybrid matching not available")
+def test_semantic_score_zero_norm_returns_zero():
+    """Zero-norm embeddings should return 0.0 instead of NaN/inf."""
+    np = pytest.importorskip("numpy")
+    from unittest.mock import MagicMock
+
+    config = HybridConfig(enable_semantic=True)
+    matcher = HybridLessonMatcher(config=config)
+
+    # Mock the embedder to return a zero vector
+    mock_embedder = MagicMock()
+    mock_embedder.encode.return_value = np.zeros(384)
+    matcher.embedder = mock_embedder
+
+    lesson = Lesson(
+        path=Path("/tmp/lessons/test-lesson.md"),
+        metadata=LessonMetadata(),
+        title="Test",
+        description="",
+        category="test",
+        body="test body",
+    )
+    context = MatchContext(message="test query")
+    query_embed = np.zeros(384)  # Zero-norm query embedding
+
+    score = matcher._semantic_score(query_embed, lesson, context)
+    assert score == 0.0
+    assert not np.isnan(score)
+    assert not np.isinf(score)


### PR DESCRIPTION
## Summary
- Guard against zero-norm embeddings in `_semantic_score()` to prevent NaN/inf from division by zero
- Remove redundant `_get_included_lessons_from_log()` call (was called twice per hook execution with identical args)
- Remove unused `find_by_keywords()` from `LessonIndex` (dead code with inconsistent case-sensitive matching)

## Test plan
- [x] Added test for zero-norm edge case (`test_semantic_score_zero_norm_returns_zero`)
- [x] All 110 lesson tests pass (90 in test_lessons.py + 20 in test_hybrid_lessons.py)
- [x] Type checking passes