### PR TITLE
fix(models): update OpenRouter Anthropic model IDs to dot notation

### DIFF
--- a/gptme/eval/leaderboard.py
+++ b/gptme/eval/leaderboard.py
@@ -132,8 +132,13 @@ def normalize_model(model: str) -> str:
         "openrouter/x-ai/grok-4-fast:free": "Grok 4 Fast",
         "openrouter/x-ai/grok-code-fast-1": "Grok Code Fast",
         "openrouter/z-ai/glm-5": "GLM-5",
-        # OpenRouter-proxied versions of direct-API models
+        # OpenRouter-proxied versions of direct-API models (dot notation — current OpenRouter naming)
         "openrouter/openai/gpt-4o-mini": "GPT-4o Mini (OR)",
+        "openrouter/anthropic/claude-sonnet-4.6": "Claude Sonnet 4.6 (OR)",
+        "openrouter/anthropic/claude-sonnet-4.5": "Claude Sonnet 4.5 (OR)",
+        "openrouter/anthropic/claude-haiku-4.5": "Claude Haiku 4.5 (OR)",
+        "openrouter/anthropic/claude-opus-4.6": "Claude Opus 4.6 (OR)",
+        # Legacy hyphen notation — kept for eval history backward compatibility
         "openrouter/anthropic/claude-sonnet-4-6": "Claude Sonnet 4.6 (OR)",
         "openrouter/anthropic/claude-sonnet-4-5": "Claude Sonnet 4.5 (OR)",
         "openrouter/anthropic/claude-haiku-4-5": "Claude Haiku 4.5 (OR)",

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -322,9 +322,9 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
         },
         "anthropic/claude-haiku-4.5": {
             "context": 200_000,
-            "max_output": 8_096,
-            "price_input": 0.8,
-            "price_output": 4,
+            "max_output": 64_000,
+            "price_input": 1,
+            "price_output": 5,
             "supports_vision": True,
         },
         "meta-llama/llama-3.3-70b-instruct": {

--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -310,7 +310,7 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             # "supports_vision": True,
             "supports_reasoning": True,
         },
-        "anthropic/claude-sonnet-4-6": {
+        "anthropic/claude-sonnet-4.6": {
             "context": 1_000_000,
             "max_output": 64_000,
             # NOTE: at >200k context price is 2x for input and 1.5x for output
@@ -319,6 +319,13 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "supports_vision": True,
             "supports_reasoning": True,
             "supports_parallel_tool_calls": True,
+        },
+        "anthropic/claude-haiku-4.5": {
+            "context": 200_000,
+            "max_output": 8_096,
+            "price_input": 0.8,
+            "price_output": 4,
+            "supports_vision": True,
         },
         "meta-llama/llama-3.3-70b-instruct": {
             "context": 128_000,

--- a/tests/test_llm_models.py
+++ b/tests/test_llm_models.py
@@ -388,8 +388,8 @@ class TestSupportsParallelToolCalls:
         assert model.supports_parallel_tool_calls is True
 
     def test_openrouter_claude_sonnet_4_6_supports_parallel(self):
-        """claude-sonnet-4-6 via OpenRouter should also support parallel tool calls."""
-        model = get_model("openrouter/anthropic/claude-sonnet-4-6")
+        """claude-sonnet-4.6 via OpenRouter should also support parallel tool calls."""
+        model = get_model("openrouter/anthropic/claude-sonnet-4.6")
         assert model.supports_parallel_tool_calls is True
 
     def test_unknown_model_defaults_to_false(self):


### PR DESCRIPTION
## Summary

OpenRouter changed their Anthropic model naming convention around April 14, 2026:
- **Old** (broken): `anthropic/claude-haiku-4-5-20251001`, `anthropic/claude-sonnet-4-6`
- **New** (current): `anthropic/claude-haiku-4.5`, `anthropic/claude-sonnet-4.6`

The old IDs now return `"anthropic/claude-haiku-4-5-20251001 is not a valid model ID"` from OpenRouter, causing all `openrouter/anthropic/*` eval runs to fail with 0/3 pass rate since Apr 14.

## Changes

- **`gptme/llm/models/data.py`**: Rename `anthropic/claude-sonnet-4-6` → `anthropic/claude-sonnet-4.6` and add `anthropic/claude-haiku-4.5` with pricing/context info in the OpenRouter static models dict
- **`gptme/eval/leaderboard.py`**: Add dot-notation display names; keep hyphen entries as legacy aliases so existing eval history still renders with correct display names
- **`tests/test_llm_models.py`**: Update openrouter parallel tool call test to use correct dot notation

## Verification

- All 86 model resolution tests pass with the new data
- The hyphen-notation fallback still works via `_find_closest_model_properties` (family prefix "anthropic" matches all `anthropic/*` entries)
- Eval history with old hyphen IDs continues to display correctly in the leaderboard