### PR TITLE
docs: add local model quickstart and Claude Managed Agents comparison

### DIFF
--- a/docs/alternatives.rst
+++ b/docs/alternatives.rst
@@ -465,10 +465,36 @@ Differences to gptme:
 Disclaimer: gptme author Erik was an early hire at Lovable.
 
 
+Claude Managed Agents
+^^^^^^^^^^^^^^^^^^^^^
+
+`Claude Managed Agents <https://platform.claude.com/docs/en/managed-agents/overview>`_ is Anthropic's hosted platform for running autonomous agents with sandboxed execution, built-in tools, and state management. Released April 8, 2026.
+
+Key features:
+
+- Cloud-hosted sandbox execution (no local setup required)
+- Built-in tool suite (web search, code execution, file management)
+- State management across tool calls within a session
+- REST API for programmatic control
+
+Differences to gptme:
+
+- **Model lock-in**: Claude Managed Agents only runs Claude; gptme works with any provider
+- **Runtime cost**: $0.08/hr for 24/7 agents (~$58/mo per agent) on top of token costs; gptme has no runtime fee
+- **No self-hosting**: Cloud-only platform; gptme runs on your own machine
+- **Memory still in preview**: Cross-session memory is a "research preview" feature; gptme agents have full git-based persistent memory out of the box
+- **Validates the category**: Anthropic building this confirms that persistent autonomous agents are the next frontier — and gptme has been doing it longer and with more flexibility
+
+.. note::
+
+   CMA launching validates the autonomous agent category. If Anthropic thinks managed
+   agents are worth building, the open-source, model-agnostic alternative matters more.
+
+
 Other Claude Products
 ^^^^^^^^^^^^^^^^^^^^^
 
-Anthropic offers several AI products beyond Claude Code:
+Anthropic offers several AI products beyond Claude Code and Claude Managed Agents:
 
 - **Claude Projects**: Upload files and chat with them in a project context. Released Jun 25, 2024.
 - **Claude Artifacts**: Preview HTML and React components inline — like a mini Lovable.dev. Released Aug 27, 2024.

--- a/docs/alternatives.rst
+++ b/docs/alternatives.rst
@@ -483,7 +483,6 @@ Differences to gptme:
 - **Runtime cost**: $0.08/hr for 24/7 agents (~$58/mo per agent) on top of token costs; gptme has no runtime fee
 - **No self-hosting**: Cloud-only platform; gptme runs on your own machine
 - **Memory still in preview**: Cross-session memory is a "research preview" feature; gptme agents have full git-based persistent memory out of the box
-- **Validates the category**: Anthropic building this confirms that persistent autonomous agents are the next frontier — and gptme has been doing it longer and with more flexibility
 
 .. note::
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -86,7 +86,8 @@ To run gptme without an API key, use a local model via `Ollama <https://ollama.c
     ollama pull llama3.2:1b
     ollama serve  # run in background or separate terminal
 
-    # Use with gptme
+    # Use with gptme (OPENAI_BASE_URL is required by the local provider)
+    export OPENAI_BASE_URL="http://127.0.0.1:11434/v1"
     gptme "hello" -m local/llama3.2:1b
 
 For better results on coding tasks, use a larger model:
@@ -94,6 +95,7 @@ For better results on coding tasks, use a larger model:
 .. code-block:: bash
 
     ollama pull llama3.1:8b
+    export OPENAI_BASE_URL="http://127.0.0.1:11434/v1"
     gptme -m local/llama3.1:8b
 
 .. tip::

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -75,6 +75,39 @@ Here are some compelling examples to get you started:
     # Resume conversations
     gptme -r
 
+Local Models (No API Key Required)
+-----------------------------------
+
+To run gptme without an API key, use a local model via `Ollama <https://ollama.com>`_:
+
+.. code-block:: bash
+
+    # Install Ollama (see https://ollama.com), then pull a model
+    ollama pull llama3.2:1b
+    ollama serve  # run in background or separate terminal
+
+    # Use with gptme
+    gptme "hello" -m local/llama3.2:1b
+
+For better results on coding tasks, use a larger model:
+
+.. code-block:: bash
+
+    ollama pull llama3.1:8b
+    gptme -m local/llama3.1:8b
+
+.. tip::
+
+   Local models work well for simple tasks and private workflows. For complex multi-step
+   coding work, API-based models (Claude, GPT-4o) give better results.
+
+   If gptme shows an error about the summary model, configure ``model.summary`` in
+   :doc:`config` to point to a local model, or pass ``-m local/MODEL_NAME`` to use the
+   same model for both chat and summaries.
+
+See :doc:`providers` for ``llama.cpp``, Groq, and all other local and remote provider options.
+
+
 Next Steps
 ----------
 


### PR DESCRIPTION
## Summary

Two documentation improvements addressing the most-requested gaps:

### 1. Local Models Quickstart (closes #2104)

Adds a "Local Models (No API Key Required)" section to the Getting Started guide, right after the Quick Examples. Addresses the #1 friction point for new users — local model setup isn't mentioned anywhere in getting-started, requiring users to independently find the providers doc.

**Changes**: `docs/getting-started.rst`
- Ollama quickstart with `llama3.2:1b` (minimal) and `llama3.1:8b` (coding)
- Tip about summary model configuration (addresses issues #949, #966)
- Links to providers doc for advanced options

### 2. Claude Managed Agents Comparison (closes #2101)

Adds a new section for Claude Managed Agents (launched April 8, 2026) to the alternatives page. CMA is a direct competitor in the autonomous agent space and deserves its own entry, not just a bullet in "Other Claude Products".

**Changes**: `docs/alternatives.rst`
- New "Claude Managed Agents" section after "Claude Code"
- Key features + gptme differentiators (model lock-in, $0.08/hr cost, cloud-only, preview memory)
- Framing note: CMA validates the autonomous agent category, making the open-source alternative more relevant

## Test plan

- [ ] RST renders correctly (no broken references — `make html` in docs/)
- [ ] Links in new sections are valid
- [ ] Ollama commands are accurate (`ollama pull llama3.2:1b`, `-m local/MODEL`)