### PR TITLE
feat(eval): add implement-connection-pool and implement-retry-decorator behavioral scenarios (31st and 32nd)

### DIFF
--- a/gptme/eval/suites/behavioral/implement_connection_pool.py
+++ b/gptme/eval/suites/behavioral/implement_connection_pool.py
@@ -1,0 +1,260 @@
+"""Behavioral scenario: implement-connection-pool."""
+
+import ast
+from typing import TYPE_CHECKING
+
+from ._common import parse_python_source
+
+if TYPE_CHECKING:
+    from gptme.eval.types import EvalSpec
+
+
+def _get_source(ctx, filename: str = "db_pool.py") -> str:
+    content = ctx.files.get(filename, "")
+    if isinstance(content, bytes):
+        content = content.decode()
+    return content
+
+
+def check_tests_pass(ctx):
+    """All tests should pass after implementing connection pool."""
+    return ctx.exit_code == 0 and "failed" not in ctx.stdout.lower()
+
+
+def check_has_pool_class(ctx):
+    """Should have a ConnectionPool class."""
+    content = _get_source(ctx)
+    module = parse_python_source(content)
+    if module is None:
+        return False
+    for node in ast.walk(module):
+        if isinstance(node, ast.ClassDef):
+            name_lower = node.name.lower()
+            if "pool" in name_lower and "connection" in name_lower:
+                return True
+    return False
+
+
+def check_has_max_size(ctx):
+    """Pool should enforce a maximum connection limit."""
+    content = _get_source(ctx)
+    content_lower = content.lower()
+    return (
+        "max_size" in content_lower
+        or "max_connections" in content_lower
+        or "max_pool" in content_lower
+        or "max_conn" in content_lower
+    )
+
+
+def check_reuses_connections(ctx):
+    """Pool should return existing idle connections before creating new ones."""
+    content = _get_source(ctx)
+    module = parse_python_source(content)
+    if module is None:
+        return False
+    # Look for an idle/free list that stores available connections
+    for node in ast.walk(module):
+        if isinstance(node, ast.Attribute):
+            if node.attr in (
+                "idle",
+                "available",
+                "_idle",
+                "_available",
+                "free",
+                "_free",
+            ):
+                return True
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id in (
+                    "idle",
+                    "available",
+                    "_idle",
+                    "_available",
+                ):
+                    return True
+    return False
+
+
+def check_has_acquire_release(ctx):
+    """Pool should have acquire/release or get/return methods."""
+    content = _get_source(ctx)
+    content_lower = content.lower()
+    has_acquire = (
+        "acquire" in content_lower
+        or "get_connection" in content_lower
+        or "get" in content_lower
+    )
+    has_release = (
+        "release" in content_lower
+        or "return_connection" in content_lower
+        or "put" in content_lower
+    )
+    return has_acquire and has_release
+
+
+def check_blocks_when_exhausted(ctx):
+    """Pool should handle the case when all connections are in use."""
+    content = _get_source(ctx)
+    content_lower = content.lower()
+    # Could block/wait, raise an error, or return None — any explicit handling
+    return (
+        "wait" in content_lower
+        or "block" in content_lower
+        or "timeout" in content_lower
+        or "exhausted" in content_lower
+        or "PoolExhaustedError" in content
+        or "full" in content_lower
+        or "max_size" in content_lower  # at minimum checks size before creating
+    )
+
+
+POOL_SRC = '''\
+"""Database connection pool."""
+
+import sqlite3
+
+
+class PooledConnection:
+    """Wrapper around a database connection for pool tracking."""
+
+    def __init__(self, conn: sqlite3.Connection, release_callback):
+        self._conn = conn
+        self._release = release_callback
+
+    def cursor(self):
+        return self._conn.cursor()
+
+    def commit(self):
+        self._conn.commit()
+
+    def close(self):
+        """Return connection to pool instead of closing."""
+        self._release(self._conn)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is None:
+            self._conn.commit()
+        self._release(self._conn)
+        return False
+'''
+
+
+TEST_POOL_SRC = '''\
+import sqlite3
+from unittest.mock import MagicMock, patch
+import threading
+import time
+
+import pytest
+
+from db_pool import PooledConnection, ConnectionPool
+
+
+@pytest.fixture
+def pool():
+    """Create a fresh pool for each test."""
+    return ConnectionPool("file::memory:?cache=shared", max_size=3)
+
+
+def test_creates_connection_on_acquire(pool):
+    """Should create a new connection on first acquire."""
+    conn = pool.acquire()
+    assert conn is not None
+    assert isinstance(conn, PooledConnection)
+    # Connection should be tracked as in-use
+    assert pool.active_count == 1
+
+
+def test_reuses_idle_connection(pool):
+    """Should return idle connection on subsequent acquire."""
+    conn1 = pool.acquire()
+    assert pool.active_count == 1
+    pool.release(conn1)
+    assert pool.active_count == 0
+
+    conn2 = pool.acquire()
+    assert pool.active_count == 1
+    # Should be the same underlying connection
+    assert conn2._conn is conn1._conn
+    pool.release(conn2)
+
+
+def test_respects_max_size(pool):
+    """Should not exceed max_size connections."""
+    conns = [pool.acquire() for _ in range(3)]
+    assert pool.active_count == 3
+
+    # Pool is exhausted — should raise or block
+    with pytest.raises(Exception):
+        pool.acquire()
+
+    for conn in conns:
+        pool.release(conn)
+    assert pool.active_count == 0
+
+
+def test_context_manager():
+    """Should work as context manager via PooledConnection."""
+    pool = ConnectionPool("file::memory:?cache=shared", max_size=2)
+    with pool.acquire() as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT 1")
+        result = cursor.fetchone()
+        assert result == (1,)
+
+    # Connection should be returned after context exit
+    assert pool.active_count == 0
+
+
+def test_release_untracked_connection(pool):
+    """Releasing a connection not from this pool should be handled gracefully."""
+    fake_conn = PooledConnection(sqlite3.connect(":memory:"), lambda c: None)
+    # Should not raise or corrupt pool state
+    pool.release(fake_conn)
+    assert pool.active_count == 0
+    assert pool.idle_count == 0
+'''
+
+
+# EvalSpec definition
+test: "EvalSpec" = {
+    "name": "implement-connection-pool",
+    "files": {
+        "db_pool.py": POOL_SRC,
+        "test_db_pool.py": TEST_POOL_SRC,
+    },
+    "run": "python3 -m pytest test_db_pool.py -v --tb=short 2>&1",
+    "prompt": (
+        "The test suite `test_db_pool.py` is failing because `ConnectionPool` "
+        "class is missing from `db_pool.py`. Only `PooledConnection` exists. "
+        "The tests expect a `ConnectionPool` with these behaviors:\n\n"
+        "1. `pool.acquire()` — returns a `PooledConnection`; creates new if no idle ones available\n"
+        "2. `pool.release(conn)` — returns connection to the idle pool\n"
+        "3. `pool.active_count` — number of currently checked-out connections\n"
+        "4. `pool.idle_count` — number of available connections in the pool\n"
+        "5. Enforces `max_size` — raises an exception when all connections are in use\n"
+        "6. Context manager support via `PooledConnection.__enter__`/`__exit__` (already implemented)\n"
+        "7. Graceful handling of releasing untracked connections\n\n"
+        "Implement `ConnectionPool.__init__(self, db_path: str, max_size: int = 5)`:\n"
+        "- Store db_path and max_size\n"
+        "- Maintain a list of idle connections\n"
+        "- acquire() returns idle connection or creates a new one (up to max_size)\n"
+        "- release() puts connection back in idle list (ignore unknown connections)\n"
+        "- `active_count` and `idle_count` properties\n\n"
+        "After implementing, run the tests to verify they all pass.\n"
+    ),
+    "tools": ["shell", "save", "read"],
+    "expect": {
+        "all tests pass": check_tests_pass,
+        "has pool class": check_has_pool_class,
+        "has max size": check_has_max_size,
+        "reuses connections": check_reuses_connections,
+        "has acquire/release": check_has_acquire_release,
+        "handles exhaustion": check_blocks_when_exhausted,
+    },
+}

--- a/gptme/eval/suites/behavioral/implement_connection_pool.py
+++ b/gptme/eval/suites/behavioral/implement_connection_pool.py
@@ -78,35 +78,38 @@ def check_reuses_connections(ctx):
 
 
 def check_has_acquire_release(ctx):
-    """Pool should have acquire/release or get/return methods."""
+    """Pool should have acquire/release or get/return methods on ConnectionPool class."""
     content = _get_source(ctx)
-    content_lower = content.lower()
-    has_acquire = (
-        "acquire" in content_lower
-        or "get_connection" in content_lower
-        or "get" in content_lower
-    )
-    has_release = (
-        "release" in content_lower
-        or "return_connection" in content_lower
-        or "put" in content_lower
+    module = parse_python_source(content)
+    if module is None:
+        return False
+    # Check for acquire/get method and a release/return method on ConnectionPool class
+    pool_methods: set[str] = set()
+    for node in ast.walk(module):
+        if isinstance(node, ast.ClassDef) and "pool" in node.name.lower():
+            for item in ast.walk(node):
+                if isinstance(item, ast.FunctionDef | ast.AsyncFunctionDef):
+                    pool_methods.add(item.name.lower())
+    has_acquire = bool(pool_methods & {"acquire", "get_connection", "get", "checkout"})
+    has_release = bool(
+        pool_methods & {"release", "return_connection", "put", "checkin"}
     )
     return has_acquire and has_release
 
 
 def check_blocks_when_exhausted(ctx):
-    """Pool should handle the case when all connections are in use."""
+    """Pool should explicitly handle exhaustion — raise, wait, or block."""
     content = _get_source(ctx)
     content_lower = content.lower()
-    # Could block/wait, raise an error, or return None — any explicit handling
+    # Must show explicit exhaustion handling, not just having the max_size parameter
     return (
-        "wait" in content_lower
+        "raise" in content_lower
+        or "wait" in content_lower
         or "block" in content_lower
         or "timeout" in content_lower
         or "exhausted" in content_lower
         or "PoolExhaustedError" in content
         or "full" in content_lower
-        or "max_size" in content_lower  # at minimum checks size before creating
     )
 
 

--- a/gptme/eval/suites/behavioral/implement_retry_decorator.py
+++ b/gptme/eval/suites/behavioral/implement_retry_decorator.py
@@ -1,0 +1,234 @@
+"""Behavioral scenario: implement-retry-decorator."""
+
+import ast
+from typing import TYPE_CHECKING
+
+from ._common import parse_python_source
+
+if TYPE_CHECKING:
+    from gptme.eval.types import EvalSpec
+
+
+def _get_source(ctx, filename: str = "retry.py") -> str:
+    content = ctx.files.get(filename, "")
+    if isinstance(content, bytes):
+        content = content.decode()
+    return content
+
+
+def check_tests_pass(ctx):
+    """All tests should pass after implementing retry decorator."""
+    return ctx.exit_code == 0 and "failed" not in ctx.stdout.lower()
+
+
+def check_has_retry_function(ctx):
+    """Should have a retry decorator or function."""
+    content = _get_source(ctx)
+    module = parse_python_source(content)
+    if module is None:
+        return False
+    for node in ast.walk(module):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            name_lower = node.name.lower()
+            if "retry" in name_lower:
+                return True
+    return False
+
+
+def check_accepts_exceptions_param(ctx):
+    """Retry should accept configurable exception types."""
+    content = _get_source(ctx)
+    content_lower = content.lower()
+    return (
+        "exceptions" in content_lower
+        or "retry_on" in content_lower
+        or "catch" in content_lower
+    )
+
+
+def check_accepts_max_attempts(ctx):
+    """Retry should accept max attempts parameter."""
+    content = _get_source(ctx)
+    content_lower = content.lower()
+    return (
+        "max_attempts" in content_lower
+        or "max_retries" in content_lower
+        or "attempts" in content_lower
+        or "retries" in content_lower
+        or "n_retries" in content_lower
+    )
+
+
+def check_has_backoff(ctx):
+    """Retry should support exponential backoff."""
+    content = _get_source(ctx)
+    content_lower = content.lower()
+    return (
+        "backoff" in content_lower
+        or "sleep" in content_lower
+        or "delay" in content_lower
+        or "exponential" in content_lower
+        or "wait" in content_lower
+    )
+
+
+def check_wraps_function(ctx):
+    """Retry decorator should use functools.wraps."""
+    content = _get_source(ctx)
+    return "wraps" in content or "functools" in content
+
+
+RETRY_SRC = '''\
+"""Retry utilities for unreliable operations."""
+'''
+
+
+TEST_RETRY_SRC = '''\
+import time
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from retry import retry
+
+
+def test_retries_on_exception():
+    """Should retry the function when specified exception is raised."""
+    call_count = 0
+
+    @retry(max_attempts=3, exceptions=(ValueError,))
+    def flaky():
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise ValueError("not yet")
+        return "success"
+
+    result = flaky()
+    assert result == "success"
+    assert call_count == 3
+
+
+def test_raises_after_max_attempts():
+    """Should raise the last exception after exhausting retries."""
+    call_count = 0
+
+    @retry(max_attempts=2, exceptions=(RuntimeError,))
+    def always_fails():
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError("always")
+
+    with pytest.raises(RuntimeError, match="always"):
+        always_fails()
+
+    assert call_count == 2
+
+
+def test_passes_through_on_success():
+    """Should return immediately on first successful call."""
+    call_count = 0
+
+    @retry(max_attempts=3, exceptions=(ValueError,))
+    def works_first_try():
+        nonlocal call_count
+        call_count += 1
+        return 42
+
+    result = works_first_try()
+    assert result == 42
+    assert call_count == 1
+
+
+def test_only_retries_specified_exceptions():
+    """Should NOT retry exceptions not in the allowed list."""
+    call_count = 0
+
+    @retry(max_attempts=3, exceptions=(ValueError,))
+    def raises_wrong_type():
+        nonlocal call_count
+        call_count += 1
+        raise TypeError("wrong type")
+
+    with pytest.raises(TypeError):
+        raises_wrong_type()
+
+    assert call_count == 1
+
+
+def test_exponential_backoff():
+    """Should wait with increasing delay between retries."""
+    sleep_calls = []
+
+    def mock_sleep(seconds):
+        sleep_calls.append(seconds)
+
+    call_count = 0
+
+    @retry(max_attempts=4, exceptions=(ConnectionError,), base_delay=0.1)
+    def flaky_connect():
+        nonlocal call_count
+        call_count += 1
+        if call_count < 4:
+            raise ConnectionError("timeout")
+        return "connected"
+
+    with patch("time.sleep", side_effect=mock_sleep):
+        result = flaky_connect()
+
+    assert result == "connected"
+    assert call_count == 4
+    # Should have slept 3 times (between attempts 1-2, 2-3, 3-4)
+    assert len(sleep_calls) == 3
+    # Delays should be increasing (exponential backoff)
+    for i in range(1, len(sleep_calls)):
+        assert sleep_calls[i] >= sleep_calls[i - 1], (
+            f"Delay {sleep_calls[i]} should be >= {sleep_calls[i-1]}"
+        )
+
+
+def test_preserves_function_metadata():
+    """Should preserve the original function's name and docstring."""
+    @retry(max_attempts=3, exceptions=(Exception,))
+    def my_function():
+        """Original docstring."""
+        return 1
+
+    assert my_function.__name__ == "my_function"
+    assert my_function.__doc__ == "Original docstring."
+'''
+
+
+# EvalSpec definition
+test: "EvalSpec" = {
+    "name": "implement-retry-decorator",
+    "files": {
+        "retry.py": RETRY_SRC,
+        "test_retry.py": TEST_RETRY_SRC,
+    },
+    "run": "python3 -m pytest test_retry.py -v --tb=short 2>&1",
+    "prompt": (
+        "The test suite `test_retry.py` is failing because the `retry` decorator "
+        "is not implemented in `retry.py`. The tests expect a `retry` decorator with:\n\n"
+        "1. `max_attempts` — maximum number of tries (including the first call)\n"
+        "2. `exceptions` — tuple of exception types to catch and retry on\n"
+        "3. `base_delay` — initial delay in seconds for exponential backoff\n\n"
+        "Behavior:\n"
+        "- On first successful call, return immediately (no retries needed)\n"
+        "- On specified exception, wait with exponential backoff and retry\n"
+        "- On non-specified exception, raise immediately without retrying\n"
+        "- After max_attempts exhausted, raise the last exception\n"
+        "- Preserve function metadata using functools.wraps\n\n"
+        "Signature: `retry(max_attempts: int = 3, exceptions: tuple = (Exception,), base_delay: float = 1.0)`\n\n"
+        "Implement the decorator in `retry.py`, then run the tests.\n"
+    ),
+    "tools": ["shell", "save", "read"],
+    "expect": {
+        "all tests pass": check_tests_pass,
+        "has retry function": check_has_retry_function,
+        "accepts exceptions param": check_accepts_exceptions_param,
+        "accepts max attempts": check_accepts_max_attempts,
+        "has backoff": check_has_backoff,
+        "wraps function": check_wraps_function,
+    },
+}

--- a/gptme/eval/suites/behavioral/implement_retry_decorator.py
+++ b/gptme/eval/suites/behavioral/implement_retry_decorator.py
@@ -173,7 +173,7 @@ def test_exponential_backoff():
             raise ConnectionError("timeout")
         return "connected"
 
-    with patch("time.sleep", side_effect=mock_sleep):
+    with patch("retry.time.sleep", side_effect=mock_sleep):
         result = flaky_connect()
 
     assert result == "connected"

--- a/tests/test_eval_behavioral_solutions.py
+++ b/tests/test_eval_behavioral_solutions.py
@@ -9,7 +9,7 @@ This is critical infrastructure for idea #19 (eval-to-lesson feedback loop):
 before running expensive baseline experiments with real models, we need
 confidence that the checkers correctly identify good work.
 
-Covers all 30 behavioral scenarios:
+Covers all 32 behavioral scenarios:
   git-selective-commit, multi-file-rename, iterative-debug,
   stage-new-files, write-test-suite, test-driven-error-handling,
   merge-conflict-resolution, extract-function-refactor, debug-data-pipeline,
@@ -19,7 +19,7 @@ Covers all 30 behavioral scenarios:
   noisy-worktree-fix, fix-data-mutation, optimize-n-squared, remove-dead-code,
   fix-mutable-default, add-deprecation-warning, add-docstrings, retry-with-backoff,
   validate-user-input, rate-limiting, circuit-breaker, implement-lru-cache,
-  implement-event-emitter
+  implement-event-emitter, implement-connection-pool, implement-retry-decorator
 """
 
 import subprocess
@@ -1125,6 +1125,125 @@ def _apply_solution(workspace: Path, scenario_name: str) -> None:
                 def emit(self, event: str, *args, **kwargs) -> None:
                     for handler in list(self._handlers[event]):
                         handler(*args, **kwargs)
+            """)
+        )
+
+    elif scenario_name == "implement-connection-pool":
+        # ConnectionPool with acquire/release, idle reuse, max_size enforcement.
+        # The POOL_SRC fixture only provides PooledConnection; ConnectionPool is
+        # what the agent must implement.  Tests import both from db_pool.
+        (workspace / "db_pool.py").write_text(
+            textwrap.dedent("""\
+            \"\"\"Database connection pool.\"\"\"
+
+            import sqlite3
+
+
+            class PooledConnection:
+                \"\"\"Wrapper around a database connection for pool tracking.\"\"\"
+
+                def __init__(self, conn: sqlite3.Connection, release_callback):
+                    self._conn = conn
+                    self._release = release_callback
+
+                def cursor(self):
+                    return self._conn.cursor()
+
+                def commit(self):
+                    self._conn.commit()
+
+                def close(self):
+                    \"\"\"Return connection to pool instead of closing.\"\"\"
+                    self._release(self._conn)
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, exc_type, exc_val, exc_tb):
+                    if exc_type is None:
+                        self._conn.commit()
+                    self._release(self._conn)
+                    return False
+
+
+            class ConnectionPool:
+                \"\"\"Manages a pool of reusable database connections.\"\"\"
+
+                def __init__(self, db_path: str, max_size: int = 5):
+                    self._db_path = db_path
+                    self._max_size = max_size
+                    self._idle: list[sqlite3.Connection] = []
+                    self._active: set[int] = set()
+                    self._all_conns: list[sqlite3.Connection] = []
+
+                def acquire(self) -> PooledConnection:
+                    if self._idle:
+                        conn = self._idle.pop(0)
+                        self._active.add(id(conn))
+                        return PooledConnection(conn, self._do_release)
+                    if len(self._all_conns) >= self._max_size:
+                        raise RuntimeError("Connection pool exhausted")
+                    conn = sqlite3.connect(self._db_path)
+                    self._all_conns.append(conn)
+                    self._active.add(id(conn))
+                    return PooledConnection(conn, self._do_release)
+
+                def _do_release(self, conn: sqlite3.Connection) -> None:
+                    conn_id = id(conn)
+                    if conn_id not in self._active:
+                        return
+                    self._active.discard(conn_id)
+                    self._idle.append(conn)
+
+                def release(self, conn: PooledConnection) -> None:
+                    self._do_release(conn._conn)
+
+                @property
+                def active_count(self) -> int:
+                    return len(self._active)
+
+                @property
+                def idle_count(self) -> int:
+                    return len(self._idle)
+            """)
+        )
+
+    elif scenario_name == "implement-retry-decorator":
+        # Generic retry decorator with exponential backoff and functools.wraps.
+        (workspace / "retry.py").write_text(
+            textwrap.dedent("""\
+            \"\"\"Retry utilities for unreliable operations.\"\"\"
+
+            import functools
+            import time
+
+
+            def retry(
+                max_attempts: int = 3,
+                exceptions: tuple = (Exception,),
+                base_delay: float = 1.0,
+            ):
+                \"\"\"Decorator that retries a function on specified exceptions.
+
+                Args:
+                    max_attempts: Maximum number of tries (including the first call).
+                    exceptions: Tuple of exception types to catch and retry.
+                    base_delay: Initial delay in seconds for exponential backoff.
+                \"\"\"
+                def decorator(func):
+                    @functools.wraps(func)
+                    def wrapper(*args, **kwargs):
+                        last_exc = None
+                        for attempt in range(max_attempts):
+                            try:
+                                return func(*args, **kwargs)
+                            except exceptions as e:
+                                last_exc = e
+                                if attempt < max_attempts - 1:
+                                    time.sleep(base_delay * (2 ** attempt))
+                        raise last_exc
+                    return wrapper
+                return decorator
             """)
         )
 


### PR DESCRIPTION
Adds two new behavioral eval scenarios:

## implement-connection-pool (31st)
Tests agent ability to implement a connection pool with:
- Idle connection reuse
- max_size enforcement
- acquire/release lifecycle
- Graceful handling of untracked connections
- Context manager support
- 5 unit tests, 6 checkers

## implement-retry-decorator (32nd)
Tests agent ability to implement a generic retry decorator with:
- Configurable exception types
- max_attempts parameter
- Exponential backoff with increasing delays
- functools.wraps metadata preservation
- Non-retryable exception passthrough
- 6 unit tests, 6 checkers

Both follow the established pattern (test: EvalSpec dict, pre-written failing tests, structured checkers via AST analysis).