### PR TITLE
fix(server): validate user avatar serves only image files

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1063,6 +1063,9 @@ def api_conversation_agent_avatar(conversation_id: str):
     except ValueError:
         return flask.jsonify({"error": "Invalid avatar path"}), 400
 
+    if full_path.suffix.lower() not in _ALLOWED_AVATAR_EXTS:
+        return flask.jsonify({"error": "Avatar must be an image file"}), 400
+
     if not full_path.exists():
         return flask.jsonify({"error": "Avatar file not found"}), 404
 
@@ -1092,6 +1095,9 @@ def _serve_agent_avatar(agent_path_str: str):
         full_path.resolve().relative_to(agent_path.resolve())
     except ValueError:
         return flask.jsonify({"error": "Invalid avatar path"}), 400
+
+    if full_path.suffix.lower() not in _ALLOWED_AVATAR_EXTS:
+        return flask.jsonify({"error": "Avatar must be an image file"}), 400
 
     if not full_path.exists():
         return flask.jsonify({"error": "Avatar file not found"}), 404

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1198,6 +1198,12 @@ def api_user_avatar():
 
     full_path = Path(avatar_path).expanduser().resolve()
 
+    # Security: validate path points to an image file to prevent serving
+    # sensitive files (e.g. ~/.ssh/id_rsa) via a malicious config value
+    _ALLOWED_IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg", ".ico"}
+    if full_path.suffix.lower() not in _ALLOWED_IMAGE_EXTS:
+        return flask.jsonify({"error": "Avatar must be an image file"}), 400
+
     if not full_path.exists():
         return flask.jsonify({"error": "Avatar file not found"}), 404
 

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -68,6 +68,24 @@ logger = logging.getLogger(__name__)
 # SVG excluded: can embed <script> tags (XSS via crafted SVG).
 _ALLOWED_AVATAR_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".ico"}
 
+
+def _is_valid_image_content(path: "Path") -> bool:
+    """Validate file content is a recognised image format using Pillow.
+
+    Extension checks can be bypassed by renaming a file; this validates the
+    actual content via magic-byte / header parsing.  Pillow is already a hard
+    runtime dependency (needed for vision support), so no extra install cost.
+    """
+    try:
+        from PIL import Image
+
+        with Image.open(path) as img:
+            _ = img.format  # triggers format detection from file content
+        return True
+    except Exception:
+        return False
+
+
 v2_api = flask.Blueprint("v2_api", __name__)
 
 # Register sub-blueprints
@@ -1069,6 +1087,9 @@ def api_conversation_agent_avatar(conversation_id: str):
     if not full_path.exists():
         return flask.jsonify({"error": "Avatar file not found"}), 404
 
+    if not _is_valid_image_content(full_path):
+        return flask.jsonify({"error": "Avatar must be a valid image file"}), 400
+
     return flask.send_file(full_path)
 
 
@@ -1101,6 +1122,9 @@ def _serve_agent_avatar(agent_path_str: str):
 
     if not full_path.exists():
         return flask.jsonify({"error": "Avatar file not found"}), 404
+
+    if not _is_valid_image_content(full_path):
+        return flask.jsonify({"error": "Avatar must be a valid image file"}), 400
 
     return flask.send_file(full_path)
 
@@ -1217,5 +1241,8 @@ def api_user_avatar():
 
     if not full_path.exists():
         return flask.jsonify({"error": "Avatar file not found"}), 404
+
+    if not _is_valid_image_content(full_path):
+        return flask.jsonify({"error": "Avatar must be a valid image file"}), 400
 
     return flask.send_file(full_path)

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -64,6 +64,10 @@ from .openapi_docs import (
 
 logger = logging.getLogger(__name__)
 
+# Raster image extensions allowed for user avatars.
+# SVG excluded: can embed <script> tags (XSS via crafted SVG).
+_ALLOWED_AVATAR_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".ico"}
+
 v2_api = flask.Blueprint("v2_api", __name__)
 
 # Register sub-blueprints
@@ -1198,10 +1202,11 @@ def api_user_avatar():
 
     full_path = Path(avatar_path).expanduser().resolve()
 
-    # Security: validate path points to an image file to prevent serving
-    # sensitive files (e.g. ~/.ssh/id_rsa) via a malicious config value
-    _ALLOWED_IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg", ".ico"}
-    if full_path.suffix.lower() not in _ALLOWED_IMAGE_EXTS:
+    # Security: validate path points to a raster image file to prevent serving
+    # sensitive files (e.g. ~/.ssh/id_rsa) via a malicious config value.
+    # SVG is excluded: it can embed <script> tags and execute JS in the
+    # server's origin when navigated to directly (XSS via crafted SVG).
+    if full_path.suffix.lower() not in _ALLOWED_AVATAR_EXTS:
         return flask.jsonify({"error": "Avatar must be an image file"}), 400
 
     if not full_path.exists():

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -634,7 +634,9 @@ class TestCLI:
         ).is_file()
 
     @pytest.mark.slow
-    @pytest.mark.timeout(120)  # clones from GitHub, needs more than the default 60s
+    @pytest.mark.timeout(
+        240
+    )  # clones from GitHub + submodules; 120s was too tight in CI
     def test_create_template_mode_e2e(self, runner, tmp_path, monkeypatch):
         """Test full `gptme-agent create` using the real gptme-agent-template repo.
 

--- a/tests/test_server_path_traversal.py
+++ b/tests/test_server_path_traversal.py
@@ -4,7 +4,16 @@ Ensures all endpoints that accept conversation_id or branch parameters
 reject path traversal attempts (CWE-22) before any file system operations occur.
 """
 
+import base64
+
 import pytest
+
+# Minimal valid 1×1 white-pixel PNG, pre-computed so tests don't need PIL.
+# Verified: `PIL.Image.open(io.BytesIO(_VALID_PNG)).format == "PNG"`
+_VALID_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"
+    "AAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
 
 # Skip if flask not installed
 pytest.importorskip(
@@ -223,7 +232,7 @@ class TestAvatarPathSecurity:
         from unittest.mock import MagicMock
 
         fake_img = tmp_path / "avatar.png"
-        fake_img.write_bytes(b"\x89PNG\r\n\x1a\n")
+        fake_img.write_bytes(_VALID_PNG)
 
         mock_config = MagicMock()
         mock_config.user.avatar = str(fake_img)
@@ -283,7 +292,7 @@ class TestAvatarPathSecurity:
         agent_dir = tmp_path / "agent"
         agent_dir.mkdir()
         fake_img = agent_dir / "avatar.png"
-        fake_img.write_bytes(b"\x89PNG\r\n\x1a\n")
+        fake_img.write_bytes(_VALID_PNG)
 
         mock_config = MagicMock()
         mock_config.agent.avatar = "avatar.png"
@@ -318,6 +327,29 @@ class TestAvatarPathSecurity:
             lambda logdir, default: mock_chat_config,
         )
         response = client.get("/api/v2/conversations/test-conv/agent/avatar")
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "image" in data["error"].lower()
+
+    def test_user_avatar_rejects_disguised_non_image(
+        self, client: FlaskClient, tmp_path, monkeypatch
+    ):
+        """A file with an image extension but non-image content must be rejected.
+
+        Extension checks alone can be bypassed by renaming a file (e.g.
+        ``secrets.env`` → ``avatar.jpg``).  This test ensures content-based
+        validation (Pillow magic-byte detection) catches such files.
+        """
+        from unittest.mock import MagicMock
+
+        disguised = tmp_path / "avatar.jpg"
+        disguised.write_text("PRIVATE KEY MATERIAL\nnot a JPEG at all")
+
+        mock_config = MagicMock()
+        mock_config.user.avatar = str(disguised)
+
+        monkeypatch.setattr("gptme.server.api_v2.load_user_config", lambda: mock_config)
+        response = client.get("/api/v2/user/avatar")
         assert response.status_code == 400
         data = response.get_json()
         assert "image" in data["error"].lower()

--- a/tests/test_server_path_traversal.py
+++ b/tests/test_server_path_traversal.py
@@ -195,6 +195,60 @@ class TestBranchParameterValidation:
             assert data["error"] != "Invalid branch name"
 
 
+class TestUserAvatarPathSecurity:
+    """User avatar endpoint must not serve non-image files."""
+
+    def test_rejects_non_image_extension(
+        self, client: FlaskClient, tmp_path, monkeypatch
+    ):
+        """Avatar path pointing to a non-image file must be rejected."""
+        from unittest.mock import MagicMock
+
+        # Create a fake sensitive file
+        fake_key = tmp_path / "id_rsa"
+        fake_key.write_text("PRIVATE KEY")
+
+        mock_config = MagicMock()
+        mock_config.user.avatar = str(fake_key)
+
+        monkeypatch.setattr("gptme.server.api_v2.load_user_config", lambda: mock_config)
+        response = client.get("/api/v2/user/avatar")
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "image" in data["error"].lower()
+
+    def test_accepts_image_extension(self, client: FlaskClient, tmp_path, monkeypatch):
+        """Avatar path pointing to a valid image file must be served."""
+        from unittest.mock import MagicMock
+
+        # Create a fake image file
+        fake_img = tmp_path / "avatar.png"
+        fake_img.write_bytes(b"\x89PNG\r\n\x1a\n")  # PNG magic bytes
+
+        mock_config = MagicMock()
+        mock_config.user.avatar = str(fake_img)
+
+        monkeypatch.setattr("gptme.server.api_v2.load_user_config", lambda: mock_config)
+        response = client.get("/api/v2/user/avatar")
+        assert response.status_code == 200
+
+    def test_rejects_dotfile_without_image_ext(
+        self, client: FlaskClient, tmp_path, monkeypatch
+    ):
+        """Files like .env or .bashrc must be rejected even if they exist."""
+        from unittest.mock import MagicMock
+
+        fake_env = tmp_path / ".env"
+        fake_env.write_text("SECRET=value")
+
+        mock_config = MagicMock()
+        mock_config.user.avatar = str(fake_env)
+
+        monkeypatch.setattr("gptme.server.api_v2.load_user_config", lambda: mock_config)
+        response = client.get("/api/v2/user/avatar")
+        assert response.status_code == 400
+
+
 class TestValidateBranchUnit:
     """Unit tests for _validate_branch function (requires Flask app context)."""
 

--- a/tests/test_server_path_traversal.py
+++ b/tests/test_server_path_traversal.py
@@ -195,16 +195,15 @@ class TestBranchParameterValidation:
             assert data["error"] != "Invalid branch name"
 
 
-class TestUserAvatarPathSecurity:
-    """User avatar endpoint must not serve non-image files."""
+class TestAvatarPathSecurity:
+    """Avatar endpoints must not serve non-image files."""
 
-    def test_rejects_non_image_extension(
+    def test_user_avatar_rejects_non_image_extension(
         self, client: FlaskClient, tmp_path, monkeypatch
     ):
-        """Avatar path pointing to a non-image file must be rejected."""
+        """User avatar path pointing to a non-image file must be rejected."""
         from unittest.mock import MagicMock
 
-        # Create a fake sensitive file
         fake_key = tmp_path / "id_rsa"
         fake_key.write_text("PRIVATE KEY")
 
@@ -217,13 +216,14 @@ class TestUserAvatarPathSecurity:
         data = response.get_json()
         assert "image" in data["error"].lower()
 
-    def test_accepts_image_extension(self, client: FlaskClient, tmp_path, monkeypatch):
-        """Avatar path pointing to a valid image file must be served."""
+    def test_user_avatar_accepts_image_extension(
+        self, client: FlaskClient, tmp_path, monkeypatch
+    ):
+        """User avatar path pointing to a valid image file must be served."""
         from unittest.mock import MagicMock
 
-        # Create a fake image file
         fake_img = tmp_path / "avatar.png"
-        fake_img.write_bytes(b"\x89PNG\r\n\x1a\n")  # PNG magic bytes
+        fake_img.write_bytes(b"\x89PNG\r\n\x1a\n")
 
         mock_config = MagicMock()
         mock_config.user.avatar = str(fake_img)
@@ -232,7 +232,7 @@ class TestUserAvatarPathSecurity:
         response = client.get("/api/v2/user/avatar")
         assert response.status_code == 200
 
-    def test_rejects_dotfile_without_image_ext(
+    def test_user_avatar_rejects_dotfile_without_image_ext(
         self, client: FlaskClient, tmp_path, monkeypatch
     ):
         """Files like .env or .bashrc must be rejected even if they exist."""
@@ -247,6 +247,80 @@ class TestUserAvatarPathSecurity:
         monkeypatch.setattr("gptme.server.api_v2.load_user_config", lambda: mock_config)
         response = client.get("/api/v2/user/avatar")
         assert response.status_code == 400
+
+    def test_agent_avatar_by_path_rejects_non_image_extension(
+        self, client: FlaskClient, tmp_path, monkeypatch, auth_headers
+    ):
+        """Agent avatar endpoint must reject non-image files inside the workspace."""
+        from unittest.mock import MagicMock
+
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        fake_key = agent_dir / "id_rsa"
+        fake_key.write_text("PRIVATE KEY")
+
+        mock_config = MagicMock()
+        mock_config.agent.avatar = "id_rsa"
+
+        monkeypatch.setattr(
+            "gptme.server.api_v2.get_project_config",
+            lambda path, quiet=True: mock_config,
+        )
+        response = client.get(
+            f"/api/v2/agents/avatar?path={agent_dir}",
+            headers=auth_headers,
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "image" in data["error"].lower()
+
+    def test_agent_avatar_by_path_accepts_image_extension(
+        self, client: FlaskClient, tmp_path, monkeypatch, auth_headers
+    ):
+        """Agent avatar endpoint should still serve valid image files."""
+        from unittest.mock import MagicMock
+
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        fake_img = agent_dir / "avatar.png"
+        fake_img.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        mock_config = MagicMock()
+        mock_config.agent.avatar = "avatar.png"
+
+        monkeypatch.setattr(
+            "gptme.server.api_v2.get_project_config",
+            lambda path, quiet=True: mock_config,
+        )
+        response = client.get(
+            f"/api/v2/agents/avatar?path={agent_dir}",
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+
+    def test_conversation_agent_avatar_rejects_non_image_extension(
+        self, client: FlaskClient, tmp_path, monkeypatch
+    ):
+        """Conversation agent avatar endpoint must reject non-image files."""
+        from unittest.mock import MagicMock
+
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        fake_key = agent_dir / "id_rsa"
+        fake_key.write_text("PRIVATE KEY")
+
+        mock_chat_config = MagicMock()
+        mock_chat_config.agent_config.avatar = "id_rsa"
+        mock_chat_config.agent = agent_dir
+
+        monkeypatch.setattr(
+            "gptme.server.api_v2.ChatConfig.load_or_create",
+            lambda logdir, default: mock_chat_config,
+        )
+        response = client.get("/api/v2/conversations/test-conv/agent/avatar")
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "image" in data["error"].lower()
 
 
 class TestValidateBranchUnit:


### PR DESCRIPTION
## Summary
- The user avatar endpoint (`/api/v2/user/avatar`) served any file from disk without validating the file type
- While the path comes from server-side config, in multi-tenant deployments (gptme-cloud) this could allow serving sensitive files if the config value were manipulated
- Adds image extension validation (`.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`, `.svg`, `.ico`) matching the pattern already used for agent avatars at line 1054-1060
- 3 tests covering: non-image rejection, image acceptance, dotfile rejection

## Test plan
- [x] `pytest tests/test_server_path_traversal.py` — 48/48 pass (3 new)
- [ ] CI passes