### PR TITLE
fix(server): restrict agent creation path to server working directory

### DIFF
--- a/gptme/server/api_v2_agents.py
+++ b/gptme/server/api_v2_agents.py
@@ -85,6 +85,20 @@ def api_agents_put():
     # Ensure path is a Path object and resolved
     path = Path(path).expanduser().resolve()
 
+    # Validate that the resolved path is within the server's working directory
+    # to prevent creating workspaces at arbitrary filesystem locations
+    try:
+        path.relative_to(INITIAL_WORKING_DIRECTORY)
+    except ValueError:
+        return (
+            flask.jsonify(
+                {
+                    "error": f"Path must be within the server working directory: {INITIAL_WORKING_DIRECTORY}"
+                }
+            ),
+            400,
+        )
+
     # Parse project config if provided
     project_config = req_json.get("project_config")
     if project_config:

--- a/gptme/server/api_v2_agents.py
+++ b/gptme/server/api_v2_agents.py
@@ -78,6 +78,15 @@ def api_agents_put():
     if not path:
         # Auto-generate path from initial directory + slugified agent name
         agent_slug = slugify_name(agent_name)
+        if not agent_slug:
+            return (
+                flask.jsonify(
+                    {
+                        "error": "agent name must contain at least one alphanumeric character"
+                    }
+                ),
+                400,
+            )
         path = INITIAL_WORKING_DIRECTORY / agent_slug
     else:
         path = Path(path).expanduser()

--- a/gptme/server/api_v2_agents.py
+++ b/gptme/server/api_v2_agents.py
@@ -29,7 +29,7 @@ from .openapi_docs import (
 logger = logging.getLogger(__name__)
 
 # Store the initial working directory when the module is imported
-INITIAL_WORKING_DIRECTORY = Path.cwd()
+INITIAL_WORKING_DIRECTORY = Path.cwd().resolve()
 
 
 def slugify_name(name: str) -> str:
@@ -80,21 +80,26 @@ def api_agents_put():
         agent_slug = slugify_name(agent_name)
         path = INITIAL_WORKING_DIRECTORY / agent_slug
     else:
-        path = Path(path).expanduser().resolve()
+        path = Path(path).expanduser()
 
     # Ensure path is a Path object and resolved
-    path = Path(path).expanduser().resolve()
+    path = Path(path).resolve()
 
     # Validate that the resolved path is within the server's working directory
     # to prevent creating workspaces at arbitrary filesystem locations
     try:
         path.relative_to(INITIAL_WORKING_DIRECTORY)
     except ValueError:
+        logger.warning(
+            "Rejected agent creation path outside working directory",
+            extra={
+                "requested_path": str(path),
+                "working_directory": str(INITIAL_WORKING_DIRECTORY),
+            },
+        )
         return (
             flask.jsonify(
-                {
-                    "error": f"Path must be within the server working directory: {INITIAL_WORKING_DIRECTORY}"
-                }
+                {"error": "Path must be within the server working directory"}
             ),
             400,
         )

--- a/tests/test_server_path_traversal.py
+++ b/tests/test_server_path_traversal.py
@@ -355,6 +355,54 @@ class TestAvatarPathSecurity:
         assert "image" in data["error"].lower()
 
 
+class TestAgentCreationPathValidation:
+    """Agent creation endpoint must reject paths outside the server working directory."""
+
+    def _put_agent(self, client: FlaskClient, path: str | None = None):
+        """Helper to send an agent creation request with optional path."""
+        payload = {
+            "name": "test-agent",
+            "template_repo": "https://github.com/gptme/gptme-agent-template",
+            "template_branch": "master",
+            "fork_command": "echo ok",
+        }
+        if path is not None:
+            payload["path"] = path
+        return client.put(
+            "/api/v2/agents",
+            json=payload,
+            content_type="application/json",
+        )
+
+    def test_rejects_absolute_path_outside_cwd(self, client: FlaskClient):
+        """Absolute paths outside server working directory must be rejected."""
+        response = self._put_agent(client, path="/tmp/evil-agent")
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "working directory" in data["error"].lower()
+
+    def test_rejects_home_directory_path(self, client: FlaskClient):
+        """Paths under home directory but outside cwd must be rejected."""
+        response = self._put_agent(client, path="~/sneaky-agent")
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "working directory" in data["error"].lower()
+
+    def test_rejects_traversal_in_path(self, client: FlaskClient):
+        """Path traversal via ../ must be rejected."""
+        response = self._put_agent(client, path="../../../tmp/escape")
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "working directory" in data["error"].lower()
+
+    def test_rejects_etc_path(self, client: FlaskClient):
+        """System directories must be rejected."""
+        response = self._put_agent(client, path="/etc/gptme-agent")
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "working directory" in data["error"].lower()
+
+
 class TestValidateBranchUnit:
     """Unit tests for _validate_branch function (requires Flask app context)."""
 

--- a/tests/test_server_path_traversal.py
+++ b/tests/test_server_path_traversal.py
@@ -428,6 +428,31 @@ class TestAgentCreationPathValidation:
         data = response.get_json()
         assert data["error"] == "Path must be within the server working directory"
 
+    def test_rejects_name_that_slugifies_to_empty(
+        self, client: FlaskClient, tmp_path, monkeypatch
+    ):
+        """Names that produce an empty slug must be rejected to prevent workspace-at-cwd."""
+        from gptme.server import api_v2_agents
+
+        monkeypatch.setattr(
+            api_v2_agents, "INITIAL_WORKING_DIRECTORY", tmp_path.resolve()
+        )
+        # "@#$%" slugifies to "" — INITIAL_WORKING_DIRECTORY / "" == INITIAL_WORKING_DIRECTORY
+        payload = {
+            "name": "@#$%",
+            "template_repo": "https://github.com/gptme/gptme-agent-template",
+            "template_branch": "master",
+            "fork_command": "echo ok",
+        }
+        response = client.put(
+            "/api/v2/agents",
+            json=payload,
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert "alphanumeric" in data["error"].lower()
+
 
 class TestValidateBranchUnit:
     """Unit tests for _validate_branch function (requires Flask app context)."""

--- a/tests/test_server_path_traversal.py
+++ b/tests/test_server_path_traversal.py
@@ -374,33 +374,59 @@ class TestAgentCreationPathValidation:
             content_type="application/json",
         )
 
-    def test_rejects_absolute_path_outside_cwd(self, client: FlaskClient):
+    def test_rejects_absolute_path_outside_cwd(
+        self, client: FlaskClient, tmp_path, monkeypatch
+    ):
         """Absolute paths outside server working directory must be rejected."""
+        from gptme.server import api_v2_agents
+
+        monkeypatch.setattr(
+            api_v2_agents, "INITIAL_WORKING_DIRECTORY", tmp_path.resolve()
+        )
         response = self._put_agent(client, path="/tmp/evil-agent")
         assert response.status_code == 400
         data = response.get_json()
-        assert "working directory" in data["error"].lower()
+        assert data["error"] == "Path must be within the server working directory"
 
-    def test_rejects_home_directory_path(self, client: FlaskClient):
+    def test_rejects_home_directory_path(
+        self, client: FlaskClient, tmp_path, monkeypatch
+    ):
         """Paths under home directory but outside cwd must be rejected."""
+        from gptme.server import api_v2_agents
+
+        monkeypatch.setattr(
+            api_v2_agents, "INITIAL_WORKING_DIRECTORY", tmp_path.resolve()
+        )
         response = self._put_agent(client, path="~/sneaky-agent")
         assert response.status_code == 400
         data = response.get_json()
-        assert "working directory" in data["error"].lower()
+        assert data["error"] == "Path must be within the server working directory"
 
-    def test_rejects_traversal_in_path(self, client: FlaskClient):
+    def test_rejects_traversal_in_path(
+        self, client: FlaskClient, tmp_path, monkeypatch
+    ):
         """Path traversal via ../ must be rejected."""
+        from gptme.server import api_v2_agents
+
+        monkeypatch.setattr(
+            api_v2_agents, "INITIAL_WORKING_DIRECTORY", tmp_path.resolve()
+        )
         response = self._put_agent(client, path="../../../tmp/escape")
         assert response.status_code == 400
         data = response.get_json()
-        assert "working directory" in data["error"].lower()
+        assert data["error"] == "Path must be within the server working directory"
 
-    def test_rejects_etc_path(self, client: FlaskClient):
+    def test_rejects_etc_path(self, client: FlaskClient, tmp_path, monkeypatch):
         """System directories must be rejected."""
+        from gptme.server import api_v2_agents
+
+        monkeypatch.setattr(
+            api_v2_agents, "INITIAL_WORKING_DIRECTORY", tmp_path.resolve()
+        )
         response = self._put_agent(client, path="/etc/gptme-agent")
         assert response.status_code == 400
         data = response.get_json()
-        assert "working directory" in data["error"].lower()
+        assert data["error"] == "Path must be within the server working directory"
 
 
 class TestValidateBranchUnit:

--- a/tests/test_server_v2_agents.py
+++ b/tests/test_server_v2_agents.py
@@ -166,8 +166,12 @@ class TestAgentsPutEndpoint:
         mock_create_workspace: MagicMock,
         client: FlaskClient,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         """Successful agent creation with all required fields."""
+        import gptme.server.api_v2_agents as agents_module
+
+        monkeypatch.setattr(agents_module, "INITIAL_WORKING_DIRECTORY", tmp_path)
         mock_init_conv.return_value = "test-conversation-id"
         agent_path = str(tmp_path / "my-agent")
 
@@ -215,8 +219,12 @@ class TestAgentsPutEndpoint:
         mock_create_workspace: MagicMock,
         client: FlaskClient,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         """WorkspaceError with 'already exists' returns 400."""
+        import gptme.server.api_v2_agents as agents_module
+
+        monkeypatch.setattr(agents_module, "INITIAL_WORKING_DIRECTORY", tmp_path)
         from gptme.agent.workspace import WorkspaceError
 
         mock_create_workspace.side_effect = WorkspaceError(
@@ -239,8 +247,12 @@ class TestAgentsPutEndpoint:
         mock_create_workspace: MagicMock,
         client: FlaskClient,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         """WorkspaceError with 'timed out' returns 504."""
+        import gptme.server.api_v2_agents as agents_module
+
+        monkeypatch.setattr(agents_module, "INITIAL_WORKING_DIRECTORY", tmp_path)
         from gptme.agent.workspace import WorkspaceError
 
         mock_create_workspace.side_effect = WorkspaceError(
@@ -263,8 +275,12 @@ class TestAgentsPutEndpoint:
         mock_create_workspace: MagicMock,
         client: FlaskClient,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         """WorkspaceError with generic message returns 500."""
+        import gptme.server.api_v2_agents as agents_module
+
+        monkeypatch.setattr(agents_module, "INITIAL_WORKING_DIRECTORY", tmp_path)
         from gptme.agent.workspace import WorkspaceError
 
         mock_create_workspace.side_effect = WorkspaceError("Something went wrong")
@@ -287,8 +303,12 @@ class TestAgentsPutEndpoint:
         mock_create_workspace: MagicMock,
         client: FlaskClient,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         """Failure in init_conversation returns 500."""
+        import gptme.server.api_v2_agents as agents_module
+
+        monkeypatch.setattr(agents_module, "INITIAL_WORKING_DIRECTORY", tmp_path)
         mock_init_conv.side_effect = RuntimeError("Conversation init failed")
 
         response = client.put(
@@ -308,8 +328,12 @@ class TestAgentsPutEndpoint:
         mock_init_conv: MagicMock,
         mock_create_workspace: MagicMock,
         client: FlaskClient,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         """Path with ~ gets expanded and resolved."""
+        import gptme.server.api_v2_agents as agents_module
+
+        monkeypatch.setattr(agents_module, "INITIAL_WORKING_DIRECTORY", Path.home())
         mock_init_conv.return_value = "conv-456"
 
         response = client.put(

--- a/tests/test_server_v2_agents.py
+++ b/tests/test_server_v2_agents.py
@@ -16,6 +16,7 @@ pytest.importorskip(
 
 from flask.testing import FlaskClient  # fmt: skip
 
+from gptme.server import api_v2_agents  # fmt: skip
 from gptme.server.api_v2_agents import slugify_name  # fmt: skip
 
 pytestmark = [pytest.mark.timeout(10)]
@@ -169,9 +170,9 @@ class TestAgentsPutEndpoint:
         monkeypatch: pytest.MonkeyPatch,
     ):
         """Successful agent creation with all required fields."""
-        import gptme.server.api_v2_agents as agents_module
-
-        monkeypatch.setattr(agents_module, "INITIAL_WORKING_DIRECTORY", tmp_path)
+        monkeypatch.setattr(
+            api_v2_agents, "INITIAL_WORKING_DIRECTORY", tmp_path.resolve()
+        )
         mock_init_conv.return_value = "test-conversation-id"
         agent_path = str(tmp_path / "my-agent")
 
@@ -198,8 +199,13 @@ class TestAgentsPutEndpoint:
         mock_init_conv: MagicMock,
         mock_create_workspace: MagicMock,
         client: FlaskClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         """When no path provided, auto-generates from INITIAL_WORKING_DIRECTORY + slugified name."""
+        monkeypatch.setattr(
+            api_v2_agents, "INITIAL_WORKING_DIRECTORY", tmp_path.resolve()
+        )
         mock_init_conv.return_value = "conv-123"
 
         response = client.put(
@@ -222,11 +228,11 @@ class TestAgentsPutEndpoint:
         monkeypatch: pytest.MonkeyPatch,
     ):
         """WorkspaceError with 'already exists' returns 400."""
-        import gptme.server.api_v2_agents as agents_module
-
-        monkeypatch.setattr(agents_module, "INITIAL_WORKING_DIRECTORY", tmp_path)
         from gptme.agent.workspace import WorkspaceError
 
+        monkeypatch.setattr(
+            api_v2_agents, "INITIAL_WORKING_DIRECTORY", tmp_path.resolve()
+        )
         mock_create_workspace.side_effect = WorkspaceError(
             "Workspace already exists at /some/path"
         )
@@ -250,11 +256,11 @@ class TestAgentsPutEndpoint:
         monkeypatch: pytest.MonkeyPatch,
     ):
         """WorkspaceError with 'timed out' returns 504."""
-        import gptme.server.api_v2_agents as agents_module
-
-        monkeypatch.setattr(agents_module, "INITIAL_WORKING_DIRECTORY", tmp_path)
         from gptme.agent.workspace import WorkspaceError
 
+        monkeypatch.setattr(
+            api_v2_agents, "INITIAL_WORKING_DIRECTORY", tmp_path.resolve()
+        )
         mock_create_workspace.side_effect = WorkspaceError(
             "Git clone timed out after 300 seconds"
         )
@@ -278,11 +284,11 @@ class TestAgentsPutEndpoint:
         monkeypatch: pytest.MonkeyPatch,
     ):
         """WorkspaceError with generic message returns 500."""
-        import gptme.server.api_v2_agents as agents_module
-
-        monkeypatch.setattr(agents_module, "INITIAL_WORKING_DIRECTORY", tmp_path)
         from gptme.agent.workspace import WorkspaceError
 
+        monkeypatch.setattr(
+            api_v2_agents, "INITIAL_WORKING_DIRECTORY", tmp_path.resolve()
+        )
         mock_create_workspace.side_effect = WorkspaceError("Something went wrong")
 
         response = client.put(
@@ -306,9 +312,9 @@ class TestAgentsPutEndpoint:
         monkeypatch: pytest.MonkeyPatch,
     ):
         """Failure in init_conversation returns 500."""
-        import gptme.server.api_v2_agents as agents_module
-
-        monkeypatch.setattr(agents_module, "INITIAL_WORKING_DIRECTORY", tmp_path)
+        monkeypatch.setattr(
+            api_v2_agents, "INITIAL_WORKING_DIRECTORY", tmp_path.resolve()
+        )
         mock_init_conv.side_effect = RuntimeError("Conversation init failed")
 
         response = client.put(
@@ -331,9 +337,8 @@ class TestAgentsPutEndpoint:
         monkeypatch: pytest.MonkeyPatch,
     ):
         """Path with ~ gets expanded and resolved."""
-        import gptme.server.api_v2_agents as agents_module
-
-        monkeypatch.setattr(agents_module, "INITIAL_WORKING_DIRECTORY", Path.home())
+        home = Path.home().resolve()
+        monkeypatch.setattr(api_v2_agents, "INITIAL_WORKING_DIRECTORY", home)
         mock_init_conv.return_value = "conv-456"
 
         response = client.put(


### PR DESCRIPTION
## Summary

- The agent creation endpoint (`PUT /api/v2/agents`) accepted user-provided filesystem paths without containment validation
- An authenticated user could create agent workspaces at arbitrary filesystem locations (e.g. `/etc/`, `/tmp/`, `~/.ssh/`) by passing a custom `path` in the request body
- Added path containment check: the resolved path must be within `INITIAL_WORKING_DIRECTORY` (where the server was started), otherwise returns 400

Continues the server security hardening pattern from #1847 and #2119.

## Test plan

- [x] 4 new tests in `test_server_path_traversal.py`: absolute path outside cwd, home directory path, traversal via `../`, system directory path
- [x] All 56 existing path traversal tests still pass
- [x] `ruff check` clean