### PR TITLE
fix(tests): fix server_confirm race condition and mark slow CLI tests

### DIFF
--- a/gptme/hooks/tests/test_server_confirm.py
+++ b/gptme/hooks/tests/test_server_confirm.py
@@ -197,6 +197,9 @@ class TestServerConfirmHook:
                             resolve_pending(tool_id, ConfirmationResult.confirm())
                         return
                     time.sleep(0.01)
+                pytest.fail(
+                    "Timed out waiting for pending confirmation to be registered"
+                )
 
             t = threading.Thread(target=resolve_after_delay)
             t.start()

--- a/gptme/hooks/tests/test_server_confirm.py
+++ b/gptme/hooks/tests/test_server_confirm.py
@@ -186,10 +186,17 @@ class TestServerConfirmHook:
             def resolve_after_delay():
                 import time
 
-                time.sleep(0.1)
-                # Find and resolve the pending confirmation
-                for tool_id, _pending in list(_pending_confirmations.items()):
-                    resolve_pending(tool_id, ConfirmationResult.confirm())
+                # Poll until a pending confirmation appears, then resolve it.
+                # A fixed sleep(0.1) races with slow imports on CI — the hook
+                # registers the pending entry only after its imports complete,
+                # so we must wait until the entry actually exists.
+                deadline = time.monotonic() + 5.0
+                while time.monotonic() < deadline:
+                    if _pending_confirmations:
+                        for tool_id in list(_pending_confirmations):
+                            resolve_pending(tool_id, ConfirmationResult.confirm())
+                        return
+                    time.sleep(0.01)
 
             t = threading.Thread(target=resolve_after_delay)
             t.start()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,6 +103,7 @@ def test_command_context(args: list[str], runner: CliRunner):
     assert result.exit_code == 0
 
 
+@pytest.mark.slow
 def test_command_log(args: list[str], runner: CliRunner):
     args.append("/log")
     result = runner.invoke(cli.main, args)

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -244,6 +244,7 @@ def test_results_to_json_all_passing():
     assert data["models"][0]["total"] == 2
 
 
+@pytest.mark.slow
 def test_eval_module_loading(tmp_path):
     """Test that --eval-module loads and registers tests from an external module."""
     # Write a minimal eval module with a tests list


### PR DESCRIPTION
## Problem

Master CI has been failing on `Test without API keys or extras` for 2 consecutive runs with 3 tests timing out at the 10-second limit:

- `test_server_confirm_with_full_context` — 9.99s
- `test_command_log` — 12.77s
- `test_eval_module_loading` — 15.32s

## Root Causes

**`test_server_confirm_with_full_context` — real bug (race condition)**

The `resolve_after_delay` thread slept a fixed 0.1s before scanning `_pending_confirmations`. On the no-extras CI environment, the first-time imports inside `server_confirm_hook` (which happen _inside_ the context manager after the thread starts) take >0.1s. The thread woke up, found an empty dict, and exited without resolving anything. The hook then blocked on `pending.event.wait(timeout=3600)` until pytest's 10s timeout killed it.

Fix: poll with a deadline instead of sleeping a fixed amount.

**`test_command_log` and `test_eval_module_loading` — slow CLI startup**

Both tests invoke full CLI initialization (tool imports, config, lessons) via CliRunner. In the no-extras environment without optional dependencies, this takes 12–15s consistently. Mark as `@pytest.mark.slow` so they run in the `SLOW=true` job (60s timeout) rather than the fast-only minimal job.

## Changes

- `gptme/hooks/tests/test_server_confirm.py`: replace fixed `sleep(0.1)` with polling loop (deadline: 5s) that waits until a pending confirmation entry exists before resolving
- `tests/test_cli.py`: mark `test_command_log` as `@pytest.mark.slow`
- `tests/test_eval.py`: mark `test_eval_module_loading` as `@pytest.mark.slow`