### PR TITLE
fix(server): return 404 for missing conversations

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -302,11 +302,16 @@ def api_conversation(conversation_id: str):
     if error := _validate_conversation_id(conversation_id):
         return error
 
+    try:
+        manager = LogManager.load(conversation_id, lock=False)
+    except FileNotFoundError:
+        return flask.jsonify(
+            {"error": f"Conversation not found: {conversation_id}"}
+        ), 404
+
     # Create and set config
     logdir = get_logs_dir() / conversation_id
     chat_config = ChatConfig.load_or_create(logdir, ChatConfig()).save()
-
-    manager = LogManager.load(conversation_id, lock=False)
     log_dict = manager.to_dict(branches=True)
 
     # make all paths relative to workspace or logdir (no "../" or absolute paths)

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -679,6 +679,20 @@ def test_v2_conversation_get(v2_conv, client: FlaskClient):
     assert "testing" in data["log"][0]["content"]
 
 
+def test_v2_conversation_get_returns_404_for_missing_conversation(
+    client: FlaskClient,
+):
+    """Missing conversations should return a structured 404 instead of a 500."""
+    conversation_id = f"missing-conversation-{random.randint(0, 1000000)}"
+
+    response = client.get(f"/api/v2/conversations/{conversation_id}")
+
+    assert response.status_code == 404
+    assert response.get_json() == {
+        "error": f"Conversation not found: {conversation_id}"
+    }
+
+
 def test_v2_create_conversation_default_system_prompt(
     client: FlaskClient, tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- return a structured 404 from `GET /api/v2/conversations/<id>` when the conversation does not exist
- avoid leaking an unhandled `FileNotFoundError` as a 500
- add a regression test covering the missing-conversation case

## Testing
- `uv run pytest tests/test_server_v2.py -q`
- `uv run ruff check gptme/server/api_v2.py tests/test_server_v2.py`
