### PR TITLE
fix(server): add missing validation in POST message and config PATCH

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -481,6 +481,9 @@ def api_conversation_put(conversation_id: str):
 )
 def api_conversation_post(conversation_id: str):
     """Append a message to a conversation."""
+    if error := _validate_conversation_id(conversation_id):
+        return error
+
     req_json = flask.request.json
     if not req_json:
         return flask.jsonify({"error": "No JSON data provided"}), 400
@@ -1026,6 +1029,18 @@ def api_conversation_config_patch(conversation_id: str):
             flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
             404,
         )
+
+    # Reject config changes while generation is in progress — config PATCH rewrites
+    # system messages and mutates global state, which races with streaming.
+    sessions = SessionManager.get_sessions_for_conversation(conversation_id)
+    for sess in sessions:
+        if sess.generating:
+            return (
+                flask.jsonify(
+                    {"error": "Cannot update config while generation is in progress"}
+                ),
+                409,
+            )
 
     # Create and set config
     req_json["_logdir"] = logdir  # Pass logdir for "@log" workspace resolution

--- a/tests/test_server_path_traversal.py
+++ b/tests/test_server_path_traversal.py
@@ -124,6 +124,18 @@ class TestWorkspaceEndpointValidation:
         _assert_traversal_rejected(response)
 
 
+class TestConversationEndpointValidation:
+    """Conversation CRUD endpoints must reject path traversal in conversation_id."""
+
+    @pytest.mark.parametrize("payload", TRAVERSAL_PAYLOADS)
+    def test_post_message_rejects_traversal(self, client: FlaskClient, payload: str):
+        response = client.post(
+            f"/api/v2/conversations/{payload}",
+            json={"role": "user", "content": "test"},
+        )
+        _assert_traversal_rejected(response)
+
+
 class TestValidConversationIdAccepted:
     """Valid conversation_ids must not be rejected by path traversal checks."""
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1001,6 +1001,27 @@ def test_v2_conversation_agent_avatar_missing_conversation_returns_404(
     )
 
 
+def test_v2_chat_config_patch_rejected_during_generation(client: FlaskClient):
+    """Config PATCH should return 409 when a session is actively generating."""
+    conv = create_conversation(client)
+    conversation_id = conv["conversation_id"]
+
+    with unittest.mock.patch(
+        "gptme.server.api_v2.SessionManager.get_sessions_for_conversation"
+    ) as mock_get:
+        mock_session = unittest.mock.MagicMock()
+        mock_session.generating = True
+        mock_get.return_value = [mock_session]
+
+        response = client.patch(
+            f"/api/v2/conversations/{conversation_id}/config",
+            json={"model": "openai/gpt-4o"},
+        )
+
+    assert response.status_code == 409
+    assert "generation is in progress" in response.get_json()["error"]
+
+
 @pytest.mark.parametrize(
     "files_payload",
     [


### PR DESCRIPTION
## Summary
- **POST /conversations/<id>**: Add `_validate_conversation_id()` call — this was the only conversation endpoint missing path traversal validation (CWE-22 defense-in-depth gap)
- **PATCH /conversations/<id>/config**: Add `sess.generating` guard returning 409 — config PATCH rewrites system messages and mutates global state, which races with active generation (message PATCH and DELETE already had this guard)

## Test plan
- [x] New parametrized test: POST with traversal payloads rejected (3 cases)
- [x] New test: config PATCH returns 409 when session is generating
- [x] Full test suite: 110 passed, 4 skipped
- [x] ruff clean