### PR TITLE
fix(server): reject non-object JSON in session endpoints

### DIFF
--- a/gptme/server/api_v2_agents.py
+++ b/gptme/server/api_v2_agents.py
@@ -55,7 +55,7 @@ agents_api = flask.Blueprint("agents_api", __name__)
 def api_agents_put():
     """Create a new agent."""
     req_json = flask.request.json
-    if not req_json or not isinstance(req_json, dict):
+    if req_json is None or not isinstance(req_json, dict):
         return flask.jsonify({"error": "Request body must be a JSON object"}), 400
 
     agent_name = req_json.get("name")

--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -60,6 +60,20 @@ from .session_step import (  # noqa: F401
 logger = logging.getLogger(__name__)
 
 
+def _get_request_json_object() -> dict | tuple[flask.Response, int]:
+    """Return request JSON as an object or a 400 error response.
+
+    Session endpoints expect JSON objects. Arrays/strings/numbers would make
+    later `.get()` access crash with AttributeError and return 500s.
+    """
+    req_json = request.get_json(silent=True)
+    if req_json is None:
+        return {}
+    if not isinstance(req_json, dict):
+        return flask.jsonify({"error": "JSON body must be an object"}), 400
+    return req_json
+
+
 # Re-export step-level symbols that other modules may import from here.
 # This preserves backward compatibility after the split.
 __all__ = [
@@ -231,7 +245,9 @@ def api_conversation_step(conversation_id: str):
     """Take a step in the conversation - generate a response or continue after tool execution."""
     if error := _validate_conversation_id(conversation_id):
         return error
-    req_json = flask.request.json or {}
+    req_json = _get_request_json_object()
+    if not isinstance(req_json, dict):
+        return req_json
     session_id = req_json.get("session_id")
 
     if not session_id:
@@ -472,7 +488,9 @@ def api_conversation_tool_confirm(conversation_id: str):
     if error := _validate_conversation_id(conversation_id):
         return error
 
-    req_json = flask.request.json or {}
+    req_json = _get_request_json_object()
+    if not isinstance(req_json, dict):
+        return req_json
     session_id = req_json.get("session_id")
     tool_id = req_json.get("tool_id")
     action = req_json.get("action")
@@ -621,7 +639,9 @@ def api_conversation_rerun(conversation_id: str):
         return error
     from ..tools import ToolUse
 
-    req_json = request.json or {}
+    req_json = _get_request_json_object()
+    if not isinstance(req_json, dict):
+        return req_json
     session_id = req_json.get("session_id")
 
     if not session_id:
@@ -733,7 +753,9 @@ def api_conversation_elicit_respond(conversation_id: str):
     """
     if error := _validate_conversation_id(conversation_id):
         return error
-    req_json = flask.request.json or {}
+    req_json = _get_request_json_object()
+    if not isinstance(req_json, dict):
+        return req_json
     elicit_id = req_json.get("elicit_id")
     action = req_json.get("action")
 
@@ -776,7 +798,9 @@ def api_conversation_interrupt(conversation_id: str):
     """Interrupt the current generation or tool execution."""
     if error := _validate_conversation_id(conversation_id):
         return error
-    req_json = flask.request.json or {}
+    req_json = _get_request_json_object()
+    if not isinstance(req_json, dict):
+        return req_json
     session_id = req_json.get("session_id")
 
     if not session_id:

--- a/tests/test_server_v2_sessions.py
+++ b/tests/test_server_v2_sessions.py
@@ -154,6 +154,31 @@ class TestStepEndpoint:
 # --- Interrupt endpoint tests ---
 
 
+@pytest.mark.parametrize(
+    "endpoint", ["step", "tool/confirm", "rerun", "elicit/respond", "interrupt"]
+)
+@pytest.mark.parametrize(
+    "body",
+    [
+        [],
+        [1, 2, 3],
+        "string",
+        42,
+    ],
+)
+def test_session_endpoints_reject_non_object_json(
+    conv, client: FlaskClient, endpoint: str, body: object
+):
+    """Session endpoints should reject non-object JSON bodies with 400."""
+    response = client.post(
+        f"/api/v2/conversations/{conv['conversation_id']}/{endpoint}",
+        json=body,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON body must be an object"}
+
+
 class TestInterruptEndpoint:
     """Test POST /api/v2/conversations/<id>/interrupt validation."""
 


### PR DESCRIPTION
## Summary
- reject non-object JSON bodies across V2 session endpoints before any `.get()` access
- add shared helper in `api_v2_sessions.py` for consistent request validation
- add regression coverage for step, tool confirm, rerun, elicit respond, and interrupt

## Testing
- uv run pytest /home/bob/gptme/tests/test_server_v2_sessions.py -q
- uv run ruff check /home/bob/gptme/gptme/server/api_v2_sessions.py /home/bob/gptme/tests/test_server_v2_sessions.py
