### PR TITLE
fix(agent): use function timeout for fork command instead of hardcoded 120s

### DIFF
--- a/gptme/agent/workspace.py
+++ b/gptme/agent/workspace.py
@@ -136,7 +136,7 @@ def create_workspace_from_template(
                 capture_output=True,
                 check=False,
                 cwd=temp_dir,
-                timeout=120,
+                timeout=timeout,
                 env=env,
             )
             if result.returncode != 0:


### PR DESCRIPTION
## Problem

`test_create_template_mode_e2e` was failing on master CI with two cascading bugs:

**Bug 1 (root cause)**: `create_workspace_from_template()` has a `timeout` parameter (default 300s) that controls git operations. The clone and submodule steps respect it, but the `fork.sh` subprocess call had a **hardcoded** `timeout=120s` that ignored the parameter entirely.

In CI, when GitHub is slow, the `fork.sh` clone timed out at 120s → `pytest-retry` retried → test passed on attempt 2, but **Bug 2** then crashed teardown.

**Bug 2 (secondary)**: `pytest-retry` + `pytest-xdist` have a compatibility bug where, after a successful retry, the `tmp_path` fixture teardown crashes with:
```
KeyError: <_pytest.stash.StashKey object at ...>
result_dict = request.node.stash[tmppath_result_key]
```
This turns a passing test into an `ERROR`, failing CI even though all tests passed.

## Fix

Change `timeout=120` → `timeout=timeout` in the fork command subprocess call. This:
- Respects the caller's intent (300s default matches the clone/submodule operations)
- Reduces CI timeouts, which eliminates retries and avoids Bug 2 entirely

The pytest-retry + xdist + tmp_path teardown bug is a known upstream issue and not fixed here, but making the test rarely need retries is the practical mitigation.

## Test

This fix is verified by the CI pattern itself — the test passes on attempt 2 (with 300s), so giving the fork command the full timeout means it should succeed on attempt 1 in CI.