### PR TITLE
fix(server): reject non-object JSON in agent creation

### DIFF
--- a/gptme/server/api_v2_agents.py
+++ b/gptme/server/api_v2_agents.py
@@ -55,8 +55,8 @@ agents_api = flask.Blueprint("agents_api", __name__)
 def api_agents_put():
     """Create a new agent."""
     req_json = flask.request.json
-    if not req_json:
-        return flask.jsonify({"error": "No JSON data provided"}), 400
+    if not req_json or not isinstance(req_json, dict):
+        return flask.jsonify({"error": "Request body must be a JSON object"}), 400
 
     agent_name = req_json.get("name")
     if not agent_name:

--- a/tests/test_server_path_traversal.py
+++ b/tests/test_server_path_traversal.py
@@ -458,6 +458,19 @@ class TestAgentCreationPathValidation:
         data = response.get_json()
         assert data["error"] == "Path must be within the server working directory"
 
+    @pytest.mark.parametrize("body", [[], [1, 2, 3], "string", 42])
+    def test_rejects_non_object_json_body(self, client: FlaskClient, body: object):
+        """Agent creation should reject non-object JSON bodies with 400."""
+        response = client.put(
+            "/api/v2/agents",
+            json=body,
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data is not None
+        assert data["error"] == "Request body must be a JSON object"
+
     def test_rejects_name_that_slugifies_to_empty(
         self, client: FlaskClient, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## Summary
- reject truthy non-object JSON bodies in `PUT /api/v2/agents`
- return a consistent 400 error instead of crashing with `AttributeError`
- add regression coverage for arrays, strings, and integers

## Testing
- `uv run pytest tests/test_server_path_traversal.py -q`
- `uv run pytest tests/test_server_path_traversal.py -q -k non_object_json_body`
- `uv run ruff check gptme/server/api_v2_agents.py tests/test_server_path_traversal.py`
- `uv run ruff format --check gptme/server/api_v2_agents.py tests/test_server_path_traversal.py`
