### PR TITLE
fix(dx): improve first-run experience with config detection and actionable errors

### DIFF
--- a/gptme/cli/onboard.py
+++ b/gptme/cli/onboard.py
@@ -40,13 +40,17 @@ PROVIDER_ENV_VARS = {
 
 def _detect_providers() -> dict[str, tuple[bool, str | None]]:
     """
-    Detect which providers have API keys configured.
+    Detect which providers have API keys configured (in env or config file).
+
+    Checks environment variables first, then falls back to the config file
+    for API keys stored in the ``[env]`` section or a model set in ``[chat]``.
 
     Returns:
         Dict mapping provider name to (has_key, key_preview)
     """
     results: dict[str, tuple[bool, str | None]] = {}
 
+    # Check environment variables (highest priority, shows key preview)
     for provider, env_var in PROVIDER_ENV_VARS.items():
         key = os.environ.get(env_var)
         if key:
@@ -56,16 +60,51 @@ def _detect_providers() -> dict[str, tuple[bool, str | None]]:
         else:
             results[provider] = (False, None)
 
+    # Also check config file for API keys and configured model
+    try:
+        from ..config import get_config
+
+        config = get_config()
+
+        # Check config [env] section for API keys not found in environment
+        for provider, env_var in PROVIDER_ENV_VARS.items():
+            if not results.get(provider, (False,))[0]:
+                config_key = config.get_env(env_var)
+                if config_key:
+                    preview = (
+                        f"{config_key[:4]}...{config_key[-4:]}"
+                        if len(config_key) > 10
+                        else "***"
+                    )
+                    results[provider] = (True, f"{preview} (config)")
+
+        # Check if a model is already configured (implies provider is available)
+        model = (config.chat.model if config.chat else None) or config.get_env("MODEL")
+        if model and "/" in model:
+            provider_name = model.split("/")[0]
+            if provider_name in results and not results[provider_name][0]:
+                results[provider_name] = (True, f"(model: {model})")
+    except Exception:
+        pass  # Config not available yet — env var detection is sufficient
+
     return results
 
 
 def _test_provider(provider: str) -> tuple[bool, str]:
-    """Test if a provider is working."""
+    """Test if a provider is working (checks env vars and config file)."""
     env_var = PROVIDER_ENV_VARS.get(provider)
     if not env_var:
         return False, f"Unknown provider: {provider}"
 
+    # Check env var first, then config file
     api_key = os.environ.get(env_var)
+    if not api_key:
+        try:
+            from ..config import get_config
+
+            api_key = get_config().get_env(env_var)
+        except Exception:
+            pass
     if not api_key:
         return False, f"No API key found (set {env_var})"
 
@@ -206,11 +245,18 @@ def _run_wizard(check_only: bool = False) -> int:
     if not available_providers:
         console.print("\n[red]❌ No API keys detected![/red]")
         console.print("\nTo use gptme, you need at least one API key.")
-        console.print("Set one of these environment variables:")
-        console.print("  • OPENAI_API_KEY for OpenAI (GPT-4)")
-        console.print("  • ANTHROPIC_API_KEY for Anthropic (Claude)")
-        console.print("  • OPENROUTER_API_KEY for OpenRouter (multiple providers)")
-        console.print("\nSee: https://gptme.org/docs/providers.html")
+        console.print(
+            "\n[bold]Quick start[/bold] — set one of these environment variables:"
+        )
+        console.print("  export ANTHROPIC_API_KEY='sk-ant-...'")
+        console.print("  export OPENAI_API_KEY='sk-...'")
+        console.print("  export OPENROUTER_API_KEY='sk-or-...'")
+        console.print(
+            "\nThen re-run [bold]gptme-onboard[/bold] or just start with [bold]gptme[/bold]."
+        )
+        console.print(
+            "\nFull guide: https://gptme.org/docs/getting-started.html#api-keys"
+        )
         return 1
 
     if check_only:

--- a/gptme/init.py
+++ b/gptme/init.py
@@ -105,9 +105,18 @@ def init_model(
     if not model and interactive:
         model, _ = ask_for_api_key()
 
-    # fail
+    # fail with actionable guidance
     if not model:
-        raise ValueError("No API key found, couldn't auto-detect provider")
+        raise ValueError(
+            "No API key found, couldn't auto-detect provider.\n\n"
+            "To get started, set an API key for one of these providers:\n"
+            "  export ANTHROPIC_API_KEY='sk-ant-...'\n"
+            "  export OPENAI_API_KEY='sk-...'\n"
+            "  export OPENROUTER_API_KEY='sk-or-...'\n\n"
+            "Or run interactively: gptme\n"
+            "Or run the setup wizard: gptme-onboard\n\n"
+            "Full guide: https://gptme.org/docs/getting-started.html"
+        )
 
     # Check if model has provider/model format
     if "/" in model:

--- a/tests/test_onboard.py
+++ b/tests/test_onboard.py
@@ -1,16 +1,24 @@
 """Tests for gptme onboard module."""
 
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from gptme.cli.onboard import _detect_providers, _test_provider
+
+
+def _mock_empty_config():
+    """Return a mock config with no API keys or model configured."""
+    mock_config = MagicMock()
+    mock_config.get_env.return_value = None
+    mock_config.chat = None
+    return mock_config
 
 
 class TestDetectProviders:
     """Test provider detection."""
 
     def test_detect_no_keys(self):
-        """Test detection with no API keys set."""
+        """Test detection with no API keys set (env or config)."""
         # Clear relevant env vars
         env_vars = [
             "OPENAI_API_KEY",
@@ -23,14 +31,16 @@ class TestDetectProviders:
             for k in env_vars:
                 os.environ.pop(k, None)
 
-            providers = _detect_providers()
-            # All should be not configured
-            for provider, (has_key, _) in providers.items():
-                if provider in ["openai", "anthropic", "openrouter", "gemini"]:
-                    assert not has_key, f"{provider} should not be detected"
+            # Mock config to return no keys either
+            with patch("gptme.config.get_config", return_value=_mock_empty_config()):
+                providers = _detect_providers()
+                # All should be not configured
+                for provider, (has_key, _) in providers.items():
+                    if provider in ["openai", "anthropic", "openrouter", "gemini"]:
+                        assert not has_key, f"{provider} should not be detected"
 
-    def test_detect_with_keys(self):
-        """Test detection with API keys set."""
+    def test_detect_with_env_keys(self):
+        """Test detection with API keys set in environment."""
         with patch.dict(
             os.environ,
             {"OPENAI_API_KEY": "sk-test1234567890abcdef"},
@@ -43,6 +53,45 @@ class TestDetectProviders:
             assert "sk-t" in preview  # First 4 chars
             assert "cdef" in preview  # Last 4 chars
 
+    def test_detect_with_config_keys(self):
+        """Test detection finds API keys in config file."""
+        env_vars = ["ANTHROPIC_API_KEY"]
+        with patch.dict(os.environ, dict.fromkeys(env_vars, ""), clear=False):
+            for k in env_vars:
+                os.environ.pop(k, None)
+
+            # Mock config to return an API key
+            mock_config = _mock_empty_config()
+            mock_config.get_env.side_effect = lambda key: (
+                "sk-ant-test1234567890" if key == "ANTHROPIC_API_KEY" else None
+            )
+            with patch("gptme.config.get_config", return_value=mock_config):
+                providers = _detect_providers()
+                has_key, preview = providers.get("anthropic", (False, None))
+                assert has_key, "Anthropic should be detected from config"
+                assert preview is not None
+                assert "(config)" in preview
+
+    def test_detect_with_config_model(self):
+        """Test detection finds provider from configured model."""
+        env_vars = ["OPENAI_API_KEY"]
+        with patch.dict(os.environ, dict.fromkeys(env_vars, ""), clear=False):
+            for k in env_vars:
+                os.environ.pop(k, None)
+
+            # Mock config with a model set but no API key
+            mock_config = _mock_empty_config()
+            mock_config.get_env.return_value = None
+            mock_chat = MagicMock()
+            mock_chat.model = "openai/gpt-4o"
+            mock_config.chat = mock_chat
+            with patch("gptme.config.get_config", return_value=mock_config):
+                providers = _detect_providers()
+                has_key, preview = providers.get("openai", (False, None))
+                assert has_key, "OpenAI should be detected from config model"
+                assert preview is not None
+                assert "model:" in preview
+
 
 class TestTestProvider:
     """Test provider connectivity testing."""
@@ -54,9 +103,11 @@ class TestTestProvider:
         assert "Unknown provider" in error
 
     def test_missing_key(self):
-        """Test with missing API key."""
+        """Test with missing API key (env and config)."""
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("OPENAI_API_KEY", None)
-            is_valid, error = _test_provider("openai")
-            assert not is_valid
-            assert "No API key found" in error
+            # Mock config to also have no key
+            with patch("gptme.config.get_config", return_value=_mock_empty_config()):
+                is_valid, error = _test_provider("openai")
+                assert not is_valid
+                assert "No API key found" in error


### PR DESCRIPTION
## Summary

Three targeted improvements to the first-run experience for new gptme users:

- **Actionable error message in `init.py`**: When no API key is found in non-interactive mode, the error now shows exactly which env vars to set, how to run interactively, and links to the getting started guide. Previously it was just `"No API key found, couldn't auto-detect provider"`.

- **Config-file provider detection in `onboard.py`**: The onboarding wizard now checks the config file (`~/.config/gptme/config.toml`) for API keys in the `[env]` section and models in `[chat]`, not just environment variables. Users who already configured gptme via config file no longer get told "no providers found".

- **Better "no providers" messaging**: The onboard wizard shows copy-pasteable `export` commands, references the correct CLI tools (`gptme-onboard`, `gptme`), and links to the full getting started guide.

Resolves the TODO comment at `onboard.py:60`.

## Test plan

- [x] All 6 onboard tests pass (including 2 new tests for config detection)
- [x] All 70 init tests pass
- [x] mypy clean on changed files
- [ ] CI green