### PR TITLE
fix(server): include exception detail in agent init error response

### DIFF
--- a/gptme/server/api_v2_agents.py
+++ b/gptme/server/api_v2_agents.py
@@ -144,7 +144,7 @@ def api_agents_put():
         conversation_id = init_conversation(workspace=path)
     except Exception as e:
         logger.exception(f"Failed to initialize conversation: {e}")
-        return flask.jsonify({"error": "Failed to initialize conversation"}), 500
+        return flask.jsonify({"error": f"Failed to initialize conversation: {e}"}), 500
 
     return flask.jsonify(
         {


### PR DESCRIPTION
Same pattern as #2157: `logger.exception` logs the exception detail but the HTTP response returns a generic string without it.

One instance in `api_v2_agents.py` — the `init_conversation` error handler:

```python
# Before
return flask.jsonify({"error": "Failed to initialize conversation"}), 500

# After  
return flask.jsonify({"error": f"Failed to initialize conversation: {e}"}), 500
```

This makes server errors actionable from the API response instead of requiring server log access.