### PR TITLE
fix(doctor): show warning when Anthropic API key quota is exhausted

### DIFF
--- a/gptme/cli/doctor.py
+++ b/gptme/cli/doctor.py
@@ -111,12 +111,23 @@ def _check_api_keys(verbose: bool = False) -> list[CheckResult]:
             if api_key:
                 # Validate the key
                 is_valid, error_msg = validate_api_key(api_key, provider)
-                if is_valid:
+                if is_valid and not error_msg:
                     results.append(
                         CheckResult(
                             name=f"API Key: {provider}",
                             status=CheckStatus.OK,
                             message="Configured and valid",
+                            details=f"Key prefix: {api_key[:8]}..."
+                            if verbose
+                            else None,
+                        )
+                    )
+                elif is_valid and error_msg:
+                    results.append(
+                        CheckResult(
+                            name=f"API Key: {provider}",
+                            status=CheckStatus.WARNING,
+                            message=error_msg,
                             details=f"Key prefix: {api_key[:8]}..."
                             if verbose
                             else None,

--- a/gptme/cli/onboard.py
+++ b/gptme/cli/onboard.py
@@ -280,7 +280,10 @@ def _run_wizard(check_only: bool = False) -> int:
     is_valid, error = _test_provider(selected)
 
     if is_valid:
-        console.print(f"[green]✅ Successfully connected to {selected}![/green]")
+        if error:
+            console.print(f"[yellow]⚠️ {error}[/yellow]")
+        else:
+            console.print(f"[green]✅ Successfully connected to {selected}![/green]")
     else:
         console.print(f"[yellow]⚠️ Connection test failed: {error}[/yellow]")
         if not Confirm.ask("Continue anyway?"):

--- a/gptme/cli/setup.py
+++ b/gptme/cli/setup.py
@@ -731,7 +731,10 @@ def _prompt_api_key() -> tuple[str, str, str]:  # pragma: no cover
         console.print()
         return _prompt_api_key()
 
-    console.print(f"[green]✓ {provider} API key validated successfully![/green]")
+    if error_msg:
+        console.print(f"[yellow]⚠️  {error_msg}[/yellow]")
+    else:
+        console.print(f"[green]✓ {provider} API key validated successfully![/green]")
     return api_key, provider, env_var
 
 

--- a/gptme/llm/validate.py
+++ b/gptme/llm/validate.py
@@ -125,8 +125,13 @@ def _validate_anthropic(api_key: str, timeout: int) -> tuple[bool, str]:
             error_data = response.json()
         except ValueError:
             return False, "Invalid API key. Please check your key and try again."
-        if "authentication" in error_data.get("error", {}).get("message", "").lower():
+        error_msg = error_data.get("error", {}).get("message", "").lower()
+        if "authentication" in error_msg:
             return False, "Invalid API key. Please check your key and try again."
+        if "usage limits" in error_msg or "api usage limits" in error_msg:
+            # Key is valid but account has hit its usage quota
+            raw_msg = error_data.get("error", {}).get("message", "")
+            return True, f"API quota exhausted — {raw_msg}"
         return True, ""  # Key is valid, request format was just wrong
     if response.status_code == 429:
         # Rate limited but key is valid

--- a/gptme/llm/validate.py
+++ b/gptme/llm/validate.py
@@ -128,7 +128,7 @@ def _validate_anthropic(api_key: str, timeout: int) -> tuple[bool, str]:
         error_msg = error_data.get("error", {}).get("message", "").lower()
         if "authentication" in error_msg:
             return False, "Invalid API key. Please check your key and try again."
-        if "usage limits" in error_msg or "api usage limits" in error_msg:
+        if "usage limits" in error_msg:
             # Key is valid but account has hit its usage quota
             raw_msg = error_data.get("error", {}).get("message", "")
             return True, f"API quota exhausted — {raw_msg}"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -433,6 +433,32 @@ class TestCheckApiKeys:
 
     @patch("gptme.cli.doctor.list_available_providers")
     @patch("gptme.cli.doctor.get_config")
+    @patch("gptme.cli.doctor.validate_api_key")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_quota_exhausted_api_key(self, mock_validate, mock_config, mock_providers):
+        """Test that quota-exhausted API keys are reported as WARNING, not OK."""
+
+        mock_providers.return_value = [("anthropic", None)]
+        mock_config_obj = mock_config.return_value
+        mock_config_obj.get_env.return_value = "sk-ant-test1234567890"
+        quota_warning = (
+            "API quota exhausted — You have reached your specified API usage limits."
+        )
+        mock_validate.return_value = (True, quota_warning)
+
+        results = _check_api_keys()
+
+        anthropic_results = [r for r in results if "anthropic" in r.name.lower()]
+        assert len(anthropic_results) >= 1
+        result = anthropic_results[0]
+        assert result.status == CheckStatus.WARNING
+        assert (
+            "quota" in result.message.lower()
+            or "usage limits" in result.message.lower()
+        )
+
+    @patch("gptme.cli.doctor.list_available_providers")
+    @patch("gptme.cli.doctor.get_config")
     @patch.dict("os.environ", {}, clear=True)
     def test_provider_available_but_key_not_retrievable(
         self, mock_config, mock_providers

--- a/tests/test_llm_validate.py
+++ b/tests/test_llm_validate.py
@@ -102,6 +102,22 @@ class TestValidateAnthropic:
         assert is_valid
         assert error == ""
 
+    @patch("gptme.llm.validate.requests.post")
+    def test_quota_exhausted_returns_warning(self, mock_post):
+        """Quota-exhausted 400 response should return (True, warning_msg) not (True, '')."""
+        quota_msg = "You have reached your specified API usage limits. You will regain access on 2026-05-01 at 00:00 UTC."
+        mock_post.return_value = Mock(
+            status_code=400,
+            json=Mock(
+                return_value={
+                    "error": {"type": "invalid_request_error", "message": quota_msg}
+                }
+            ),
+        )
+        is_valid, error = _validate_anthropic("sk-ant-valid-key", 10)
+        assert is_valid  # Key itself is valid (will work after reset)
+        assert "quota" in error.lower() or "usage limits" in error.lower()
+
 
 class TestValidateOpenRouter:
     """Tests for OpenRouter API key validation."""


### PR DESCRIPTION
## Problem

When an Anthropic API key hits its usage quota, the messages endpoint returns HTTP 400 with:
```json
{"error": {"type": "invalid_request_error", "message": "You have reached your specified API usage limits. Will regain access on 2026-05-01..."}}
```

`gptme-doctor` was treating this 400 as "key format is valid, request format was wrong (expected)" — showing a green ✅ **Configured and valid** even though the key can't make any API calls.

## Fix

`_validate_anthropic` now detects the "usage limits" phrase in 400 responses and returns `(True, "API quota exhausted — {message}")` instead of `(True, "")`.

`_check_api_keys` in `doctor.py` now handles `(True, non_empty_msg)` as a WARNING instead of OK:
- ✅ `(True, "")` → **Configured and valid**
- ⚠️ `(True, "API quota exhausted — ...")` → **WARNING with quota message**
- ❌ `(False, "error")` → **Invalid: error**

## Tests

Added `test_quota_exhausted_returns_warning` in `test_llm_validate.py` and `test_quota_exhausted_api_key` in `test_doctor.py` to cover the new path.