### PR TITLE
ci: always run webui ci on master

### DIFF
--- a/.github/workflows/webui.yml
+++ b/.github/workflows/webui.yml
@@ -3,9 +3,6 @@ name: WebUI
 on:
   push:
     branches: [ master ]
-    paths:
-      - 'webui/**'
-      - '.github/workflows/webui.yml'
   pull_request:
     branches: [ master, 'dev/*' ]
     paths:


### PR DESCRIPTION
I noticed webui CI was failing on a PR like https://github.com/gptme/gptme/pull/1847 which wasn't even being ran on every commit to master! Now only conditionally run in PRs