### PR TITLE
feat(util): add models test command for verifying model connectivity

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -661,6 +661,134 @@ def models_info(model_name: str, as_json: bool):
         print("Status: DEPRECATED")
 
 
+@models.command("test")
+@click.argument("model_name", required=False)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def models_test(model_name: str | None, as_json: bool):
+    """Test connectivity to a model by making a minimal API call.
+
+    Verifies that the API key is configured, the model is reachable, and
+    returns a response. Useful for troubleshooting provider setup.
+
+    MODEL_NAME can be a full model identifier like 'anthropic/claude-haiku-4-5'
+    or just a provider like 'anthropic' to use the provider's default model.
+    If omitted, uses the default model from config.
+    """
+    from ..llm import (  # fmt: skip
+        PROVIDER_API_KEYS,
+        get_provider_from_model,
+        init_llm,
+    )
+
+    # Resolve model name
+    if model_name is None:
+        config = get_config()
+        model_name = config.get_env("MODEL") or "anthropic/claude-haiku-4-5"
+        if not as_json:
+            click.echo(f"No model specified, using: {model_name}")
+
+    # Resolve bare provider name to a default model
+    if "/" not in model_name and model_name in PROVIDER_API_KEYS:
+        provider = model_name
+
+        # Use a known cheap/fast default model per provider
+        _provider_defaults: dict[str, str] = {
+            "anthropic": "anthropic/claude-haiku-4-5",
+            "openai": "openai/gpt-4o-mini",
+            "openrouter": "openrouter/anthropic/claude-haiku-4-5",
+            "gemini": "gemini/gemini-2.0-flash",
+            "groq": "groq/llama-3.1-8b-instant",
+            "xai": "xai/grok-3-mini",
+            "deepseek": "deepseek/deepseek-chat",
+        }
+        model_name = _provider_defaults.get(provider, f"{provider}/default")
+        if not as_json:
+            click.echo(f"Using default model for {provider}: {model_name}")
+
+    result: dict = {"model": model_name, "success": False}
+
+    # Check if API key is configured
+    try:
+        provider = get_provider_from_model(model_name)
+    except Exception as e:
+        result["error"] = f"Unknown model or provider: {e}"
+        if as_json:
+            click.echo(json.dumps(result, indent=2))
+        else:
+            click.echo(f"❌ {result['error']}")
+            click.echo()
+            click.echo("Try: gptme-util models list --available")
+        sys.exit(1)
+
+    result["provider"] = str(provider)
+
+    # Check API key availability
+    env_var = PROVIDER_API_KEYS.get(str(provider))
+    if env_var:
+        config = get_config()
+        if not config.get_env(env_var):
+            result["error"] = f"API key not configured: ${env_var} is not set"
+            if as_json:
+                click.echo(json.dumps(result, indent=2))
+            else:
+                click.echo(f"❌ {result['error']}")
+                click.echo()
+                click.echo(f"Set it with: export {env_var}=your-api-key")
+                click.echo("Or add to ~/.config/gptme/config.toml under [env]")
+            sys.exit(1)
+        result["api_key_env"] = env_var
+
+    if not as_json:
+        click.echo(f"🔌 Testing model: {model_name}")
+        if env_var:
+            click.echo(f"   API key: ${env_var} ✓")
+        click.echo("   Sending test message...")
+
+    # Make a minimal API call
+    try:
+        init_llm(provider)
+        from ..llm import _chat_complete  # fmt: skip
+
+        start = time.monotonic()
+        response, metadata = _chat_complete(
+            [
+                Message("system", "You are a test assistant."),
+                Message("user", "Reply with exactly: OK"),
+            ],
+            model_name,
+            tools=None,
+            max_tokens=5,
+        )
+        elapsed = time.monotonic() - start
+
+        result["success"] = True
+        result["response"] = response.strip()
+        result["latency_ms"] = round(elapsed * 1000)
+        if metadata:
+            result["metadata"] = {k: v for k, v in metadata.items() if v is not None}
+
+        if as_json:
+            click.echo(json.dumps(result, indent=2))
+        else:
+            click.echo(f"   ✅ Response: {response.strip()!r} ({elapsed:.1f}s)")
+            click.echo()
+            click.echo(f"✅ Model {model_name!r} is working correctly")
+
+    except Exception as e:
+        result["error"] = str(e)
+        if as_json:
+            click.echo(json.dumps(result, indent=2))
+        else:
+            click.echo(f"   ❌ Request failed: {e}")
+            click.echo()
+            click.echo("Common causes:")
+            click.echo("  • Invalid or expired API key")
+            click.echo("  • Model name not recognized by provider")
+            click.echo("  • Rate limit exceeded")
+            click.echo("  • Network connectivity issue")
+        sys.exit(1)
+
+
 @main.group("profile")
 def profile_group():
     """Commands for managing agent profiles.

--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -44,6 +44,19 @@ main.add_command(hooks)
 main.add_command(mcp)
 main.add_command(skills)
 
+# Default cheap/fast model per provider (for bare provider name resolution).
+# Azure is intentionally absent: deployments are tenant-specific, so there is
+# no universal default — users must supply a full model name.
+_PROVIDER_DEFAULT_MODELS: dict[str, str] = {
+    "anthropic": "anthropic/claude-haiku-4-5",
+    "openai": "openai/gpt-4o-mini",
+    "openrouter": "openrouter/anthropic/claude-haiku-4-5",
+    "gemini": "gemini/gemini-2.0-flash",
+    "groq": "groq/llama-3.1-8b-instant",
+    "xai": "xai/grok-3-mini",
+    "deepseek": "deepseek/deepseek-chat",
+}
+
 
 @main.group()
 def providers():
@@ -690,18 +703,18 @@ def models_test(model_name: str | None, as_json: bool):
     # Resolve bare provider name to a default model
     if "/" not in model_name and model_name in PROVIDER_API_KEYS:
         provider = model_name
-
-        # Use a known cheap/fast default model per provider
-        _provider_defaults: dict[str, str] = {
-            "anthropic": "anthropic/claude-haiku-4-5",
-            "openai": "openai/gpt-4o-mini",
-            "openrouter": "openrouter/anthropic/claude-haiku-4-5",
-            "gemini": "gemini/gemini-2.0-flash",
-            "groq": "groq/llama-3.1-8b-instant",
-            "xai": "xai/grok-3-mini",
-            "deepseek": "deepseek/deepseek-chat",
-        }
-        model_name = _provider_defaults.get(provider, f"{provider}/default")
+        if provider not in _PROVIDER_DEFAULT_MODELS:
+            err = f"No default model for '{provider}': specify a full model name (e.g. azure/my-deployment)"
+            if as_json:
+                click.echo(
+                    json.dumps(
+                        {"model": model_name, "success": False, "error": err}, indent=2
+                    )
+                )
+            else:
+                click.echo(f"❌ {err}")
+            sys.exit(1)
+        model_name = _PROVIDER_DEFAULT_MODELS[provider]
         if not as_json:
             click.echo(f"Using default model for {provider}: {model_name}")
 

--- a/tests/test_util_cli_models.py
+++ b/tests/test_util_cli_models.py
@@ -151,3 +151,13 @@ class TestModelsTest:
         assert result.exit_code == 0, result.output
         assert "Using default model for anthropic" in result.output
         assert "claude-haiku-4-5" in result.output
+
+    def test_bare_provider_no_default(self):
+        """Test that providers without a default model (e.g. azure) give a clear error."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["models", "test", "azure"])
+        assert result.exit_code == 1
+        assert "No default model for 'azure'" in result.output
+        assert (
+            "azure/my-deployment" in result.output or "full model name" in result.output
+        )

--- a/tests/test_util_cli_models.py
+++ b/tests/test_util_cli_models.py
@@ -1,0 +1,153 @@
+"""Tests for the models-related gptme-util CLI commands."""
+
+import json
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from gptme.cli.util import main
+
+
+class TestModelsTest:
+    """Tests for 'models test' command."""
+
+    def test_help(self):
+        """Test that help text is shown."""
+        runner = CliRunner()
+        result = runner.invoke(main, ["models", "test", "--help"])
+        assert result.exit_code == 0
+        assert "Test connectivity to a model" in result.output
+        assert "MODEL_NAME" in result.output
+
+    def test_unknown_model(self):
+        """Test error on unrecognized model/provider."""
+        with patch(
+            "gptme.llm.get_provider_from_model",
+            side_effect=ValueError("Unknown provider: fake"),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(main, ["models", "test", "fake/model"])
+        assert result.exit_code == 1
+        assert "Unknown model or provider" in result.output
+        assert "gptme-util models list" in result.output
+
+    def test_missing_api_key(self):
+        """Test error when API key is not configured."""
+        mock_config = Mock()
+        mock_config.get_env.return_value = None
+        with (
+            patch("gptme.llm.get_provider_from_model", return_value="anthropic"),
+            patch("gptme.cli.util.get_config", return_value=mock_config),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main, ["models", "test", "anthropic/claude-haiku-4-5"]
+            )
+        assert result.exit_code == 1
+        assert "ANTHROPIC_API_KEY" in result.output
+        assert "not set" in result.output or "not configured" in result.output
+
+    def test_missing_api_key_json(self):
+        """Test --json output when API key is missing."""
+        mock_config = Mock()
+        mock_config.get_env.return_value = None
+        with (
+            patch("gptme.llm.get_provider_from_model", return_value="anthropic"),
+            patch("gptme.cli.util.get_config", return_value=mock_config),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main, ["models", "test", "anthropic/claude-haiku-4-5", "--json"]
+            )
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert "ANTHROPIC_API_KEY" in data["error"]
+
+    def test_successful_call(self):
+        """Test successful model test call."""
+        mock_config = Mock()
+        mock_config.get_env.return_value = "sk-ant-test-key"
+        with (
+            patch("gptme.llm.get_provider_from_model", return_value="anthropic"),
+            patch("gptme.cli.util.get_config", return_value=mock_config),
+            patch("gptme.llm.init_llm"),
+            patch(
+                "gptme.llm._chat_complete",
+                return_value=("OK", {"model": "claude-haiku-4-5"}),
+            ) as mock_complete,
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main, ["models", "test", "anthropic/claude-haiku-4-5"]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "✅" in result.output
+        assert "working correctly" in result.output
+        call_args = mock_complete.call_args
+        messages = call_args[0][0]
+        assert messages[0].role == "system"
+        assert messages[1].role == "user"
+        assert call_args[1]["max_tokens"] == 5
+
+    def test_successful_call_json(self):
+        """Test --json output on successful call."""
+        mock_config = Mock()
+        mock_config.get_env.return_value = "sk-ant-test-key"
+        with (
+            patch("gptme.llm.get_provider_from_model", return_value="anthropic"),
+            patch("gptme.cli.util.get_config", return_value=mock_config),
+            patch("gptme.llm.init_llm"),
+            patch("gptme.llm._chat_complete", return_value=("OK", {})),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main, ["models", "test", "anthropic/claude-haiku-4-5", "--json"]
+            )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["model"] == "anthropic/claude-haiku-4-5"
+        assert data["provider"] == "anthropic"
+        assert "latency_ms" in data
+        assert data["response"] == "OK"
+
+    def test_api_failure(self):
+        """Test error output when API call fails."""
+        mock_config = Mock()
+        mock_config.get_env.return_value = "sk-ant-expired"
+        with (
+            patch("gptme.llm.get_provider_from_model", return_value="anthropic"),
+            patch("gptme.cli.util.get_config", return_value=mock_config),
+            patch("gptme.llm.init_llm"),
+            patch(
+                "gptme.llm._chat_complete",
+                side_effect=Exception("Error code: 401 - Unauthorized"),
+            ),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main, ["models", "test", "anthropic/claude-haiku-4-5"]
+            )
+        assert result.exit_code == 1
+        assert "Request failed" in result.output
+        assert "Common causes" in result.output
+
+    def test_bare_provider_resolves_default(self):
+        """Test that a bare provider name resolves to a default model."""
+        mock_config = Mock()
+        mock_config.get_env.side_effect = lambda k: (
+            "sk-test" if k == "ANTHROPIC_API_KEY" else None
+        )
+        with (
+            patch("gptme.llm.get_provider_from_model", return_value="anthropic"),
+            patch("gptme.cli.util.get_config", return_value=mock_config),
+            patch("gptme.llm.init_llm"),
+            patch("gptme.llm._chat_complete", return_value=("OK", {})),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(main, ["models", "test", "anthropic"])
+        assert result.exit_code == 0, result.output
+        assert "Using default model for anthropic" in result.output
+        assert "claude-haiku-4-5" in result.output


### PR DESCRIPTION
## Summary

- Adds `gptme-util models test <model>` — a one-command diagnostic for verifying that a model is reachable end-to-end
- Checks API key config before any network request; gives specific env-var guidance if missing
- Makes a minimal API call (`max_tokens=5`) and reports latency + response
- Bare provider names (e.g. `anthropic`) resolve to a sensible cheap default model
- `--json` flag for scripting/CI use

## Usage

```sh
# Test a specific model
gptme-util models test anthropic/claude-haiku-4-5
# 🔌 Testing model: anthropic/claude-haiku-4-5
#    API key: $ANTHROPIC_API_KEY ✓
#    Sending test message...
#    ✅ Response: 'OK' (1.2s)
# ✅ Model 'anthropic/claude-haiku-4-5' is working correctly

# Use bare provider name (resolves to default fast model)
gptme-util models test anthropic

# JSON output for scripting
gptme-util models test openai/gpt-4o-mini --json

# Missing key error
gptme-util models test anthropic/claude-haiku-4-5
# ❌ API key not configured: $ANTHROPIC_API_KEY is not set
# Set it with: export ANTHROPIC_API_KEY=your-api-key
```

## Test plan

- [x] 8 unit tests covering: help, unknown model, missing API key, missing key JSON, success, success JSON, API failure, bare provider name
- [x] All tests pass locally
- [x] Pre-commit hooks pass (ruff format auto-staged)