### PR TITLE
fix(server): reject non-object JSON in task PATCH endpoint

### DIFF
--- a/gptme/server/tasks_api.py
+++ b/gptme/server/tasks_api.py
@@ -831,8 +831,8 @@ def api_tasks_update(task_id: str):
         return flask.jsonify({"error": f"Task not found: {task_id}"}), 404
 
     req_json = flask.request.json
-    if not req_json:
-        return flask.jsonify({"error": "No JSON data provided"}), 400
+    if not req_json or not isinstance(req_json, dict):
+        return flask.jsonify({"error": "Request body must be a JSON object"}), 400
 
     # Validate field types before applying
     if "content" in req_json and not isinstance(req_json["content"], str):

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1368,11 +1368,11 @@ def test_v2_create_conversation_non_string_timestamp(client: FlaskClient):
 
 
 @pytest.mark.parametrize("body", [[], [1, 2, 3], "string", 42])
-def test_v2_tasks_patch_rejects_non_object_json(client: FlaskClient, body: object):
-    """Task PATCH should reject non-object JSON bodies with 400."""
+def test_v2_tasks_put_rejects_non_object_json(client: FlaskClient, body: object):
+    """Task PUT should reject non-object JSON bodies with 400."""
     create_resp = client.post(
         "/api/v2/tasks",
-        json={"content": "test task for patch validation"},
+        json={"content": "test task for put validation"},
     )
     assert create_resp.status_code == 201
     task_id = create_resp.get_json()["id"]

--- a/tests/test_server_v2.py
+++ b/tests/test_server_v2.py
@@ -1365,3 +1365,21 @@ def test_v2_create_conversation_non_string_timestamp(client: FlaskClient):
     data = response.get_json()
     assert data is not None
     assert "timestamp" in data["error"].lower()
+
+
+@pytest.mark.parametrize("body", [[], [1, 2, 3], "string", 42])
+def test_v2_tasks_patch_rejects_non_object_json(client: FlaskClient, body: object):
+    """Task PATCH should reject non-object JSON bodies with 400."""
+    create_resp = client.post(
+        "/api/v2/tasks",
+        json={"content": "test task for patch validation"},
+    )
+    assert create_resp.status_code == 201
+    task_id = create_resp.get_json()["id"]
+
+    response = client.put(
+        f"/api/v2/tasks/{task_id}",
+        json=body,
+    )
+    assert response.status_code == 400
+    assert "object" in response.get_json()["error"].lower()


### PR DESCRIPTION
## Summary
- Add `isinstance(req_json, dict)` type check to the `PUT /api/v2/tasks/<task_id>` endpoint
- Without this, non-dict JSON bodies (arrays, strings, integers) pass the truthiness check and cause unexpected behavior when dict methods are called
- Consistent with the same pattern applied in #2138 and #2139 for other endpoints

## Test plan
- [x] Added parametrized test with `[]`, `[1, 2, 3]`, `"string"`, and `42` bodies — all return 400
- [x] Full `test_server_v2.py` suite passes (59 passed, 4 skipped)