### PR TITLE
fix(server): 404 orphaned conversation avatar requests

### DIFF
--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1122,6 +1122,14 @@ def api_conversation_agent_avatar(conversation_id: str):
             404,
         )
 
+    try:
+        LogManager.load(conversation_id, lock=False)
+    except FileNotFoundError:
+        return (
+            flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),
+            404,
+        )
+
     chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
 
     agent_config = chat_config.agent_config

--- a/gptme/server/api_v2.py
+++ b/gptme/server/api_v2.py
@@ -1123,7 +1123,7 @@ def api_conversation_agent_avatar(conversation_id: str):
         )
 
     try:
-        LogManager.load(conversation_id, lock=False)
+        LogManager.load(logdir, lock=False)
     except FileNotFoundError:
         return (
             flask.jsonify({"error": f"Conversation not found: {conversation_id}"}),

--- a/tests/test_server_path_traversal.py
+++ b/tests/test_server_path_traversal.py
@@ -334,10 +334,19 @@ class TestAvatarPathSecurity:
         mock_chat_config.agent_config.avatar = "id_rsa"
         mock_chat_config.agent = agent_dir
 
-        # Create the logdir so the conversation-exists guard passes
+        # Create the logdir and a valid conversation log so the
+        # conversation-exists guards pass and the test reaches avatar
+        # validation.
+        from gptme.logmanager import LogManager
+        from gptme.message import Message
+
         logs_dir = tmp_path / "logs"
         conv_logdir = logs_dir / "test-conv"
-        conv_logdir.mkdir(parents=True)
+        LogManager.load(
+            logdir=conv_logdir,
+            initial_msgs=[Message("user", "hi")],
+            create=True,
+        ).write()
 
         monkeypatch.setattr(
             "gptme.server.api_v2.get_logs_dir",

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1001,6 +1001,25 @@ def test_v2_conversation_agent_avatar_missing_conversation_returns_404(
     )
 
 
+def test_v2_conversation_agent_avatar_orphaned_logdir_returns_404(
+    client: FlaskClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Avatar endpoint should reject logdirs without a conversation log."""
+    logdir = tmp_path / "logs" / "orphaned-avatar-conversation"
+    logdir.mkdir(parents=True)
+
+    monkeypatch.setattr("gptme.server.api_v2.get_logs_dir", lambda: tmp_path / "logs")
+
+    response = client.get(
+        "/api/v2/conversations/orphaned-avatar-conversation/agent/avatar"
+    )
+
+    assert response.status_code == 404
+    assert response.get_json() == {
+        "error": "Conversation not found: orphaned-avatar-conversation"
+    }
+
+
 @pytest.mark.parametrize(
     "body",
     [


### PR DESCRIPTION
## Summary
- return 404 from the conversation avatar endpoint when the logdir exists but the conversation log is missing
- add a regression test for orphaned avatar logdirs
- update the avatar path traversal test to create a real conversation log so it still exercises non-image validation

## Testing
- uv run --active pytest tests/test_server_path_traversal.py::TestAvatarPathSecurity::test_conversation_agent_avatar_rejects_non_image_extension -q
- uv run --active pytest tests/test_server_v2.py -k 'avatar_missing_conversation or orphaned_logdir_returns_404 or chat_config_update_missing_conversation_returns_404 or chat_config_patch_rejected_during_generation' -q
- uv run --active ruff check gptme/server/api_v2.py tests/test_server_v2.py tests/test_server_path_traversal.py
- uv run --active ruff format --check gptme/server/api_v2.py tests/test_server_v2.py tests/test_server_path_traversal.py
