### PR TITLE
fix(doctor): add Python version check (require 3.10+)

### DIFF
--- a/gptme/cli/doctor.py
+++ b/gptme/cli/doctor.py
@@ -378,6 +378,30 @@ def _check_permissions(verbose: bool = False) -> list[CheckResult]:
     return results
 
 
+def _check_python_version(verbose: bool = False) -> list[CheckResult]:
+    """Check that Python version meets gptme's minimum requirement (3.10+)."""
+    version = sys.version_info
+    version_str = f"{version.major}.{version.minor}.{version.micro}"
+
+    if version >= (3, 10):
+        return [
+            CheckResult(
+                name="Version: Python",
+                status=CheckStatus.OK,
+                message=f"Python {version_str}",
+                details=sys.executable if verbose else None,
+            )
+        ]
+    return [
+        CheckResult(
+            name="Version: Python",
+            status=CheckStatus.ERROR,
+            message=f"Python {version_str} is below minimum (3.10)",
+            fix_hint="Upgrade to Python 3.10 or newer",
+        )
+    ]
+
+
 def _check_version(verbose: bool = False) -> list[CheckResult]:
     """Check if gptme is up to date by comparing with PyPI."""
     results = []
@@ -679,6 +703,7 @@ def run_diagnostics(verbose: bool = False) -> tuple[list[CheckResult], dict]:
     all_results: list[CheckResult] = []
 
     # Run all checks
+    all_results.extend(_check_python_version(verbose))
     all_results.extend(_check_version(verbose))
     all_results.extend(_check_config(verbose))
     all_results.extend(_check_api_keys(verbose))

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -14,6 +14,7 @@ from gptme.cli.doctor import (
     _check_mcp,
     _check_permissions,
     _check_python_deps,
+    _check_python_version,
     _check_tools,
     _check_version,
     main,
@@ -60,6 +61,53 @@ class TestCheckResult:
         )
         assert result.details == "Detailed info"
         assert result.fix_hint == "Try this fix"
+
+
+class TestCheckPythonVersion:
+    """Test _check_python_version function."""
+
+    def test_current_python_passes(self):
+        """Test that the running Python version (must be >=3.10 to run gptme) is OK."""
+        results = _check_python_version()
+        assert len(results) == 1
+        assert results[0].status == CheckStatus.OK
+        assert "Python" in results[0].name
+
+    def test_old_python_fails(self):
+        """Test that Python < 3.10 produces an ERROR."""
+        from unittest.mock import MagicMock
+
+        old_version = MagicMock()
+        old_version.major = 3
+        old_version.minor = 9
+        old_version.micro = 0
+        old_version.__ge__ = lambda self, other: other <= (3, 9, 0)
+        with patch("gptme.cli.doctor.sys.version_info", old_version):
+            results = _check_python_version()
+        assert len(results) == 1
+        assert results[0].status == CheckStatus.ERROR
+        assert "3.9.0" in results[0].message
+        assert results[0].fix_hint is not None
+
+    def test_minimum_python_passes(self):
+        """Test that exactly Python 3.10 is accepted."""
+        from unittest.mock import MagicMock
+
+        min_version = MagicMock()
+        min_version.major = 3
+        min_version.minor = 10
+        min_version.micro = 0
+        min_version.__ge__ = lambda self, other: other <= (3, 10, 0)
+        with patch("gptme.cli.doctor.sys.version_info", min_version):
+            results = _check_python_version()
+        assert len(results) == 1
+        assert results[0].status == CheckStatus.OK
+
+    def test_verbose_shows_executable(self):
+        """Test that verbose mode shows the Python executable path."""
+        results = _check_python_version(verbose=True)
+        assert len(results) == 1
+        assert results[0].details is not None
 
 
 class TestCheckVersion:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -75,13 +75,10 @@ class TestCheckPythonVersion:
 
     def test_old_python_fails(self):
         """Test that Python < 3.10 produces an ERROR."""
-        from unittest.mock import MagicMock
+        from collections import namedtuple
 
-        old_version = MagicMock()
-        old_version.major = 3
-        old_version.minor = 9
-        old_version.micro = 0
-        old_version.__ge__ = lambda self, other: other <= (3, 9, 0)
+        VersionInfo = namedtuple("VersionInfo", ["major", "minor", "micro"])
+        old_version = VersionInfo(3, 9, 0)
         with patch("gptme.cli.doctor.sys.version_info", old_version):
             results = _check_python_version()
         assert len(results) == 1
@@ -91,13 +88,10 @@ class TestCheckPythonVersion:
 
     def test_minimum_python_passes(self):
         """Test that exactly Python 3.10 is accepted."""
-        from unittest.mock import MagicMock
+        from collections import namedtuple
 
-        min_version = MagicMock()
-        min_version.major = 3
-        min_version.minor = 10
-        min_version.micro = 0
-        min_version.__ge__ = lambda self, other: other <= (3, 10, 0)
+        VersionInfo = namedtuple("VersionInfo", ["major", "minor", "micro"])
+        min_version = VersionInfo(3, 10, 0)
         with patch("gptme.cli.doctor.sys.version_info", min_version):
             results = _check_python_version()
         assert len(results) == 1


### PR DESCRIPTION
## Summary

- Adds `_check_python_version()` check to `gptme doctor` that validates the running Python interpreter meets the 3.10+ minimum requirement
- Runs as the first check in `run_diagnostics()` so version incompatibility is surfaced immediately
- Shows ERROR with `fix_hint: "Upgrade to Python 3.10 or newer"` if below 3.10; shows OK with version string otherwise
- Verbose mode shows the Python executable path (`sys.executable`)

## Test plan

- [ ] `TestCheckPythonVersion::test_current_python_passes` — passes on any valid install
- [ ] `TestCheckPythonVersion::test_old_python_fails` — mocks 3.9.0, expects ERROR + fix_hint
- [ ] `TestCheckPythonVersion::test_minimum_python_passes` — mocks 3.10.0, expects OK
- [ ] `TestCheckPythonVersion::test_verbose_shows_executable` — verbose populates `details`
- [ ] `gptme-doctor` output shows `Version: Python X.Y.Z ✅` at the top of the diagnostics