### PR TITLE
fix(server+eval): event trimming for memory leak + eval timeout bug

### DIFF
--- a/gptme/eval/run.py
+++ b/gptme/eval/run.py
@@ -189,7 +189,8 @@ def run_evals(
             model_results[config][test_name] = result
 
         # worse-case run time, with some buffer to account for overhead
-        max_timeout = timeout * len(evals) / parallel + 10
+        # n_runs accounts for all model×eval combinations, not just evals
+        max_timeout = timeout * n_runs / parallel + 10
         completed = set()
         try:
             # TODO: can we do better than this? handle timeouts within futures instead?

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -155,14 +155,14 @@ def api_conversation_events(conversation_id: str):
             # Send immediate ping to ensure connection is established right away
             yield f"data: {flask.json.dumps({'type': 'ping'})}\n\n"
 
-            # Create an event queue
-            last_event_index = 0
+            # Track position using absolute event indices (offset-aware)
+            last_event_index = session.events_count
 
             while True:
                 # Check if there are new events
-                if last_event_index < (new_index := len(session.events)):
+                if last_event_index < (new_index := session.events_count):
                     # Send any new events
-                    for event in session.events[last_event_index:new_index]:
+                    for event in session.get_events_since(last_event_index):
                         yield f"data: {flask.json.dumps(event)}\n\n"
                     last_event_index = new_index
 
@@ -177,7 +177,7 @@ def api_conversation_events(conversation_id: str):
                 # Re-check after clearing: events may have arrived between the
                 # check above and the clear(), which would otherwise delay
                 # delivery by up to the full wait timeout.
-                if last_event_index < len(session.events):
+                if last_event_index < session.events_count:
                     continue
 
                 session.event_flag.wait(timeout=15)
@@ -376,8 +376,8 @@ def api_conversation_step(conversation_id: str):
         if acp_runtime is not None and model:
             acp_runtime.model = model
 
-        # Snapshot event count before starting, so we can detect new events below
-        initial_event_count = len(session.events)
+        # Snapshot absolute event count before starting, so we can detect new events below
+        initial_event_count = session.events_count
 
         # Route through ACP subprocess if the session has opted in
         if acp_runtime is not None:
@@ -420,7 +420,7 @@ def api_conversation_step(conversation_id: str):
     deadline = time.monotonic() + _STARTUP_TIMEOUT
     while time.monotonic() < deadline:
         # Check new events since we started
-        new_events = session.events[initial_event_count:]
+        new_events = session.get_events_since(initial_event_count)
         for event in new_events:
             event_type = event.get("type") if isinstance(event, dict) else None
             if event_type == "error":

--- a/gptme/server/session_models.py
+++ b/gptme/server/session_models.py
@@ -74,6 +74,7 @@ class ConversationSession(BaseSession):
     )
     last_error: str | None = None
     events: list[EventType] = field(default_factory=list)
+    _events_offset: int = 0  # number of events trimmed from front of list
     pending_tools: dict[str, ToolExecution] = field(default_factory=dict)
     auto_confirm_count: int = 0
     clients: set[str] = field(default_factory=set)
@@ -88,6 +89,34 @@ class ConversationSession(BaseSession):
     # Index of the last user message processed through ACP mode.
     # Prevents duplicate /step calls from re-sending the same user message.
     acp_last_user_msg_index: int = -1
+
+    # Maximum events to keep in memory per session before trimming.
+    # Each LLM token generates one event, so a 10K-token response = 10K events.
+    # At ~200 bytes/event, 10K events ≈ 2MB. We trim to keep_last when exceeded.
+    _MAX_EVENTS = 10_000
+    _KEEP_EVENTS = 1_000
+
+    @property
+    def events_count(self) -> int:
+        """Absolute event count (including trimmed events)."""
+        return self._events_offset + len(self.events)
+
+    def get_events_since(self, abs_index: int) -> list[EventType]:
+        """Get events from an absolute index (accounting for trimmed events)."""
+        rel_index = max(0, abs_index - self._events_offset)
+        return self.events[rel_index:]
+
+    def trim_events(self) -> None:
+        """Trim old events when the list exceeds _MAX_EVENTS.
+
+        Only trims when no clients are connected to avoid breaking
+        in-flight SSE streams that reference absolute indices.
+        """
+        if len(self.events) <= self._MAX_EVENTS or self.clients:
+            return
+        trim_count = len(self.events) - self._KEEP_EVENTS
+        self._events_offset += trim_count
+        self.events = self.events[trim_count:]
 
 
 class SessionManager:
@@ -128,6 +157,7 @@ class SessionManager:
         """Add an event to all sessions for a conversation."""
         for session in cls.get_sessions_for_conversation(conversation_id):
             session.events.append(event)
+            session.trim_events()
             session.touch()  # Update last_activity timestamp
             session.event_flag.set()  # Signal that new events are available
 

--- a/tests/test_server_session_models.py
+++ b/tests/test_server_session_models.py
@@ -218,6 +218,96 @@ class TestConversationSession:
         s1.events.append({"type": "ping"})  # type: ignore[arg-type]
         assert s2.events == []
 
+    def test_events_count_matches_len_initially(self):
+        """events_count equals len(events) when no trimming has occurred."""
+        session = SessionManager.create_session("conv-1")
+        for _i in range(5):
+            session.events.append({"type": "ping"})  # type: ignore[arg-type]
+        assert session.events_count == 5
+        assert session.events_count == len(session.events)
+
+    def test_events_offset_starts_at_zero(self):
+        """_events_offset starts at 0."""
+        session = SessionManager.create_session("conv-1")
+        assert session._events_offset == 0
+
+    def test_get_events_since_returns_all_from_zero(self):
+        """get_events_since(0) returns all events."""
+        session = SessionManager.create_session("conv-1")
+        for i in range(3):
+            session.events.append({"type": "ping", "n": i})  # type: ignore[arg-type]
+        result = session.get_events_since(0)
+        assert len(result) == 3
+
+    def test_get_events_since_returns_subset(self):
+        """get_events_since returns events from the given index onward."""
+        session = SessionManager.create_session("conv-1")
+        for i in range(5):
+            session.events.append({"type": "ping", "n": i})  # type: ignore[arg-type]
+        result = session.get_events_since(3)
+        assert len(result) == 2
+        assert result[0]["n"] == 3  # type: ignore[typeddict-item]
+        assert result[1]["n"] == 4  # type: ignore[typeddict-item]
+
+    def test_trim_events_no_clients(self):
+        """trim_events trims when over threshold and no clients connected."""
+        session = SessionManager.create_session("conv-1")
+        # Fill beyond _MAX_EVENTS
+        for i in range(session._MAX_EVENTS + 500):
+            session.events.append({"type": "ping", "n": i})  # type: ignore[arg-type]
+        assert len(session.events) == session._MAX_EVENTS + 500
+
+        session.trim_events()
+        assert len(session.events) == session._KEEP_EVENTS
+        assert (
+            session._events_offset == session._MAX_EVENTS + 500 - session._KEEP_EVENTS
+        )
+        assert session.events_count == session._MAX_EVENTS + 500
+
+    def test_trim_events_preserves_absolute_indexing(self):
+        """After trimming, get_events_since still works with absolute indices."""
+        session = SessionManager.create_session("conv-1")
+        total = session._MAX_EVENTS + 100
+        for i in range(total):
+            session.events.append({"type": "ping", "n": i})  # type: ignore[arg-type]
+        session.trim_events()
+
+        # The last event should still be retrievable
+        result = session.get_events_since(total - 1)
+        assert len(result) == 1
+        assert result[0]["n"] == total - 1  # type: ignore[typeddict-item]
+
+    def test_trim_events_skipped_when_clients_connected(self):
+        """trim_events does not trim when clients are connected."""
+        session = SessionManager.create_session("conv-1")
+        session.clients.add("client-1")
+        for i in range(session._MAX_EVENTS + 500):
+            session.events.append({"type": "ping", "n": i})  # type: ignore[arg-type]
+
+        session.trim_events()
+        # No trimming because a client is connected
+        assert len(session.events) == session._MAX_EVENTS + 500
+        assert session._events_offset == 0
+
+    def test_trim_events_skipped_below_threshold(self):
+        """trim_events does nothing when below _MAX_EVENTS."""
+        session = SessionManager.create_session("conv-1")
+        for i in range(100):
+            session.events.append({"type": "ping", "n": i})  # type: ignore[arg-type]
+        session.trim_events()
+        assert len(session.events) == 100
+        assert session._events_offset == 0
+
+    def test_get_events_since_clamps_negative_relative_index(self):
+        """get_events_since with index before offset returns all available events."""
+        session = SessionManager.create_session("conv-1")
+        for i in range(session._MAX_EVENTS + 100):
+            session.events.append({"type": "ping", "n": i})  # type: ignore[arg-type]
+        session.trim_events()
+        # Requesting from index 0, which was trimmed away
+        result = session.get_events_since(0)
+        assert len(result) == session._KEEP_EVENTS
+
 
 # ---------------------------------------------------------------------------
 # SessionManager
@@ -413,6 +503,20 @@ class TestSessionManagerAddEvent:
         # Should not raise
         event: ErrorEvent = {"type": "error", "error": "nowhere"}
         SessionManager.add_event("unknown-conv", event)
+
+    def test_add_event_trims_when_over_threshold(self):
+        """add_event triggers trimming when events exceed threshold."""
+        session = SessionManager.create_session("conv-1")
+        # Fill to just below threshold
+        for i in range(session._MAX_EVENTS):
+            session.events.append({"type": "ping", "n": i})  # type: ignore[arg-type]
+        assert len(session.events) == session._MAX_EVENTS
+
+        # One more event via add_event pushes over threshold and triggers trim
+        event: ErrorEvent = {"type": "error", "error": "trigger trim"}
+        SessionManager.add_event("conv-1", event)
+        assert len(session.events) == session._KEEP_EVENTS
+        assert session.events_count == session._MAX_EVENTS + 1
 
 
 class TestSessionManagerCleanInactive:


### PR DESCRIPTION
## Summary
- **Event trimming**: `session.events` list grew without bound — each LLM token appended a dict that was never freed. Added offset-aware trimming that caps events at 10K entries (keeping 1K) when no SSE clients are connected. All event consumers updated to use absolute indexing.
- **Eval timeout**: `max_timeout` used `len(evals)` instead of `n_runs` (evals × models), causing premature cancellation and silently lost results when running multi-model evaluations.

## Test plan
- [x] 70 tests pass in `test_server_session_models.py` (10 new tests for trimming)
- [x] mypy clean on all changed files
- [x] Pre-commit (prek) passes
- [ ] CI green