### PR TITLE
fix(server): serial multi-tool execution and call_id propagation

### DIFF
--- a/gptme/server/api_v2_sessions.py
+++ b/gptme/server/api_v2_sessions.py
@@ -682,6 +682,12 @@ def api_conversation_rerun(conversation_id: str):
         ), 400
 
     # Set them as pending (same flow as step() tool detection)
+    first_auto_id: str | None = None
+    logdir = get_logs_dir() / conversation_id
+    chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
+    default_model = get_default_model()
+    model = chat_config.model or (default_model.full if default_model else "anthropic")
+
     for tooluse in tooluses:
         tool_id = str(uuid.uuid4())
         tool_exec = ToolExecution(
@@ -708,15 +714,20 @@ def api_conversation_rerun(conversation_id: str):
         if tool_exec.auto_confirm:
             if session.auto_confirm_count > 0:
                 session.auto_confirm_count -= 1
-            logdir = get_logs_dir() / conversation_id
-            chat_config = ChatConfig.load_or_create(logdir, ChatConfig())
-            default_model = get_default_model()
-            model = chat_config.model or (
-                default_model.full if default_model else "anthropic"
-            )
-            start_tool_execution(
-                conversation_id, session, tool_id, tooluse, model, chat_config
-            )
+            if first_auto_id is None:
+                first_auto_id = tool_id
+
+    # Start execution for only the first auto-confirm tool.
+    # execute_tool_thread will chain the remaining tools serially (same as step()).
+    if first_auto_id is not None:
+        start_tool_execution(
+            conversation_id,
+            session,
+            first_auto_id,
+            session.pending_tools[first_auto_id].tooluse,
+            model,
+            chat_config,
+        )
 
     return flask.jsonify(
         {

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -703,11 +703,12 @@ def step(
         )
 
         if len(tooluses) > 1:
-            logger.warning(
-                "Multiple tools per message not yet supported, expect issues"
-            )
+            logger.debug(f"Processing {len(tooluses)} tool uses from single message")
 
-        # Handle tool use
+        # Handle tool use — register all tools first, then start execution.
+        # With break_on_tooluse=False, a single assistant message may contain
+        # multiple tool uses that must execute serially.
+        first_auto_id: str | None = None
         for tooluse in tooluses:
             # Create a tool execution record
             tool_id = str(uuid.uuid4())
@@ -734,13 +735,24 @@ def step(
                 },
             )
 
-            # If auto-confirm is enabled, execute the tool
+            # Track the first auto-confirm tool; decrement counter for all
             if tool_exec.auto_confirm:
                 if session.auto_confirm_count > 0:
                     session.auto_confirm_count -= 1
-                start_tool_execution(
-                    conversation_id, session, tool_id, tooluse, model, chat_config
-                )
+                if first_auto_id is None:
+                    first_auto_id = tool_id
+
+        # Start execution for only the first auto-confirm tool.
+        # execute_tool_thread will chain remaining auto-confirm tools serially.
+        if first_auto_id is not None:
+            start_tool_execution(
+                conversation_id,
+                session,
+                first_auto_id,
+                None,  # no edit for auto-confirm
+                model,
+                chat_config,
+            )
 
     except Exception as e:
         logger.exception(f"Error during step execution: {e}")
@@ -785,57 +797,84 @@ def start_tool_execution(
             chat_config=chat_config,
         )
 
-        # Load the conversation
-        manager = LogManager.load(conversation_id, lock=False)
+        # Execute tools serially. When break_on_tooluse=False, a single
+        # assistant message may contain multiple tool uses. After completing
+        # each tool we chain to the next pending auto-confirm tool (if any)
+        # to guarantee serial execution order.
+        current_tool_id: str = tool_id
+        current_edited_tooluse: ToolUse | None = edited_tooluse
 
-        # Use .get() to atomically retrieve and handle concurrent removal — the API
-        # endpoint or another thread may have deleted this entry between the caller's
-        # check and our execution here.
-        tool_exec = session.pending_tools.get(tool_id)
-        if tool_exec is None:
-            logger.warning(
-                f"Tool {tool_id} not found in pending tools (may have been handled by another thread)"
+        while True:
+            # Reload the conversation to pick up outputs from prior tools
+            manager = LogManager.load(conversation_id, lock=False)
+
+            # Use .get() to atomically retrieve and handle concurrent removal
+            tool_exec = session.pending_tools.get(current_tool_id)
+            if tool_exec is None:
+                logger.warning(
+                    f"Tool {current_tool_id} not found in pending tools "
+                    "(may have been handled by another thread)"
+                )
+                break
+            tool_exec.status = ToolStatus.EXECUTING
+
+            # use explicit tooluse if set (may be modified), else from pending
+            tooluse: ToolUse = current_edited_tooluse or tool_exec.tooluse
+
+            # Remove the tool from pending
+            session.pending_tools.pop(current_tool_id, None)
+
+            # Notify about tool execution
+            SessionManager.add_event(
+                conversation_id,
+                {"type": "tool_executing", "tool_id": current_tool_id},
             )
-            return
-        tool_exec.status = ToolStatus.EXECUTING
+            logger.info(f"Tool {current_tool_id} executing")
 
-        # use explicit tooluse if set (may be modified), else use the one from the pending tool
-        tooluse: ToolUse = edited_tooluse or tool_exec.tooluse
+            # Execute the tool
+            try:
+                logger.info(f"Executing tool: {tooluse.tool}")
+                tool_outputs = list(
+                    tooluse.execute(log=manager.log, workspace=manager.workspace)
+                )
+                logger.info(f"Tool execution complete, outputs: {len(tool_outputs)}")
 
-        # Remove the tool from pending (use pop to avoid KeyError if concurrently removed)
-        session.pending_tools.pop(tool_id, None)
+                # Store the tool outputs, propagating call_id to pair results
+                # with the assistant's tool-use block (matches CLI behavior)
+                for tool_output in tool_outputs:
+                    _append_and_notify(
+                        manager,
+                        session,
+                        tool_output.replace(call_id=tooluse.call_id),
+                    )
+            except Exception as e:
+                logger.exception(f"Error executing tool {tooluse.tool}: {e}")
+                tool_exec.status = ToolStatus.FAILED
 
-        # Notify about tool execution
-        SessionManager.add_event(
-            conversation_id, {"type": "tool_executing", "tool_id": tool_id}
-        )
-        logger.info(f"Tool {tool_id} executing")
+                msg = Message("system", f"Error: {e!s}", call_id=tooluse.call_id)
+                _append_and_notify(manager, session, msg)
 
-        # Execute the tool
-        try:
-            logger.info(f"Executing tool: {tooluse.tool}")
-            tool_outputs = list(
-                tooluse.execute(log=manager.log, workspace=manager.workspace)
-            )
-            logger.info(f"Tool execution complete, outputs: {len(tool_outputs)}")
+            # Persist tool outputs to disk
+            manager.write()
 
-            # Store the tool outputs
-            for tool_output in tool_outputs:
-                _append_and_notify(manager, session, tool_output)
-        except Exception as e:
-            logger.exception(f"Error executing tool {tooluse.tool}: {e}")
-            tool_exec.status = ToolStatus.FAILED
+            # Chain to next pending auto-confirm tool (serial execution)
+            next_auto_id: str | None = None
+            for tid, texec in list(session.pending_tools.items()):
+                if texec.auto_confirm:
+                    next_auto_id = tid
+                    break
 
-            msg = Message("system", f"Error: {e!s}")
-            _append_and_notify(manager, session, msg)
+            if next_auto_id is not None:
+                current_tool_id = next_auto_id
+                current_edited_tooluse = None
+            else:
+                break
 
-        # Persist tool outputs to disk (every other _append_and_notify call
-        # site is followed by manager.write(); without this, tool outputs
-        # survive only in memory until the next step writes)
-        manager.write()
-
-        # This implements auto-stepping similar to the CLI behavior
-        _start_step_thread(conversation_id, session, model, chat_config.workspace)
+        # Only auto-step when all pending tools have been executed.
+        # With multiple tools per message, we must wait until every tool
+        # has run before asking the model for a continuation.
+        if not session.pending_tools:
+            _start_step_thread(conversation_id, session, model, chat_config.workspace)
 
     # Start execution in a thread
     thread = threading.Thread(target=execute_tool_thread)

--- a/gptme/server/session_step.py
+++ b/gptme/server/session_step.py
@@ -815,7 +815,7 @@ def start_tool_execution(
                     f"Tool {current_tool_id} not found in pending tools "
                     "(may have been handled by another thread)"
                 )
-                break
+                return  # another thread claimed this tool; don't trigger auto-step
             tool_exec.status = ToolStatus.EXECUTING
 
             # use explicit tooluse if set (may be modified), else from pending

--- a/tests/test_server_v2_auto_stepping.py
+++ b/tests/test_server_v2_auto_stepping.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import time
 import unittest.mock
 
 import pytest
@@ -171,3 +172,122 @@ def test_generation_error_persists_system_message(
     ), "Lingering empty assistant placeholder found in log after error"
     assert messages[-1]["role"] == "system"
     assert messages[-1]["content"] == "Error: provider quota exceeded"
+
+
+@pytest.mark.timeout(30)
+def test_multi_tool_per_message(
+    init_, setup_conversation, event_listener, mock_generation, wait_for_event
+):
+    """Test multiple tool uses in a single assistant message.
+
+    Verifies:
+    - Both tools execute serially (second file writes after first)
+    - Auto-step fires only after all tools complete
+    """
+    port, conversation_id, session_id = setup_conversation
+
+    ts_file_a = f"/tmp/test_multi_tool_a_{int(time.time())}"
+    ts_file_b = f"/tmp/test_multi_tool_b_{int(time.time())}"
+
+    tool1 = ToolUse(
+        tool="shell",
+        args=[],
+        content=f"date +%s%N > {ts_file_a}",
+    )
+
+    tool2 = ToolUse(
+        tool="shell",
+        args=[],
+        content=f"date +%s%N > {ts_file_b}",
+    )
+
+    # Single assistant response containing BOTH tool uses
+    combined = (
+        "I'll run two commands.\n\n"
+        + tool1.to_output("markdown")
+        + "\n\n"
+        + tool2.to_output("markdown")
+    )
+
+    mock_stream = mock_generation(
+        [
+            combined,
+            "Both commands completed.",
+        ]
+    )
+
+    with unittest.mock.patch("gptme.server.session_step._stream", mock_stream):
+        requests.post(
+            f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
+            json={
+                "role": "user",
+                "content": "Run two commands",
+            },
+        )
+
+        requests.post(
+            f"http://localhost:{port}/api/v2/conversations/{conversation_id}/step",
+            json={
+                "session_id": session_id,
+                "model": "openai/mock-model",
+                "auto_confirm": 2,
+            },
+        )
+
+        # Generation produces a single message with two tools.
+        # Event order: generation_started → message_added (assistant) →
+        #   generation_complete → tool_pending × 2 → tool_executing →
+        #   message_added (output 1) → tool_executing → message_added (output 2)
+        #   → generation_started → message_added (final) → generation_complete
+        assert wait_for_event(event_listener, "generation_started")
+        assert wait_for_event(event_listener, "generation_complete")
+
+        # Both tools pending, then execute serially
+        assert wait_for_event(event_listener, "tool_pending")
+        assert wait_for_event(event_listener, "tool_pending")
+        assert wait_for_event(event_listener, "tool_executing")
+        assert wait_for_event(event_listener, "message_added")  # output of tool 1
+        assert wait_for_event(event_listener, "tool_executing")
+        assert wait_for_event(event_listener, "message_added")  # output of tool 2
+
+        # After both tools, auto-step triggers final generation.
+        # message_added fires before generation_complete, so wait in that order.
+        assert wait_for_event(event_listener, "message_added")  # final assistant
+
+    # Verify both files exist (tools actually ran)
+    assert os.path.exists(ts_file_a), f"First tool output {ts_file_a} missing"
+    assert os.path.exists(ts_file_b), f"Second tool output {ts_file_b} missing"
+
+    # Verify serial execution: file B timestamp >= file A
+    with open(ts_file_a) as f:
+        ts_a = int(f.read().strip())
+    with open(ts_file_b) as f:
+        ts_b = int(f.read().strip())
+    assert ts_b >= ts_a, f"Tools ran out of order: ts_a={ts_a}, ts_b={ts_b}"
+
+    # Verify conversation has the expected messages
+    resp = requests.get(
+        f"http://localhost:{port}/api/v2/conversations/{conversation_id}",
+    )
+    assert resp.status_code == 200
+    messages = resp.json()["log"]
+
+    # Should have: system prompt, [token_budget], [lessons], user, assistant (2 tools),
+    # system (tool 1 output), system (tool 2 output), assistant (final)
+    system_outputs = [
+        m
+        for m in messages
+        if m["role"] == "system" and "Ran command:" in m.get("content", "")
+    ]
+    assert len(system_outputs) == 2, (
+        f"Expected 2 tool output messages, got {len(system_outputs)}"
+    )
+
+    # Final message should be the concluding assistant response
+    assert messages[-1]["role"] == "assistant"
+    assert "completed" in messages[-1]["content"].lower()
+
+    # Clean up
+    for path in [ts_file_a, ts_file_b]:
+        if os.path.exists(path):
+            os.remove(path)

--- a/tests/test_server_v2_auto_stepping.py
+++ b/tests/test_server_v2_auto_stepping.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import time
 import unittest.mock
 
 import pytest
@@ -176,7 +175,7 @@ def test_generation_error_persists_system_message(
 
 @pytest.mark.timeout(30)
 def test_multi_tool_per_message(
-    init_, setup_conversation, event_listener, mock_generation, wait_for_event
+    init_, setup_conversation, event_listener, mock_generation, wait_for_event, tmp_path
 ):
     """Test multiple tool uses in a single assistant message.
 
@@ -186,19 +185,19 @@ def test_multi_tool_per_message(
     """
     port, conversation_id, session_id = setup_conversation
 
-    ts_file_a = f"/tmp/test_multi_tool_a_{int(time.time())}"
-    ts_file_b = f"/tmp/test_multi_tool_b_{int(time.time())}"
+    ts_file_a = str(tmp_path / "tool_a")
+    ts_file_b = str(tmp_path / "tool_b")
 
     tool1 = ToolUse(
         tool="shell",
         args=[],
-        content=f"date +%s%N > {ts_file_a}",
+        content=f'python3 -c \'import time; open("{ts_file_a}", "w").write(str(time.time_ns()))\'',
     )
 
     tool2 = ToolUse(
         tool="shell",
         args=[],
-        content=f"date +%s%N > {ts_file_b}",
+        content=f'python3 -c \'import time; open("{ts_file_b}", "w").write(str(time.time_ns()))\'',
     )
 
     # Single assistant response containing BOTH tool uses
@@ -286,8 +285,3 @@ def test_multi_tool_per_message(
     # Final message should be the concluding assistant response
     assert messages[-1]["role"] == "assistant"
     assert "completed" in messages[-1]["content"].lower()
-
-    # Clean up
-    for path in [ts_file_a, ts_file_b]:
-        if os.path.exists(path):
-            os.remove(path)


### PR DESCRIPTION
## Summary

Fix three bugs in the server/webui tool execution path when `break_on_tooluse=False` allows multiple tools per assistant message (#2165):

### Bug 1: Concurrent tool execution
The auto-confirm loop spawned a separate thread for each tool, causing all tools in a multi-tool message to execute concurrently. This broke the serial execution guarantee established in #1002.

**Fix**: Only the first auto-confirm tool starts a thread. `execute_tool_thread` now loops to chain remaining auto-confirm tools serially in the same thread, preserving execution order (matching CLI behavior in `tools/__init__.py`).

### Bug 2: Missing call_id on tool outputs
The server path didn't propagate `call_id` from `ToolUse` to tool output messages, while the CLI path correctly did `tool_response.replace(call_id=tooluse.call_id)`. This breaks pairing of tool results with the assistant's tool-use blocks in the native tool-call format.

**Fix**: `_append_and_notify(manager, session, tool_output.replace(call_id=tooluse.call_id))`

### Bug 3: Premature auto-step
`_start_step_thread()` fired after each individual tool completed, triggering a fresh LLM generation while other tools were still pending.

**Fix**: Guard with `if not session.pending_tools:` — auto-step only fires when all tools have completed.

### Additional
- Downgraded "Multiple tools per message not yet supported" warning to debug log since it's now properly handled.
- Added `test_multi_tool_per_message` test verifying serial execution order (via nanosecond timestamps) and correct event sequence.

Closes #2165