### PR TITLE
fix(server): detect and clean up stuck generating sessions

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -11,6 +11,7 @@ import logging
 import time
 import uuid
 from collections.abc import Generator
+from datetime import datetime, timezone
 
 import flask
 from flask import request
@@ -308,6 +309,7 @@ def api_conversation_step(conversation_id: str):
         # check above and those calls — enough for a second request to slip through
         # on threaded WSGI servers.
         session.generating = True
+        session.generating_since = datetime.now(tz=timezone.utc)
 
     # Wrap setup in try/finally so any unexpected exception (get_default_model,
     # config I/O, etc.) resets the flag rather than leaving the session
@@ -407,6 +409,7 @@ def api_conversation_step(conversation_id: str):
     finally:
         if not _step_dispatched:
             session.generating = False
+            session.generating_since = None
 
     # Wait briefly for early errors (bad model, auth failure, empty messages, etc.)
     # so we can return them in the HTTP response instead of swallowing silently.
@@ -791,6 +794,7 @@ def api_conversation_interrupt(conversation_id: str):
 
     # Mark session as not generating
     session.generating = False
+    session.generating_since = None
 
     # Clear pending tools
     session.pending_tools.clear()

--- a/gptme/server/session_models.py
+++ b/gptme/server/session_models.py
@@ -69,6 +69,9 @@ class ConversationSession(BaseSession):
 
     # Server-specific fields (all have defaults, required for dataclass inheritance)
     generating: bool = False
+    generating_since: datetime | None = (
+        None  # When generation started (for stuck detection)
+    )
     last_error: str | None = None
     events: list[EventType] = field(default_factory=list)
     pending_tools: dict[str, ToolExecution] = field(default_factory=dict)
@@ -128,14 +131,40 @@ class SessionManager:
             session.touch()  # Update last_activity timestamp
             session.event_flag.set()  # Signal that new events are available
 
+    # Max time a session can remain in generating=True before being considered stuck.
+    # Protects against sessions permanently stuck when a step thread crashes
+    # without resetting the generating flag.
+    _STUCK_GENERATING_TIMEOUT_MINUTES = 10
+
     @classmethod
     def clean_inactive_sessions(cls, max_age_minutes: int = 60) -> None:
-        """Clean up inactive sessions."""
-        cutoff = datetime.now(tz=timezone.utc) - timedelta(minutes=max_age_minutes)
+        """Clean up inactive sessions.
+
+        Also detects sessions stuck in generating=True state: if a session has
+        been generating for longer than _STUCK_GENERATING_TIMEOUT_MINUTES, it is
+        force-cleaned to prevent permanent resource leaks.
+        """
+        now = datetime.now(tz=timezone.utc)
+        cutoff = now - timedelta(minutes=max_age_minutes)
+        stuck_cutoff = now - timedelta(minutes=cls._STUCK_GENERATING_TIMEOUT_MINUTES)
         to_remove = []
 
         for session_id, session in list(cls._sessions.items()):
             if session.last_activity < cutoff and not session.generating:
+                to_remove.append(session_id)
+            elif (
+                session.generating
+                and session.generating_since is not None
+                and session.generating_since < stuck_cutoff
+            ):
+                logger.warning(
+                    "Force-cleaning stuck session %s (generating since %s, "
+                    "exceeded %d min timeout)",
+                    session_id,
+                    session.generating_since.isoformat(),
+                    cls._STUCK_GENERATING_TIMEOUT_MINUTES,
+                )
+                session.generating = False
                 to_remove.append(session_id)
 
         for session_id in to_remove:

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -14,6 +14,7 @@ import os
 import threading
 import uuid
 from collections.abc import Iterable
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -346,6 +347,7 @@ async def _acp_step(
             {"type": "error", "error": "Internal error: ACP runtime not initialized"},
         )
         session.generating = False
+        session.generating_since = None
         return
     acp_runtime = session.acp_runtime  # snapshot to avoid TOCTOU races
 
@@ -388,6 +390,7 @@ async def _acp_step(
         }
         SessionManager.add_event(conversation_id, error_event)
         session.generating = False
+        session.generating_since = None
         return
 
     next_user_index = session.acp_last_user_msg_index + 1
@@ -399,6 +402,7 @@ async def _acp_step(
         }
         SessionManager.add_event(conversation_id, duplicate_error_event)
         session.generating = False
+        session.generating_since = None
         return
 
     SessionManager.add_event(conversation_id, {"type": "generation_started"})
@@ -479,6 +483,7 @@ async def _acp_step(
     finally:
         acp_runtime.set_on_update(None)
         session.generating = False
+        session.generating_since = None
 
 
 def _start_acp_step_thread(
@@ -489,6 +494,7 @@ def _start_acp_step_thread(
     """Start an ACP-backed step in a background thread."""
     session.last_error = None
     session.generating = True
+    session.generating_since = datetime.now(tz=timezone.utc)
 
     def _run() -> None:
         asyncio.run(_acp_step(conversation_id, session, workspace))
@@ -606,6 +612,7 @@ def step(
         }
         SessionManager.add_event(conversation_id, error_event)
         session.generating = False
+        session.generating_since = None
         return
 
     # Notify clients about generation status
@@ -735,9 +742,6 @@ def step(
                     conversation_id, session, tool_id, tooluse, model, chat_config
                 )
 
-        # Mark session as not generating
-        session.generating = False
-
     except Exception as e:
         logger.exception(f"Error during step execution: {e}")
         error_message = str(e) or "Generation failed"
@@ -749,7 +753,9 @@ def step(
         SessionManager.add_event(
             conversation_id, {"type": "error", "error": error_message}
         )
+    finally:
         session.generating = False
+        session.generating_since = None
 
 
 def start_tool_execution(
@@ -863,6 +869,7 @@ def _start_step_thread(
     # the /step route's guard.
     session.last_error = None
     session.generating = True
+    session.generating_since = datetime.now(tz=timezone.utc)
 
     def step_thread() -> None:
         step(

--- a/tests/test_server_session_models.py
+++ b/tests/test_server_session_models.py
@@ -515,5 +515,7 @@ class TestSessionManagerCleanInactive:
         # Capture session reference before it's removed
         assert session.generating is True
         SessionManager.clean_inactive_sessions(max_age_minutes=60)
-        # Session is removed, so generating flag was reset (verified by the cleanup logic)
+        # Session is removed from the manager
         assert SessionManager.get_session(session.id) is None
+        # generating flag is reset to False before removal (the key invariant this test verifies)
+        assert session.generating is False

--- a/tests/test_server_session_models.py
+++ b/tests/test_server_session_models.py
@@ -151,6 +151,11 @@ class TestConversationSession:
         session = SessionManager.create_session("conv-1")
         assert session.generating is False
 
+    def test_default_generating_since_none(self):
+        """generating_since defaults to None."""
+        session = SessionManager.create_session("conv-1")
+        assert session.generating_since is None
+
     def test_default_events_empty(self):
         """events list defaults to empty."""
         session = SessionManager.create_session("conv-1")
@@ -454,3 +459,61 @@ class TestSessionManagerCleanInactive:
 
         assert SessionManager.get_session(s_old.id) is None
         assert SessionManager.get_session(s_recent.id) is not None
+
+    def test_removes_stuck_generating_sessions(self):
+        """Sessions stuck in generating=True beyond the timeout are force-cleaned."""
+        from datetime import datetime, timedelta, timezone
+
+        session = SessionManager.create_session("conv-stuck")
+        session.generating = True
+        # Simulate stuck for 15 minutes (exceeds 10-minute timeout)
+        session.generating_since = datetime.now(tz=timezone.utc) - timedelta(minutes=15)
+        # Keep last_activity recent so the normal inactive cleanup wouldn't catch it
+        session.last_activity = datetime.now(tz=timezone.utc)
+
+        SessionManager.clean_inactive_sessions(max_age_minutes=60)
+        assert SessionManager.get_session(session.id) is None
+
+    def test_does_not_remove_recently_generating_sessions(self):
+        """Sessions that started generating recently are not removed."""
+        from datetime import datetime, timezone
+
+        session = SessionManager.create_session("conv-gen")
+        session.generating = True
+        session.generating_since = datetime.now(tz=timezone.utc)  # just started
+        session.last_activity = datetime.now(tz=timezone.utc)
+
+        SessionManager.clean_inactive_sessions(max_age_minutes=60)
+        # Still present because generating started recently
+        assert SessionManager.get_session(session.id) is not None
+
+    def test_does_not_remove_generating_without_timestamp(self):
+        """Sessions with generating=True but no generating_since are not force-cleaned.
+
+        This handles the edge case of sessions created before this change was deployed.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        session = SessionManager.create_session("conv-legacy")
+        session.generating = True
+        session.generating_since = None  # no timestamp (legacy behavior)
+        session.last_activity = datetime.now(tz=timezone.utc) - timedelta(minutes=5)
+
+        SessionManager.clean_inactive_sessions(max_age_minutes=60)
+        # Still present — can't determine if stuck without timestamp
+        assert SessionManager.get_session(session.id) is not None
+
+    def test_stuck_session_generating_flag_reset(self):
+        """Force-cleaned stuck sessions have their generating flag reset."""
+        from datetime import datetime, timedelta, timezone
+
+        session = SessionManager.create_session("conv-stuck-flag")
+        session.generating = True
+        session.generating_since = datetime.now(tz=timezone.utc) - timedelta(minutes=15)
+        session.last_activity = datetime.now(tz=timezone.utc)
+
+        # Capture session reference before it's removed
+        assert session.generating is True
+        SessionManager.clean_inactive_sessions(max_age_minutes=60)
+        # Session is removed, so generating flag was reset (verified by the cleanup logic)
+        assert SessionManager.get_session(session.id) is None


### PR DESCRIPTION
## Summary

- Sessions could become permanently stuck in `generating=True` state if a step thread crashed without resetting the flag (e.g., `SystemExit`, thread kill, or unexpected termination). The `clean_inactive_sessions()` method skipped these sessions due to the `not session.generating` guard, causing a resource leak.
- Adds a `generating_since` timestamp to track when generation started, and force-cleans sessions stuck generating for >10 minutes
- Converts the in-process step function from `try/except` to `try/finally` to ensure the generating flag is always reset

## Test plan

- [x] 5 new tests in `test_server_session_models.py` covering:
  - Stuck sessions (generating >10 min) are force-cleaned
  - Recently-started generating sessions are not removed
  - Sessions without `generating_since` (legacy) are not force-cleaned
  - Generating flag is reset before removal
- [x] All 60 existing + new tests pass
- [x] mypy clean on all changed files