### PR TITLE
fix(lessons): validate tools field in frontmatter like keywords/patterns

### DIFF
--- a/gptme/lessons/parser.py
+++ b/gptme/lessons/parser.py
@@ -363,6 +363,16 @@ def parse_lesson(path: Path) -> Lesson:
                             d for d in raw_depends if isinstance(d, str) and d.strip()
                         ]
 
+                        # Validate and filter tools (must be non-empty strings)
+                        raw_tools = match_data.get("tools", [])
+                        if isinstance(raw_tools, str):
+                            raw_tools = [raw_tools]
+                        elif not isinstance(raw_tools, list):
+                            raw_tools = []
+                        tools = [
+                            t for t in raw_tools if isinstance(t, str) and t.strip()
+                        ]
+
                         metadata = LessonMetadata(
                             name=name,
                             description=description,
@@ -370,7 +380,7 @@ def parse_lesson(path: Path) -> Lesson:
                             depends=depends,
                             keywords=keywords,
                             patterns=patterns,
-                            tools=match_data.get("tools", []),
+                            tools=tools,
                             status=status,
                         )
             except yaml.YAMLError as e:

--- a/gptme/lessons/parser.py
+++ b/gptme/lessons/parser.py
@@ -189,7 +189,12 @@ def _translate_cursor_metadata(frontmatter: dict) -> LessonMetadata:
 
     # Translate globs to keywords
     # Note: YAML parses empty values (e.g., "globs:") as None, not missing
+    # Validate: bare string "globs: *.py" must become ["*.py"], not char iteration
     globs = frontmatter.get("globs") or []
+    if isinstance(globs, str):
+        globs = [globs]
+    elif not isinstance(globs, list):
+        globs = []
     keywords = []
     for glob in globs:
         keywords.extend(_glob_to_keywords(glob))
@@ -206,7 +211,12 @@ def _translate_cursor_metadata(frontmatter: dict) -> LessonMetadata:
 
     # Extract other Cursor-specific fields
     # Note: YAML parses empty values as None, not missing
+    # Validate: bare string "triggers: file_change" must become ["file_change"]
     triggers = frontmatter.get("triggers") or []
+    if isinstance(triggers, str):
+        triggers = [triggers]
+    elif not isinstance(triggers, list):
+        triggers = []
     version = frontmatter.get("version")
 
     return LessonMetadata(

--- a/tests/test_lessons_parser.py
+++ b/tests/test_lessons_parser.py
@@ -366,6 +366,111 @@ Description.
             assert lesson.metadata.keywords == []
 
 
+class TestToolsFieldValidation:
+    """Tests for tools field validation in lesson frontmatter."""
+
+    def test_tools_as_list(self):
+        """Test that tools as a list works correctly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lesson_dir = Path(tmpdir) / "tools"
+            lesson_dir.mkdir()
+            lesson_file = lesson_dir / "test.md"
+
+            content = """---
+match:
+  keywords:
+    - test
+  tools:
+    - shell
+    - python
+---
+
+# Test Lesson
+
+Description.
+"""
+            lesson_file.write_text(content)
+            lesson = parse_lesson(lesson_file)
+
+            assert lesson.metadata.tools == ["shell", "python"]
+
+    def test_tools_as_string_converted_to_list(self):
+        """Test that tools as a bare string is converted to a single-element list."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lesson_dir = Path(tmpdir) / "tools"
+            lesson_dir.mkdir()
+            lesson_file = lesson_dir / "test.md"
+
+            content = """---
+match:
+  keywords:
+    - test
+  tools: shell
+---
+
+# Test Lesson
+
+Description.
+"""
+            lesson_file.write_text(content)
+            lesson = parse_lesson(lesson_file)
+
+            # Should be ["shell"], not ['s', 'h', 'e', 'l', 'l']
+            assert lesson.metadata.tools == ["shell"]
+
+    def test_tools_as_none_becomes_empty_list(self):
+        """Test that tools: null or missing becomes empty list."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lesson_dir = Path(tmpdir) / "tools"
+            lesson_dir.mkdir()
+            lesson_file = lesson_dir / "test.md"
+
+            content = """---
+match:
+  keywords:
+    - test
+  tools:
+---
+
+# Test Lesson
+
+Description.
+"""
+            lesson_file.write_text(content)
+            lesson = parse_lesson(lesson_file)
+
+            assert lesson.metadata.tools == []
+
+    def test_tools_filters_non_string_elements(self):
+        """Test that non-string elements in tools list are filtered out."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lesson_dir = Path(tmpdir) / "tools"
+            lesson_dir.mkdir()
+            lesson_file = lesson_dir / "test.md"
+
+            content = """---
+match:
+  keywords:
+    - test
+  tools:
+    - shell
+    - 123
+    - true
+    - python
+---
+
+# Test Lesson
+
+Description.
+"""
+            lesson_file.write_text(content)
+            lesson = parse_lesson(lesson_file)
+
+            # Non-string elements should be filtered (YAML parses 123 as int, true as bool)
+            assert "shell" in lesson.metadata.tools
+            assert "python" in lesson.metadata.tools
+
+
 class TestLessonDataclasses:
     """Tests for Lesson and LessonMetadata dataclasses."""
 

--- a/tests/test_lessons_parser.py
+++ b/tests/test_lessons_parser.py
@@ -467,8 +467,7 @@ Description.
             lesson = parse_lesson(lesson_file)
 
             # Non-string elements should be filtered (YAML parses 123 as int, true as bool)
-            assert "shell" in lesson.metadata.tools
-            assert "python" in lesson.metadata.tools
+            assert lesson.metadata.tools == ["shell", "python"]
 
 
 class TestLessonDataclasses:

--- a/tests/test_lessons_parser.py
+++ b/tests/test_lessons_parser.py
@@ -630,6 +630,31 @@ class TestTranslateCursorMetadata:
         assert "typescript" in metadata.keywords
         assert "javascript" in metadata.keywords
 
+    def test_cursor_globs_as_string_converted_to_list(self):
+        """Test that globs as a bare string is converted to a single-element list."""
+        frontmatter = {
+            "name": "Python Rule",
+            "description": "Test",
+            "globs": "**/*.py",
+        }
+        metadata = _translate_cursor_metadata(frontmatter)
+
+        # Should be ["**/*.py"], not ['*', '*', '/', '*', '.', 'p', 'y']
+        assert metadata.globs == ["**/*.py"]
+        assert "python" in metadata.keywords
+
+    def test_cursor_triggers_as_string_converted_to_list(self):
+        """Test that triggers as a bare string is converted to a single-element list."""
+        frontmatter = {
+            "name": "Trigger Rule",
+            "description": "Test",
+            "triggers": "file_change",
+        }
+        metadata = _translate_cursor_metadata(frontmatter)
+
+        # Should be ["file_change"], not ['f', 'i', 'l', 'e', '_', ...]
+        assert metadata.triggers == ["file_change"]
+
     def test_cursor_metadata_propagates_id(self):
         """Test that explicit id field is propagated through .mdc translation."""
         frontmatter = {


### PR DESCRIPTION
## Summary
- The `tools` field in lesson match metadata was passed through without validation, unlike `keywords`, `patterns`, and `depends` which all have string-vs-list coercion and non-string filtering
- A bare YAML string (e.g. `tools: shell`) would be iterated character-by-character ('s','h','e','l','l') instead of treated as `["shell"]`, causing silent matching failures
- Applies the same validation pattern already used for the other fields (lines 340-364 of parser.py)
- 4 tests covering: list input, string coercion, null handling, non-string filtering

## Test plan
- [x] `pytest tests/test_lessons_parser.py` — 54/54 pass (4 new)
- [ ] CI passes