### PR TITLE
fix(server): add random suffix to task IDs to prevent collisions

### DIFF
--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -9,6 +9,7 @@ with workspace and git information derived from the active conversation.
 import json
 import logging
 import subprocess
+import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -716,8 +717,9 @@ def api_tasks_create():
         return flask.jsonify({"error": "metadata must be an object"}), 400
 
     try:
-        # Generate task ID
-        task_id = f"task-{datetime.now(tz=timezone.utc).strftime('%Y%m%d-%H%M%S')}"
+        # Generate task ID with a short random suffix to prevent collisions
+        # when two tasks are created within the same second.
+        task_id = f"task-{datetime.now(tz=timezone.utc).strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:6]}"
 
         # Create task
         task = Task(

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -752,6 +752,29 @@ class TestTasksCreateAPI:
         assert get_resp.status_code == 200
         assert get_resp.json["content"] == "Persist me"
 
+    def test_create_task_ids_are_unique(self, client):
+        """Two tasks created within the same second must have different IDs."""
+        ids: list[str] = []
+        with (
+            patch(
+                "gptme.server.tasks_api.create_task_conversation",
+                return_value="conv-mock-0",
+            ),
+            patch(
+                "gptme.server.tasks_api.get_task_info",
+                side_effect=lambda t: {**asdict(t)},
+            ),
+        ):
+            for _ in range(10):
+                resp = client.post(
+                    "/api/v2/tasks",
+                    json={"content": f"task-{len(ids)}"},
+                )
+                assert resp.status_code == 201
+                ids.append(resp.json["id"])
+        # All IDs must be unique
+        assert len(set(ids)) == len(ids), f"Duplicate task IDs: {ids}"
+
 
 class TestTasksInputValidation:
     """Tests for input validation on create and update endpoints."""


### PR DESCRIPTION
## Summary

Task IDs used format `task-YYYYMMDD-HHMMSS` which has no uniqueness guarantee. Two tasks created within the same second would silently overwrite each other on disk (last-write-wins on the JSON file).

## Fix

Append a 6-char hex suffix from `uuid4` to every generated task ID.

- Before: `task-20260414-001234`
- After: `task-20260414-001234-a1b2c3`

## Test

New `test_create_task_ids_are_unique` creates 10 tasks rapidly and asserts all IDs are distinct. Without the fix this test would flake/fail when two IDs land on the same second.

All 76 tasks API tests pass.