### PR TITLE
fix(server): cap text file preview at 10MB to prevent OOM

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -77,12 +77,15 @@ def _is_valid_image_content(path: "Path") -> bool:
     runtime dependency (needed for vision support), so no extra install cost.
     """
     try:
-        from PIL import Image
+        from PIL import Image, UnidentifiedImageError
 
         with Image.open(path) as img:
             _ = img.format  # triggers format detection from file content
         return True
+    except (UnidentifiedImageError, FileNotFoundError, IsADirectoryError, OSError):
+        return False
     except Exception:
+        logger.warning("Unexpected error validating image %s", path, exc_info=True)
         return False
 
 

--- a/gptme/server/workspace_api.py
+++ b/gptme/server/workspace_api.py
@@ -20,6 +20,9 @@ from .openapi_docs import ErrorResponse, api_doc_simple
 
 logger = logging.getLogger(__name__)
 
+# Maximum bytes returned for text-file preview to avoid OOM on huge files.
+MAX_PREVIEW_BYTES = 10 * 1024 * 1024  # 10 MB
+
 workspace_api = flask.Blueprint("workspace_api", __name__)
 
 
@@ -511,10 +514,16 @@ def preview_file(conversation_id: str, filepath: str):
 
         # Handle different file types
         if wfile.is_text:
-            # Text files
+            # Text files — cap preview to avoid OOM on huge files
+            file_size = path.stat().st_size
+            truncated = file_size > MAX_PREVIEW_BYTES
             with open(path) as f:
-                content = f.read()
-            return flask.jsonify({"type": "text", "content": content})
+                content = f.read(MAX_PREVIEW_BYTES)
+            resp: dict = {"type": "text", "content": content}
+            if truncated:
+                resp["truncated"] = True
+                resp["total_size"] = file_size
+            return flask.jsonify(resp)
         if mime_type and mime_type.startswith("image/"):
             # Images
             return flask.send_file(path, mimetype=mime_type)

--- a/gptme/server/workspace_api.py
+++ b/gptme/server/workspace_api.py
@@ -514,11 +514,14 @@ def preview_file(conversation_id: str, filepath: str):
 
         # Handle different file types
         if wfile.is_text:
-            # Text files — cap preview to avoid OOM on huge files
+            # Text files — cap preview to avoid OOM on huge files.
+            # Read in binary mode so MAX_PREVIEW_BYTES is a hard byte limit,
+            # not a character limit (which would be up to 4× larger for UTF-8).
             file_size = path.stat().st_size
             truncated = file_size > MAX_PREVIEW_BYTES
-            with open(path) as f:
-                content = f.read(MAX_PREVIEW_BYTES)
+            with open(path, "rb") as fb:
+                raw = fb.read(MAX_PREVIEW_BYTES)
+            content = raw.decode("utf-8", errors="replace")
             resp: dict = {"type": "text", "content": content}
             if truncated:
                 resp["truncated"] = True

--- a/tests/test_server_workspace.py
+++ b/tests/test_server_workspace.py
@@ -717,6 +717,41 @@ class TestWorkspaceEdgeCases:
         assert data["type"] == "text"
         assert len(data["content"]) == 100_000
 
+    def test_large_file_truncated(
+        self, client: FlaskClient, workspace_conv, monkeypatch
+    ):
+        """Test that files exceeding the preview limit are truncated."""
+        import gptme.server.workspace_api as ws_mod
+
+        # Use a tiny limit so we can test truncation without huge files
+        monkeypatch.setattr(ws_mod, "MAX_PREVIEW_BYTES", 50)
+
+        workspace = workspace_conv["workspace"]
+        large_file = workspace / "huge.txt"
+        large_file.write_text("a" * 200)
+
+        conv_id = workspace_conv["conversation_id"]
+        response = client.get(
+            f"/api/v2/conversations/{conv_id}/workspace/huge.txt/preview"
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["type"] == "text"
+        assert len(data["content"]) == 50
+        assert data["truncated"] is True
+        assert data["total_size"] == 200
+
+    def test_small_file_not_truncated(self, client: FlaskClient, workspace_conv):
+        """Test that small files have no truncation metadata."""
+        conv_id = workspace_conv["conversation_id"]
+        response = client.get(
+            f"/api/v2/conversations/{conv_id}/workspace/readme.txt/preview"
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["type"] == "text"
+        assert "truncated" not in data
+
     def test_special_characters_in_filename(self, client: FlaskClient, workspace_conv):
         """Test files with special characters in names."""
         workspace = workspace_conv["workspace"]

--- a/tests/test_server_workspace.py
+++ b/tests/test_server_workspace.py
@@ -752,6 +752,35 @@ class TestWorkspaceEdgeCases:
         assert data["type"] == "text"
         assert "truncated" not in data
 
+    def test_multibyte_utf8_truncation(
+        self, client: FlaskClient, workspace_conv, monkeypatch
+    ):
+        """Test that truncation respects byte boundaries, not character counts.
+
+        Each CJK character is 3 bytes in UTF-8. With a limit of 9 bytes and
+        10 CJK characters (30 bytes total), we expect exactly 3 characters
+        (9 bytes) returned — not 9 characters (27 bytes).
+        """
+        import gptme.server.workspace_api as ws_mod
+
+        monkeypatch.setattr(ws_mod, "MAX_PREVIEW_BYTES", 9)  # 3 CJK chars
+
+        workspace = workspace_conv["workspace"]
+        cjk_file = workspace / "cjk.txt"
+        # Each '中' is 3 bytes in UTF-8
+        cjk_file.write_text("中" * 10, encoding="utf-8")
+
+        conv_id = workspace_conv["conversation_id"]
+        response = client.get(
+            f"/api/v2/conversations/{conv_id}/workspace/cjk.txt/preview"
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["type"] == "text"
+        # 9 bytes = 3 CJK chars, not 9 chars
+        assert len(data["content"].replace("\ufffd", "")) == 3
+        assert data["truncated"] is True
+
     def test_special_characters_in_filename(self, client: FlaskClient, workspace_conv):
         """Test files with special characters in names."""
         workspace = workspace_conv["workspace"]


### PR DESCRIPTION
## Summary
- Add `MAX_PREVIEW_BYTES` (10MB) cap to the `preview_file` endpoint — previously read entire text files into memory with no limit, risking OOM on large files
- Return `truncated: true` and `total_size` metadata when a file exceeds the limit so the client knows the preview is partial
- Narrow exception handling in `_is_valid_image_content` avatar validation — log unexpected errors via `logger.warning` instead of silently swallowing all exceptions
- Add tests for both truncation and non-truncation cases

## Test plan
- [x] All 128 server workspace + path traversal tests pass
- [x] New `test_large_file_truncated` verifies truncation with monkeypatched limit
- [x] New `test_small_file_not_truncated` verifies no truncation metadata on small files
- [x] Existing `test_large_file_preview` (100KB) still passes