### PR TITLE
fix(server): validate task_id to prevent path traversal in tasks API

### DIFF
--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -147,12 +147,12 @@ class TaskListResponse(BaseModel):
 
 
 # Task IDs must be alphanumeric with hyphens/underscores, no path separators
-_TASK_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+_TASK_ID_PATTERN = re.compile(r"[a-zA-Z0-9_-]+")
 
 
 def _validate_task_id(task_id: str) -> bool:
     """Check that task_id doesn't contain path traversal characters."""
-    return bool(_TASK_ID_PATTERN.match(task_id))
+    return bool(_TASK_ID_PATTERN.fullmatch(task_id))
 
 
 def get_tasks_dir() -> Path:

--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -8,6 +8,7 @@ with workspace and git information derived from the active conversation.
 
 import json
 import logging
+import re
 import subprocess
 import uuid
 from dataclasses import asdict, dataclass, field
@@ -145,6 +146,15 @@ class TaskListResponse(BaseModel):
     tasks: list[TaskResponse] = Field(..., description="List of tasks")
 
 
+# Task IDs must be alphanumeric with hyphens/underscores, no path separators
+_TASK_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def _validate_task_id(task_id: str) -> bool:
+    """Check that task_id doesn't contain path traversal characters."""
+    return bool(_TASK_ID_PATTERN.match(task_id))
+
+
 def get_tasks_dir() -> Path:
     """Get the tasks storage directory."""
     return get_logs_dir().parent / "tasks"
@@ -152,6 +162,10 @@ def get_tasks_dir() -> Path:
 
 def load_task(task_id: str) -> Task | None:
     """Load a task from storage."""
+    if not _validate_task_id(task_id):
+        logger.warning(f"Rejected load_task with invalid task_id: {task_id!r}")
+        return None
+
     tasks_dir = get_tasks_dir()
     task_file = tasks_dir / f"{task_id}.json"
 
@@ -169,6 +183,9 @@ def load_task(task_id: str) -> Task | None:
 
 def save_task(task: Task) -> None:
     """Save a task to storage."""
+    if not _validate_task_id(task.id):
+        raise ValueError(f"Invalid task_id: {task.id!r}")
+
     tasks_dir = get_tasks_dir()
     tasks_dir.mkdir(parents=True, exist_ok=True)
 
@@ -564,6 +581,9 @@ def get_git_status(workspace_path: Path) -> dict[str, Any]:
 
 def create_task_conversation(task: Task) -> str:
     """Create a conversation for a task."""
+    if not _validate_task_id(task.id):
+        raise ValueError(f"Invalid task_id: {task.id!r}")
+
     # Use simple incremental suffix instead of timestamp
     suffix = len(task.conversation_ids)
     conversation_id = f"{task.id}-{suffix}"
@@ -611,6 +631,9 @@ def create_task_conversation(task: Task) -> str:
 
 def setup_task_workspace(task_id: str, target_repo: str | None = None) -> Path:
     """Setup workspace for task. All conversations for this task will share this workspace."""
+    if not _validate_task_id(task_id):
+        raise ValueError(f"Invalid task_id: {task_id!r}")
+
     # Use task-level workspace that all conversations for this task will share
     task_dir = get_tasks_dir() / task_id
     workspace = task_dir / "workspace"

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -867,3 +867,61 @@ class TestTasksInputValidation:
                 json={"target_type": tt},
             )
             assert resp.status_code == 200, f"target_type '{tt}' should be valid"
+
+
+# ── Path traversal prevention ─────────────────────────────────────
+
+
+class TestTaskIdPathTraversal:
+    """Verify task_id values with path traversal characters are rejected."""
+
+    def test_load_rejects_parent_traversal(self):
+        assert load_task("../../etc/passwd") is None
+
+    def test_load_rejects_absolute_path(self):
+        assert load_task("/etc/passwd") is None
+
+    def test_load_rejects_dot_segments(self):
+        assert load_task("../secret") is None
+        assert load_task("foo/../bar") is None
+
+    def test_load_rejects_null_bytes(self):
+        assert load_task("task\x00.json") is None
+
+    def test_load_accepts_valid_id(self, tmp_path, monkeypatch):
+        """A valid task_id should still work normally."""
+        # Create a temp task file
+        task_file = tmp_path / "task-valid-123.json"
+        task_file.write_text(
+            json.dumps(
+                {
+                    "id": "task-valid-123",
+                    "content": "test",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "status": "pending",
+                    "target_type": "stdout",
+                }
+            )
+        )
+
+        monkeypatch.setattr("gptme.server.tasks_api.get_tasks_dir", lambda: tmp_path)
+        task = load_task("task-valid-123")
+        assert task is not None
+        assert task.id == "task-valid-123"
+
+    def test_save_rejects_traversal_id(self, tmp_path, monkeypatch):
+        """save_task should raise on path traversal task IDs."""
+        monkeypatch.setattr("gptme.server.tasks_api.get_tasks_dir", lambda: tmp_path)
+        task = Task(
+            id="../../evil",
+            content="test",
+            created_at="2026-01-01T00:00:00Z",
+            status="pending",
+            target_type="stdout",
+        )
+        with pytest.raises(ValueError, match="Invalid task_id"):
+            save_task(task)
+
+    def test_api_get_rejects_traversal(self, client):
+        resp = client.get("/api/v2/tasks/../../etc/passwd")
+        assert resp.status_code == 404


### PR DESCRIPTION
Task IDs from URL parameters were used directly as filename stems in `load_task`/`save_task` without validation. A malicious task_id like `../../etc/passwd` could read/write files outside the tasks directory.

**Fix**: Add `_validate_task_id()` regex check (alphanumeric + hyphens/underscores only) to all code paths that use task_id for file I/O:
- `load_task()` — returns None for invalid IDs
- `save_task()` — raises ValueError
- `create_task_conversation()` — raises ValueError
- `setup_task_workspace()` — raises ValueError

**Tests**: 7 new tests covering parent traversal, absolute paths, dot segments, null bytes, valid IDs still work, save rejection, and API 404 response.

Part of ongoing server hardening (follows #2119, #2123, #2124).