### PR TITLE
fix(server): reject non-object JSON in config patch

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1004,9 +1004,11 @@ def api_conversation_config_patch(conversation_id: str):
     if error := _validate_conversation_id(conversation_id):
         return error
 
-    req_json = flask.request.json
-    if not req_json:
+    req_json = request.get_json(silent=True)
+    if req_json is None:
         return flask.jsonify({"error": "No JSON data provided"}), 400
+    if not isinstance(req_json, dict):
+        return flask.jsonify({"error": "JSON body must be an object"}), 400
 
     logdir = get_logs_dir() / conversation_id
 

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1001,14 +1001,25 @@ def test_v2_conversation_agent_avatar_missing_conversation_returns_404(
     )
 
 
-def test_v2_chat_config_patch_rejects_non_object_json(client: FlaskClient):
+@pytest.mark.parametrize(
+    "body",
+    [
+        [],  # empty array — was rejected by old truthiness guard
+        [1, 2, 3],  # non-empty array — the real regression: old guard accepted this
+        "string",  # JSON string
+        42,  # JSON number
+    ],
+)
+def test_v2_chat_config_patch_rejects_non_object_json(
+    client: FlaskClient, body: object
+):
     """Config PATCH should reject JSON arrays/strings before config parsing."""
     conv = create_conversation(client)
     conversation_id = conv["conversation_id"]
 
     response = client.patch(
         f"/api/v2/conversations/{conversation_id}/config",
-        json=[],
+        json=body,
     )
 
     assert response.status_code == 400

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1001,6 +1001,20 @@ def test_v2_conversation_agent_avatar_missing_conversation_returns_404(
     )
 
 
+def test_v2_chat_config_patch_rejects_non_object_json(client: FlaskClient):
+    """Config PATCH should reject JSON arrays/strings before config parsing."""
+    conv = create_conversation(client)
+    conversation_id = conv["conversation_id"]
+
+    response = client.patch(
+        f"/api/v2/conversations/{conversation_id}/config",
+        json=[],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON body must be an object"}
+
+
 def test_v2_chat_config_patch_rejected_during_generation(client: FlaskClient):
     """Config PATCH should return 409 when a session is actively generating."""
     conv = create_conversation(client)


### PR DESCRIPTION
## Summary
- reject JSON arrays/strings in `PATCH /api/v2/conversations/<id>/config`
- use `request.get_json(silent=True)` so malformed/empty input stays a clean 400
- add a regression test covering non-object JSON bodies

## Why
`config` PATCH was still using `flask.request.json` and only checking truthiness. That meant non-object JSON like `[]` could slip through to `ChatConfig.from_dict(...)`, which is the wrong layer to fail in and can produce ugly/less-stable behavior. The endpoint should match the stricter JSON-object validation already used elsewhere.

## Testing
- `uv run --active pytest tests/test_server_v2.py -k 'chat_config' -q`
- `uv run --active ruff format gptme/server/api_v2.py tests/test_server_v2.py`
- `uv run --active ruff check gptme/server/api_v2.py tests/test_server_v2.py`
