### PR TITLE
feat(models): add claude-opus-4-7 and anthropic/claude-opus-4.7 (OpenRouter)

### DIFF
--- a/gptme/llm/models/data.py
+++ b/gptme/llm/models/data.py
@@ -18,6 +18,19 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
     # https://docs.anthropic.com/en/docs/about-claude/models
     # Active models here; deprecated models in llm_anthropic_models_deprecated.py
     "anthropic": {
+        "claude-opus-4-7": {
+            "context": 1_000_000,
+            "max_output": 128_000,
+            # NOTE: at >200k context price is 2x for input and 1.5x for output
+            "price_input": 5,
+            "price_output": 25,
+            "supports_vision": True,
+            "supports_reasoning": True,
+            "supports_parallel_tool_calls": True,
+            "knowledge_cutoff": datetime(
+                2025, 8, 1, tzinfo=timezone.utc
+            ),  # training cutoff Aug 2025
+        },
         "claude-opus-4-6": {
             "context": 1_000_000,
             "max_output": 128_000,
@@ -309,6 +322,16 @@ MODELS: dict[Provider, dict[str, _ModelDictMeta]] = {
             "price_output": 5,
             # "supports_vision": True,
             "supports_reasoning": True,
+        },
+        "anthropic/claude-opus-4.7": {
+            "context": 1_000_000,
+            "max_output": 128_000,
+            # NOTE: at >200k context price is 2x for input and 1.5x for output
+            "price_input": 5,
+            "price_output": 25,
+            "supports_vision": True,
+            "supports_reasoning": True,
+            "supports_parallel_tool_calls": True,
         },
         "anthropic/claude-sonnet-4.6": {
             "context": 1_000_000,

--- a/tests/test_llm_models.py
+++ b/tests/test_llm_models.py
@@ -298,7 +298,7 @@ class TestClosestModelMatch:
         """An unknown claude-opus variant should inherit from the latest known opus."""
         model = get_model("anthropic/claude-opus-5-0")
         assert model.provider == "anthropic"
-        assert model.context == 1_000_000  # claude-opus-4-6 has 1M context (GA)
+        assert model.context == 1_000_000  # claude-opus-4-7 has 1M context (GA)
         assert model.supports_reasoning is True
         # Opus is more expensive than sonnet
         assert model.price_input >= 5


### PR DESCRIPTION
## Summary

- Adds `claude-opus-4-7` to the native Anthropic model registry (the latest Claude Opus model, successor to `claude-opus-4-6`)
- Adds `anthropic/claude-opus-4.7` to the OpenRouter section (matching the dot-notation format added in #2149)

## Properties

Inherits from `claude-opus-4-6` (same price tier and capabilities):
- 1M context, 128K max output
- $5/$25 per M input/output tokens  
- Supports vision, reasoning, parallel tool calls
- Knowledge cutoff: Aug 2025

The existing fallback in `_find_closest_model_properties()` would have picked `claude-opus-4-6` anyway for unknown variants of this model family, but having it explicitly in the registry gives accurate model listing and avoids the debug log warning.

## Test plan

- [ ] `uv run pytest tests/test_llm_models.py tests/test_llm_models_resolution.py` — 134 tests pass
- [ ] `gptme --model anthropic/claude-opus-4-7 "hello"` — model resolves without warning