### PR TITLE
fix(tools): report error on invalid read line numbers and fix tool name in server error log

### DIFF
--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -823,7 +823,7 @@ def start_tool_execution(
             for tool_output in tool_outputs:
                 _append_and_notify(manager, session, tool_output)
         except Exception as e:
-            logger.exception(f"Error executing tool {tooluse.__class__.__name__}: {e}")
+            logger.exception(f"Error executing tool {tooluse.tool}: {e}")
             tool_exec.status = ToolStatus.FAILED
 
             msg = Message("system", f"Error: {e!s}")

--- a/gptme/tools/read.py
+++ b/gptme/tools/read.py
@@ -130,12 +130,20 @@ def execute_read(
             try:
                 start_line = int(kwargs["start_line"])
             except ValueError:
-                pass
+                yield Message(
+                    "system",
+                    f"Invalid start_line: {kwargs['start_line']!r} (expected integer)",
+                )
+                return
         if "end_line" in kwargs:
             try:
                 end_line = int(kwargs["end_line"])
             except ValueError:
-                pass
+                yield Message(
+                    "system",
+                    f"Invalid end_line: {kwargs['end_line']!r} (expected integer)",
+                )
+                return
 
     try:
         content = path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- **read.py**: When `start_line` or `end_line` kwargs can't be parsed as integers, yield an error message instead of silently falling back to defaults. Previously, `read /path start_line=abc` would silently read the entire file — now it returns a clear error.
- **session_step.py**: Use `tooluse.tool` (actual tool name like "shell", "python") in the exception log instead of `tooluse.__class__.__name__` (always prints "ToolUse" regardless of which tool failed).

## Test plan

- [x] `pytest tests/test_tools_read.py` — all 11 tests pass
- [x] `mypy` on both modified files — clean
- [x] Manual verification: invalid kwargs return error, valid kwargs still work