### PR TITLE
feat(chats): expose context/matches options in search and read commands

### DIFF
--- a/gptme/cli/cmd_chats.py
+++ b/gptme/cli/cmd_chats.py
@@ -10,7 +10,6 @@ import click
 from ..dirs import get_logs_dir
 from ..logmanager import LogManager
 from ..logmanager.conversations import ConversationMeta
-from ..message import Message
 from ..tools import get_tools, init_tools
 from ..tools.chats import find_empty_conversations, list_chats, search_chats
 
@@ -93,7 +92,20 @@ def chats_list(limit: int, summarize: bool, output_json: bool):
     "--summarize", is_flag=True, help="Generate LLM-based summaries for chats"
 )
 @click.option("--json", "output_json", is_flag=True, help="Output as JSON.")
-def chats_search(query: str, limit: int, summarize: bool, output_json: bool):
+@click.option(
+    "-c", "--context", default=50, help="Characters of context around each match."
+)
+@click.option(
+    "-m", "--matches", default=1, help="Maximum matches to show per conversation."
+)
+def chats_search(
+    query: str,
+    limit: int,
+    summarize: bool,
+    output_json: bool,
+    context: int,
+    matches: int,
+):
     """Search conversation logs."""
     _ensure_tools()
 
@@ -134,24 +146,35 @@ def chats_search(query: str, limit: int, summarize: bool, output_json: bool):
             tool_allowlist=[],
             tool_format="markdown",
         )
-    search_chats(query, max_results=limit)
+    search_chats(query, max_results=limit, context_size=context, max_matches=matches)
 
 
 @chats.command("read")
 @click.argument("id")
-def chats_read(id: str):
+@click.option("-n", "--limit", default=20, help="Maximum number of messages to show.")
+@click.option("--system", is_flag=True, help="Include system messages.")
+@click.option(
+    "-c", "--context", default=0, help="Messages of context before start message."
+)
+@click.option(
+    "--start",
+    type=int,
+    default=None,
+    help="Start from this message number (1-indexed).",
+)
+def chats_read(id: str, limit: int, system: bool, context: int, start: int | None):
     """Read a specific chat log."""
     _ensure_tools()
 
-    logdir = get_logs_dir() / id
-    if not logdir.exists():
-        print(f"Chat '{id}' not found")
-        return
+    from ..tools.chats import read_chat  # fmt: skip
 
-    log = LogManager.load(logdir)
-    for msg in log.log:
-        if isinstance(msg, Message):
-            print(f"{msg.role}: {msg.content}")
+    read_chat(
+        id,
+        max_results=limit,
+        incl_system=system,
+        context_messages=context,
+        start_message=start,
+    )
 
 
 @chats.command("rename")

--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -73,6 +73,8 @@ def search_chats(
     max_results: int = 5,
     system=False,
     sort: Literal["date", "count"] = "date",
+    context_size: int = 50,
+    max_matches: int = 1,
 ) -> None:
     """
     Search past conversation logs for the given query and print a summary of the results.
@@ -81,6 +83,8 @@ def search_chats(
         query (str): The search query.
         max_results (int): Maximum number of conversations to display.
         system (bool): Whether to include system messages in the search.
+        context_size (int): Number of characters to show around each match.
+        max_matches (int): Maximum number of matches to show per conversation.
     """
     from ..logmanager import LogManager, list_conversations  # fmt: skip
 
@@ -114,9 +118,12 @@ def search_chats(
     )
     for i, result in enumerate(results[:max_results], 1):
         conversation = result["conversation"]
-        matches = result["matching_messages"][:1]
+        matches = result["matching_messages"][:max_matches]
         match_strs = [
-            _format_message_with_context(msg.content, query) for _, msg in matches
+            _format_message_with_context(
+                msg.content, query, context_size=context_size, max_matches=max_matches
+            )
+            for _, msg in matches
         ]
         print(
             f"{i}. {conversation.name} ({len(result['matching_messages'])}): {match_strs[0]}"
@@ -190,7 +197,13 @@ def _format_message_with_context(
     return result
 
 
-def read_chat(id: str, max_results: int = 5, incl_system=False) -> None:
+def read_chat(
+    id: str,
+    max_results: int = 5,
+    incl_system: bool = False,
+    context_messages: int = 0,
+    start_message: int | None = None,
+) -> None:
     """
     Read a specific conversation log.
 
@@ -198,6 +211,8 @@ def read_chat(id: str, max_results: int = 5, incl_system=False) -> None:
         id (str): The id of the conversation to read.
         max_results (int): Maximum number of messages to display.
         incl_system (bool): Whether to include system messages.
+        context_messages (int): Number of messages to show before/after start_message.
+        start_message (int | None): Start from this message number (1-indexed), if specified.
     """
     from ..logmanager import LogManager, list_conversations  # fmt: skip
 
@@ -206,13 +221,16 @@ def read_chat(id: str, max_results: int = 5, incl_system=False) -> None:
             log_path = Path(conv.path)
             logmanager = LogManager.load(log_path, lock=False)
             print(f"Reading conversation: {conv.name} ({conv.id})")
-            i = 0
-            for msg in logmanager.log:
-                if msg.role != "system" or incl_system:
-                    print(f"{i}. {msg.format(max_length=100)}")
-                    i += 1
-                if i >= max_results:
-                    break
+            messages = [
+                msg for msg in logmanager.log if msg.role != "system" or incl_system
+            ]
+            if start_message is not None:
+                start_idx = max(0, start_message - 1 - context_messages)
+                messages = messages[start_idx:]
+            for i, msg in enumerate(messages[:max_results]):
+                print(
+                    f"{i + (start_message or 1) - 1 + (context_messages if start_message else 0)}. {msg.format(max_length=100)}"
+                )
             break
     else:
         print(f"Conversation '{id}' not found.")

--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -212,7 +212,7 @@ def read_chat(
         id (str): The id of the conversation to read.
         max_results (int): Maximum number of messages to display.
         incl_system (bool): Whether to include system messages.
-        context_messages (int): Number of messages to show before/after start_message.
+        context_messages (int): Number of messages to show before start_message.
         start_message (int | None): Start from this message number (1-indexed), if specified.
     """
     from ..logmanager import LogManager, list_conversations  # fmt: skip

--- a/gptme/tools/chats.py
+++ b/gptme/tools/chats.py
@@ -125,8 +125,9 @@ def search_chats(
             )
             for _, msg in matches
         ]
+        match_preview = f": {match_strs[0]}" if match_strs else ""
         print(
-            f"{i}. {conversation.name} ({len(result['matching_messages'])}): {match_strs[0]}"
+            f"{i}. {conversation.name} ({len(result['matching_messages'])}){match_preview}"
         )
 
 
@@ -224,13 +225,12 @@ def read_chat(
             messages = [
                 msg for msg in logmanager.log if msg.role != "system" or incl_system
             ]
+            start_idx = 0
             if start_message is not None:
                 start_idx = max(0, start_message - 1 - context_messages)
                 messages = messages[start_idx:]
             for i, msg in enumerate(messages[:max_results]):
-                print(
-                    f"{i + (start_message or 1) - 1 + (context_messages if start_message else 0)}. {msg.format(max_length=100)}"
-                )
+                print(f"{start_idx + i}. {msg.format(max_length=100)}")
             break
     else:
         print(f"Conversation '{id}' not found.")


### PR DESCRIPTION
## Summary

Ports improvements from #437 to the current CLI structure (`gptme/cli/cmd_chats.py`).

The original PR couldn't be cleanly rebased since `gptme/util/cli.py` was restructured into `gptme/cli/`, so these changes are applied directly to the current code.

### Changes

- **`chats search`**: Add `--context/-c` (characters of context around each match) and `--matches/-m` (max matches to show per conversation) — previously hardcoded to 50 chars / 1 match
- **`chats read`**: Add `--limit/-n`, `--system`, `--context/-c`, `--start` options — previously had no filtering or navigation options
- **`read_chat()`**: Add `context_messages` and `start_message` params
- **`search_chats()`**: Add `context_size` and `max_matches` params
- Remove unused `Message` import from `cmd_chats.py`

Closes #437

## Test plan

- [x] All existing tests pass (`test_util_cli.py`, `test_tools_chats.py`)
- [x] mypy clean on modified files
- [x] ruff formatting applied