### PR TITLE
fix(server): validate message content and timestamp in conversation creation

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -411,11 +411,19 @@ def api_conversation_put(conversation_id: str):
                 ),
                 400,
             )
-        timestamp: datetime = (
-            isoparse(msg["timestamp"])
-            if "timestamp" in msg
-            else datetime.now(tz=timezone.utc)
-        )
+        if "content" not in msg:
+            return flask.jsonify(
+                {"error": "Message missing required 'content' field"}
+            ), 400
+        if "timestamp" in msg:
+            try:
+                timestamp: datetime = isoparse(msg["timestamp"])
+            except (ValueError, OverflowError):
+                return flask.jsonify(
+                    {"error": f"Invalid timestamp format: {msg['timestamp']}"}
+                ), 400
+        else:
+            timestamp = datetime.now(tz=timezone.utc)
         msgs.append(Message(msg["role"], msg["content"], timestamp=timestamp))
 
     log = LogManager.load(logdir=logdir, initial_msgs=msgs, create=True)

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -11,7 +11,7 @@ from dataclasses import replace
 from datetime import datetime, timezone
 from itertools import islice
 from pathlib import Path
-from typing import cast
+from typing import Literal, cast
 
 import flask
 from dateutil.parser import isoparse
@@ -374,6 +374,37 @@ def api_conversation_put(conversation_id: str):
             400,
         )
 
+    # Validate all messages before creating any side effects (directories).
+    # This prevents orphaned directories when validation fails: if logdir.mkdir()
+    # runs before a 400 is returned, the same conversation_id gets a 409 on retry.
+    _RoleType = Literal["system", "user", "assistant"]
+    valid_roles = ("system", "user", "assistant")
+    validated_msgs: list[tuple[_RoleType, str, datetime]] = []
+    for msg in req_json.get("messages", []):
+        if msg.get("role") not in valid_roles:
+            return (
+                flask.jsonify(
+                    {
+                        "error": f"Invalid role: {msg.get('role')}. Must be one of: {valid_roles}"
+                    }
+                ),
+                400,
+            )
+        if "content" not in msg:
+            return flask.jsonify(
+                {"error": "Message missing required 'content' field"}
+            ), 400
+        if "timestamp" in msg:
+            try:
+                ts: datetime = isoparse(msg["timestamp"])
+            except (ValueError, OverflowError, TypeError):
+                return flask.jsonify(
+                    {"error": f"Invalid timestamp format: {msg['timestamp']}"}
+                ), 400
+        else:
+            ts = datetime.now(tz=timezone.utc)
+        validated_msgs.append((cast(_RoleType, msg["role"]), msg["content"], ts))
+
     # Create the log directory atomically to avoid TOCTOU race
     try:
         logdir.mkdir(parents=True)
@@ -400,31 +431,8 @@ def api_conversation_put(conversation_id: str):
         agent_path=chat_config.agent,
     )
 
-    valid_roles = ("system", "user", "assistant")
-    for msg in req_json.get("messages", []):
-        if msg.get("role") not in valid_roles:
-            return (
-                flask.jsonify(
-                    {
-                        "error": f"Invalid role: {msg.get('role')}. Must be one of: {valid_roles}"
-                    }
-                ),
-                400,
-            )
-        if "content" not in msg:
-            return flask.jsonify(
-                {"error": "Message missing required 'content' field"}
-            ), 400
-        if "timestamp" in msg:
-            try:
-                timestamp: datetime = isoparse(msg["timestamp"])
-            except (ValueError, OverflowError):
-                return flask.jsonify(
-                    {"error": f"Invalid timestamp format: {msg['timestamp']}"}
-                ), 400
-        else:
-            timestamp = datetime.now(tz=timezone.utc)
-        msgs.append(Message(msg["role"], msg["content"], timestamp=timestamp))
+    for role, content, timestamp in validated_msgs:
+        msgs.append(Message(role, content, timestamp=timestamp))
 
     log = LogManager.load(logdir=logdir, initial_msgs=msgs, create=True)
     log.write()

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1201,8 +1201,11 @@ def test_v2_step_last_error_set_on_failure(v2_conv, client: FlaskClient):
 
 def test_v2_create_conversation_missing_content(client: FlaskClient):
     """Creating a conversation with a message missing 'content' returns 400."""
+    import uuid
+
+    conv_id = f"test-missing-content-{uuid.uuid4().hex[:8]}"
     response = client.put(
-        "/api/v2/conversations/test-missing-content",
+        f"/api/v2/conversations/{conv_id}",
         json={
             "messages": [{"role": "user"}],
         },
@@ -1215,8 +1218,11 @@ def test_v2_create_conversation_missing_content(client: FlaskClient):
 
 def test_v2_create_conversation_invalid_timestamp(client: FlaskClient):
     """Creating a conversation with an invalid timestamp returns 400."""
+    import uuid
+
+    conv_id = f"test-bad-timestamp-{uuid.uuid4().hex[:8]}"
     response = client.put(
-        "/api/v2/conversations/test-bad-timestamp",
+        f"/api/v2/conversations/{conv_id}",
         json={
             "messages": [
                 {"role": "user", "content": "hello", "timestamp": "not-a-date"}

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1233,3 +1233,20 @@ def test_v2_create_conversation_invalid_timestamp(client: FlaskClient):
     data = response.get_json()
     assert data is not None
     assert "timestamp" in data["error"].lower()
+
+
+def test_v2_create_conversation_non_string_timestamp(client: FlaskClient):
+    """Creating a conversation with a non-string timestamp returns 400 (not 500)."""
+    import uuid
+
+    conv_id = f"test-numeric-ts-{uuid.uuid4().hex[:8]}"
+    response = client.put(
+        f"/api/v2/conversations/{conv_id}",
+        json={
+            "messages": [{"role": "user", "content": "hello", "timestamp": 12345}],
+        },
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None
+    assert "timestamp" in data["error"].lower()

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1197,3 +1197,33 @@ def test_v2_step_last_error_set_on_failure(v2_conv, client: FlaskClient):
     assert "Model not found" in session.last_error
     # Session should not be stuck in generating state
     assert not session.generating
+
+
+def test_v2_create_conversation_missing_content(client: FlaskClient):
+    """Creating a conversation with a message missing 'content' returns 400."""
+    response = client.put(
+        "/api/v2/conversations/test-missing-content",
+        json={
+            "messages": [{"role": "user"}],
+        },
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None
+    assert "content" in data["error"].lower()
+
+
+def test_v2_create_conversation_invalid_timestamp(client: FlaskClient):
+    """Creating a conversation with an invalid timestamp returns 400."""
+    response = client.put(
+        "/api/v2/conversations/test-bad-timestamp",
+        json={
+            "messages": [
+                {"role": "user", "content": "hello", "timestamp": "not-a-date"}
+            ],
+        },
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data is not None
+    assert "timestamp" in data["error"].lower()


### PR DESCRIPTION
## Summary

- Return 400 when a message in conversation creation is missing the required `content` field (previously caused `KeyError` → 500)
- Catch `ValueError`/`OverflowError` from `isoparse()` when timestamp is malformed (previously caused unhandled `ParserError` → 500)
- Add tests for both validation paths

## Test plan

- [x] New test: `test_v2_create_conversation_missing_content` — verifies 400 response
- [x] New test: `test_v2_create_conversation_invalid_timestamp` — verifies 400 response
- [x] mypy clean
- [ ] CI passes