### PR TITLE
fix(webui): use dynamic month name in ConversationList date group test

### DIFF
--- a/webui/src/components/__tests__/ConversationList.test.tsx
+++ b/webui/src/components/__tests__/ConversationList.test.tsx
@@ -190,12 +190,15 @@ describe('ConversationList', () => {
   describe('date group headers', () => {
     it('renders date group headers for conversations', () => {
       const now = Date.now() / 1000;
+      const daysAgo = 40;
+      const oldDate = new Date((now - 60 * 60 * 24 * daysAgo) * 1000);
+      const expectedMonth = oldDate.toLocaleString('default', { month: 'long' });
       const convs = [
         createConversation({ id: 'today-conv', name: 'Today Chat', modified: now }),
         createConversation({
           id: 'old-conv',
           name: 'Old Chat',
-          modified: now - 60 * 60 * 24 * 40, // 40 days ago
+          modified: now - 60 * 60 * 24 * daysAgo, // daysAgo days ago
         }),
       ];
       renderWithProviders(<ConversationList {...defaultProps} conversations={convs} />);
@@ -203,7 +206,7 @@ describe('ConversationList', () => {
       expect(headers.length).toBeGreaterThanOrEqual(2);
       expect(headers[0]).toHaveTextContent('Today');
       // Monthly drill-down: "Older" group is broken into month names
-      expect(headers[headers.length - 1]).toHaveTextContent('February');
+      expect(headers[headers.length - 1]).toHaveTextContent(expectedMonth);
     });
 
     it('shows single group header when all conversations are from today', () => {


### PR DESCRIPTION
## Problem

The `ConversationList › date group headers › renders date group headers for conversations` test was hardcoding `'February'` as the expected month-name header for a conversation timestamped 40 days in the past.

This breaks every time the calendar advances past a month boundary — on April 13, 2026, 40 days ago is March 4, so the test now gets `'March'` instead of `'February'`.

## Fix

Compute the expected month name dynamically using the same 40-day offset used to create the test conversation:

```typescript
const daysAgo = 40;
const oldDate = new Date((now - 60 * 60 * 24 * daysAgo) * 1000);
const expectedMonth = oldDate.toLocaleString('default', { month: 'long' });
// ...
expect(headers[headers.length - 1]).toHaveTextContent(expectedMonth);
```

This way the test assertion always matches what the component will actually render, regardless of when it runs.

## Test plan
- [ ] WebUI CI passes (was failing with `Expected: February / Received: March`)