### PR TITLE
fix(server): return 404 when patching missing conversation config

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1021,7 +1021,14 @@ def api_conversation_config_patch(conversation_id: str):
     tools = get_tools()
 
     # Update system prompt with new tools
-    manager = LogManager.load(conversation_id, lock=False)
+    try:
+        manager = LogManager.load(conversation_id, lock=False)
+    except FileNotFoundError:
+        return (
+            flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
+            404,
+        )
+
     if len(manager.log.messages) >= 1 and manager.log.messages[0].role == "system":
         # Remove leading system messages and replace with new ones
         # Use immutable Log interface instead of mutating the frozen dataclass's list

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1007,7 +1007,10 @@ def api_conversation_config_patch(conversation_id: str):
 
     logdir = get_logs_dir() / conversation_id
 
-    if not (logdir / "conversation.jsonl").exists():
+    # Guard: check conversation exists before any side-effecting operations.
+    # ChatConfig.save() creates the logdir on disk and set_config/init_tools mutate
+    # process-wide state, so the 404 check must come first.
+    if not logdir.exists():
         return (
             flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
             404,

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1007,6 +1007,12 @@ def api_conversation_config_patch(conversation_id: str):
 
     logdir = get_logs_dir() / conversation_id
 
+    if not (logdir / "conversation.jsonl").exists():
+        return (
+            flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
+            404,
+        )
+
     # Create and set config
     req_json["_logdir"] = logdir  # Pass logdir for "@log" workspace resolution
     request_config = ChatConfig.from_dict(req_json)
@@ -1021,13 +1027,7 @@ def api_conversation_config_patch(conversation_id: str):
     tools = get_tools()
 
     # Update system prompt with new tools
-    try:
-        manager = LogManager.load(conversation_id, lock=False)
-    except FileNotFoundError:
-        return (
-            flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
-            404,
-        )
+    manager = LogManager.load(conversation_id, lock=False)
 
     if len(manager.log.messages) >= 1 and manager.log.messages[0].role == "system":
         # Remove leading system messages and replace with new ones

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -8,7 +8,6 @@ from typing import Any, cast
 import pytest
 
 from gptme.config import ChatConfig, MCPConfig
-from gptme.dirs import get_logs_dir
 from gptme.llm.models import ModelMeta, get_default_model
 from gptme.prompts import get_prompt
 from gptme.tools import get_toolchain
@@ -950,15 +949,17 @@ def test_v2_chat_config_update_works(client: FlaskClient):
 def test_v2_chat_config_update_missing_conversation_returns_404(client: FlaskClient):
     """Test that updating config for a missing conversation returns a 404.
 
-    Also verifies no orphaned directory or config file is created on disk
-    (regression: guard was firing after ChatConfig.save() and set_config()).
+    Also asserts that no orphaned directory or config file is created on disk,
+    and that the existence check fires before any side-effecting operations.
     """
-    conversation_id = "missing-conversation"
-    logdir = get_logs_dir() / conversation_id
+    from gptme.dirs import get_logs_dir  # fmt: skip
 
     input_config = ChatConfig(model="openai/gpt-4o")
     input_config.tools = [t.name for t in get_toolchain(None) if not t.is_mcp]
     input_config.mcp = MCPConfig()
+
+    conversation_id = "missing-conversation"
+    logdir = get_logs_dir() / conversation_id
 
     response = client.patch(
         f"/api/v2/conversations/{conversation_id}/config",
@@ -969,8 +970,10 @@ def test_v2_chat_config_update_missing_conversation_returns_404(client: FlaskCli
     assert response.get_json() == {
         "error": f"Conversation not found: {conversation_id}"
     }
-    # Verify no orphaned directory or config was created as a side effect
-    assert not logdir.exists(), f"Orphaned logdir created at {logdir}"
+    # Ensure no orphaned directory or config file was created on disk
+    assert not logdir.exists(), (
+        f"Orphaned logdir was created at {logdir} despite 404 response"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -946,6 +946,23 @@ def test_v2_chat_config_update_works(client: FlaskClient):
     assert config.to_dict() == input_config.to_dict()
 
 
+def test_v2_chat_config_update_missing_conversation_returns_404(client: FlaskClient):
+    """Test that updating config for a missing conversation returns a 404."""
+    input_config = ChatConfig(model="openai/gpt-4o")
+    input_config.tools = [t.name for t in get_toolchain(None) if not t.is_mcp]
+    input_config.mcp = MCPConfig()
+
+    response = client.patch(
+        "/api/v2/conversations/missing-conversation/config",
+        json=input_config.to_dict(),
+    )
+
+    assert response.status_code == 404
+    assert response.get_json() == {
+        "error": "Conversation not found: missing-conversation"
+    }
+
+
 @pytest.mark.parametrize(
     "files_payload",
     [

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 import pytest
 
 from gptme.config import ChatConfig, MCPConfig
+from gptme.dirs import get_logs_dir
 from gptme.llm.models import ModelMeta, get_default_model
 from gptme.prompts import get_prompt
 from gptme.tools import get_toolchain
@@ -947,20 +948,29 @@ def test_v2_chat_config_update_works(client: FlaskClient):
 
 
 def test_v2_chat_config_update_missing_conversation_returns_404(client: FlaskClient):
-    """Test that updating config for a missing conversation returns a 404."""
+    """Test that updating config for a missing conversation returns a 404.
+
+    Also verifies no orphaned directory or config file is created on disk
+    (regression: guard was firing after ChatConfig.save() and set_config()).
+    """
+    conversation_id = "missing-conversation"
+    logdir = get_logs_dir() / conversation_id
+
     input_config = ChatConfig(model="openai/gpt-4o")
     input_config.tools = [t.name for t in get_toolchain(None) if not t.is_mcp]
     input_config.mcp = MCPConfig()
 
     response = client.patch(
-        "/api/v2/conversations/missing-conversation/config",
+        f"/api/v2/conversations/{conversation_id}/config",
         json=input_config.to_dict(),
     )
 
     assert response.status_code == 404
     assert response.get_json() == {
-        "error": "Conversation not found: missing-conversation"
+        "error": f"Conversation not found: {conversation_id}"
     }
+    # Verify no orphaned directory or config was created as a side effect
+    assert not logdir.exists(), f"Orphaned logdir created at {logdir}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- return a structured 404 instead of a 500 when PATCH /api/v2/conversations/<id>/config targets a missing conversation
- add a regression test for the missing-conversation config PATCH path

## Testing
- uv run pytest tests/test_server_v2.py -q
- uv run ruff check gptme/server/api_v2.py tests/test_server_v2.py