### PR TITLE
fix(doctor): suppress requests version-compatibility warning

### DIFF
--- a/gptme/cli/doctor.py
+++ b/gptme/cli/doctor.py
@@ -7,6 +7,16 @@ Usage:
     gptme-doctor --fix        # Attempt to fix issues (future)
 """
 
+# Suppress requests' overly-strict version-compatibility warning before any
+# import path can pull in `requests`. Newer urllib3/chardet/charset_normalizer
+# work fine with requests; the warning just pollutes gptme-doctor output.
+import warnings
+
+warnings.filterwarnings(
+    "ignore",
+    message=r".*urllib3.*chardet.*charset_normalizer.*",
+)
+
 import importlib.util
 import logging
 import os


### PR DESCRIPTION
## Summary

Same fix as #2160 for `gptme-util`: filters the `RequestsDependencyWarning` from `requests/__init__.py` before any import transitively pulls in `requests`. Newer urllib3/chardet/charset_normalizer work fine with requests — the warning just pollutes `gptme-doctor` output.

**Before:**
```
$ gptme-doctor
/path/to/requests/__init__.py:113: RequestsDependencyWarning: urllib3 (2.6.3) or chardet (6.0.0.post1)/charset_normalizer (3.4.4) doesn't match a supported version!
  warnings.warn(
╭───────────────────╮
│  🩺 gptme doctor  │
```

**After:**
```
$ gptme-doctor
╭───────────────────╮
│  🩺 gptme doctor  │
```

## Test plan
- [x] `gptme-doctor` runs without the warning
- [x] `uv run gptme-doctor` produces clean output