### PR TITLE
fix(cli): suppress requests version-compatibility warning in gptme-util

### DIFF
--- a/gptme/cli/util.py
+++ b/gptme/cli/util.py
@@ -8,6 +8,16 @@ Command groups are split into separate modules for maintainability:
 - cmd_skills.py: Skills and lessons (list, show, search, install, validate, etc.)
 """
 
+# Filter requests' overly-strict version-compatibility warning before any
+# import path can pull in `requests`. Newer urllib3/chardet/charset_normalizer
+# work fine with requests; the warning just pollutes every CLI invocation.
+import warnings
+
+warnings.filterwarnings(
+    "ignore",
+    message=r".*urllib3.*chardet.*charset_normalizer.*",
+)
+
 import io
 import json
 import logging


### PR DESCRIPTION
## Summary

Every `gptme-util` invocation prints a noisy stderr warning:

```
/path/to/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.6.3) or chardet (6.0.0.post1)/charset_normalizer (3.4.4) doesn't match a supported version!
  warnings.warn(
```

It's `requests` being overly strict about its known-good dependency ranges — the actual `urllib3`/`chardet`/`charset_normalizer` versions all work fine.

This filters the warning at the top of `gptme/cli/util.py`, *before* the import chain pulls in `requests`, so `gptme-util` output is clean.

## Before

```
$ gptme-util --help
/path/to/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.6.3) or chardet (6.0.0.post1)/charset_normalizer (3.4.4) doesn't match a supported version!
  warnings.warn(
Usage: gptme-util [OPTIONS] COMMAND [ARGS]...
...
```

## After

```
$ gptme-util --help
Usage: gptme-util [OPTIONS] COMMAND [ARGS]...
...
```

## Test plan

- [x] `gptme-util --help` — no warning
- [x] `gptme-util prompts expand "test"` — no warning, output correct
- [x] `gptme-util models list --simple --available` — no warning, output correct
- [x] `pytest tests/test_cli.py` — 22 passed, 8 skipped (no regressions)
- [x] Main `gptme` CLI unaffected (warning was already absent there)