### PR TITLE
fix(dx): improve error messages with actionable context

### DIFF
--- a/gptme/server/acp_session_runtime.py
+++ b/gptme/server/acp_session_runtime.py
@@ -145,7 +145,11 @@ class AcpSessionRuntime:
             await self.start()
 
         if self._client is None or self._session_id is None:
-            raise RuntimeError("ACP runtime failed to initialize")
+            raise RuntimeError(
+                "ACP runtime failed to initialize: "
+                f"client={'connected' if self._client else 'None'}, "
+                f"session_id={self._session_id!r}"
+            )
 
         resp = await self._client.prompt(self._session_id, message)
         text = extract_text_from_prompt_response(resp)

--- a/gptme/server/workspace_api.py
+++ b/gptme/server/workspace_api.py
@@ -167,7 +167,9 @@ def safe_workspace_path(workspace: Path, path: str | None = None) -> Path:
 
     # Check if path is within workspace
     if not full_path.is_relative_to(workspace):
-        raise ValueError("Path escapes workspace")
+        raise ValueError(
+            f"Path escapes workspace: '{path}' resolves outside '{workspace}'"
+        )
 
     return full_path
 
@@ -208,7 +210,7 @@ def list_directory(
         List of file metadata
     """
     if not path.is_dir():
-        raise ValueError("Path is not a directory")
+        raise ValueError(f"Path is not a directory: {path}")
 
     files = []
     for item in path.iterdir():

--- a/gptme/tools/patch.py
+++ b/gptme/tools/patch.py
@@ -100,11 +100,18 @@ class Patch:
     def apply(self, content: str) -> str:
         # Fast path: try exact match first (backward compatible)
         if self.original in content:
-            if content.count(self.original) > 1:
-                raise ValueError("original chunk not unique")
+            count = content.count(self.original)
+            if count > 1:
+                raise ValueError(
+                    f"original chunk is not unique ({count} matches found). "
+                    "Provide more surrounding context to make the match unique."
+                )
             new_content = content.replace(self.original, self.updated, 1)
             if new_content == content:
-                raise ValueError("patch did not change the file")
+                raise ValueError(
+                    "patch did not change the file "
+                    "(original and updated chunks are identical)"
+                )
             return new_content
 
         # Fallback: try relaxed matching (treat whitespace-only lines as equivalent)
@@ -121,7 +128,10 @@ class Patch:
         # Apply the replacement using the actual matched content
         new_content = content.replace(actual_original, self.updated, 1)
         if new_content == content:
-            raise ValueError("patch did not change the file")
+            raise ValueError(
+                "patch did not change the file "
+                "(original and updated chunks are identical)"
+            )
         return new_content
 
     def _find_relaxed_match(self, content: str) -> str | None:
@@ -146,7 +156,9 @@ class Patch:
             return None
         if len(matches) > 1:
             raise ValueError(
-                "original chunk not unique (multiple matches with relaxed whitespace matching)"
+                f"original chunk is not unique ({len(matches)} matches with "
+                "relaxed whitespace matching). "
+                "Provide more surrounding context to make the match unique."
             )
 
         return matches[0][1]


### PR DESCRIPTION
## Summary

Improve error messages across the codebase to include actionable context instead of generic strings:

- **Patch tool**: When `original chunk is not unique`, now shows the match count (e.g. "3 matches found") and suggests providing more surrounding context. When original and updated chunks are identical, explicitly says so instead of the ambiguous "patch did not change the file".
- **Workspace API**: The "Path escapes workspace" error now includes the attempted path and workspace boundary, making path traversal debugging much easier. "Path is not a directory" now includes the path.
- **ACP runtime**: Initialization failure now shows client connection state and session ID, replacing a bare "ACP runtime failed to initialize".

## Test plan

- [x] All existing tests pass (19 pass, 3 skipped in affected test files)
- [x] Regex-based test assertions still match (e.g. `match="escapes workspace"`)
- [x] mypy clean on all 3 changed files