### PR TITLE
fix(eval): isolate user context from benchmark runs

### DIFF
--- a/gptme/eval/agents/__init__.py
+++ b/gptme/eval/agents/__init__.py
@@ -22,6 +22,7 @@ class Agent:
     tool_format: ToolFormat
     tools: list[str] | None = None
     system_prompt: str | None = None
+    include_user_context: bool = False
     log_dir: Path
     workspace_dir: Path
     use_docker: bool = False
@@ -32,12 +33,14 @@ class Agent:
         tool_format: ToolFormat = "markdown",
         tools: list[str] | None = None,
         system_prompt: str | None = None,
+        include_user_context: bool = False,
         use_docker: bool = False,
     ):
         self.model = model
         self.tool_format = tool_format
         self.tools = tools
         self.system_prompt = system_prompt
+        self.include_user_context = include_user_context
         self.use_docker = use_docker
 
         _id = uuid.uuid4().hex[:8]
@@ -137,7 +140,8 @@ class GPTMe(Agent):
             workspace=self.workspace_dir,
             prompt=self.system_prompt or "full",  # this only replaces the base prompt
             interactive=False,  # eval agents run non-interactively
-            context_mode="selective",  # skip workspace files to prevent contamination from user's gptme config
+            context_mode="selective",  # skip workspace files/context_cmd in evals
+            include_user_context=self.include_user_context,
         )
 
         # Modify the first (core) system prompt to add eval-specific instructions

--- a/gptme/eval/agents/claude_code.py
+++ b/gptme/eval/agents/claude_code.py
@@ -87,6 +87,11 @@ class ClaudeCodeAgent(Agent):
 
     def _act_local(self, store: FileStore, prompt: str) -> Files:
         """Execute Claude Code directly on the host."""
+        if not self.include_user_context:
+            logger.warning(
+                "include_user_context=False has no effect for ClaudeCodeAgent — "
+                "the Claude Code CLI reads its own user config (e.g. ~/.claude/) unconditionally."
+            )
         claude_bin = shutil.which("claude")
         if claude_bin is None:
             raise FileNotFoundError(

--- a/gptme/eval/main.py
+++ b/gptme/eval/main.py
@@ -479,6 +479,12 @@ def aggregate_and_display_results(result_files: list[str]):
     help="Run evals in Docker container for isolation (prevents host environment pollution)",
 )
 @click.option(
+    "--user-context/--no-user-context",
+    default=False,
+    show_default=True,
+    help="Include user-level prompt files and agent instructions from ~/.config/gptme. Disabled by default for reproducible evals.",
+)
+@click.option(
     "--json",
     "json_output",
     is_flag=True,
@@ -529,6 +535,7 @@ def main(
     list_tests: bool = False,
     tool_format: ToolFormat | None = None,
     use_docker: bool = False,
+    user_context: bool = False,
     json_output: bool = False,
     eval_modules: tuple[Path, ...] = (),
     leaderboard: bool = False,
@@ -785,7 +792,12 @@ def main(
     if not json_output:
         print("=== Running evals ===")
     model_results = run_evals(
-        evals_to_run, model_configs, timeout, parallel, use_docker
+        evals_to_run,
+        model_configs,
+        timeout,
+        parallel,
+        use_docker,
+        include_user_context=user_context,
     )
     if not json_output:
         print("=== Finished ===")

--- a/gptme/eval/run.py
+++ b/gptme/eval/run.py
@@ -89,6 +89,7 @@ def run_evals(
     timeout: int,
     parallel: int,
     use_docker: bool = False,
+    include_user_context: bool = False,
 ) -> dict[ModelConfig, list[EvalResult]]:
     """
     Run evals for a list of tests.
@@ -99,6 +100,8 @@ def run_evals(
         timeout: Timeout in seconds for each eval
         parallel: Number of parallel evaluations to run
         use_docker: Run tests in Docker containers for isolation
+        include_user_context: Include user-level prompt files and agent
+            instructions from ~/.config/gptme in eval runs
     """
     # For coverage to work with multiprocessing
     # https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html
@@ -136,6 +139,7 @@ def run_evals(
                         model=config.model,
                         tools=tools,
                         timeout=timeout,
+                        include_user_context=include_user_context,
                         use_docker=use_docker,
                     )
                 else:
@@ -143,6 +147,7 @@ def run_evals(
                         model=config.model,
                         tool_format=config.tool_format,
                         tools=tools,
+                        include_user_context=include_user_context,
                         use_docker=use_docker,
                     )
                 future = executor.submit(

--- a/gptme/prompts/__init__.py
+++ b/gptme/prompts/__init__.py
@@ -113,6 +113,7 @@ def get_prompt(
     agent_path: Path | None = None,
     context_mode: ContextMode | None = None,
     context_include: list[str] | None = None,
+    include_user_context: bool = True,
 ) -> list[Message]:
     """
     Get the initial system prompt.
@@ -157,6 +158,8 @@ def get_prompt(
         agent_path: Agent identity workspace (if different from project workspace)
         context_mode: Context mode (full or selective)
         context_include: Components to include in selective mode
+        include_user_context: Whether to include user-level prompt files and
+            agent instruction files from ~/.config/gptme
 
     Returns a list of messages: [core_system_prompt, workspace_prompt, ...].
     """
@@ -239,7 +242,13 @@ def get_prompt(
     # Always exclude context_cmd here — it's collected separately below
     # for better prompt caching (static/semi-static content first, dynamic last).
     workspace_msgs = (
-        list(prompt_workspace(workspace, include_context_cmd=False))
+        list(
+            prompt_workspace(
+                workspace,
+                include_context_cmd=False,
+                include_user_context=include_user_context,
+            )
+        )
         if include_workspace and workspace and workspace != agent_path
         else []
     )
@@ -252,6 +261,7 @@ def get_prompt(
                 title="Agent Config",
                 include_path=True,
                 include_context_cmd=False,
+                include_user_context=include_user_context,
             )
         )
         if include_agent_config

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -134,6 +134,7 @@ def prompt_workspace(
     title="Project Workspace",
     include_path: bool = False,
     include_context_cmd: bool = True,
+    include_user_context: bool = True,
 ) -> Generator[Message, None, None]:
     """Generate the workspace context prompt."""
     # TODO: update this prompt if the files change
@@ -169,15 +170,16 @@ def prompt_workspace(
         _loaded_agent_files_var.set(loaded_agent_files)
 
     # 1. Load user-level agent files from ~/.config/gptme/ (global)
-    for filename in AGENT_FILES:
-        user_file = config_dir / filename
-        if user_file.exists():
-            resolved = str(user_file.resolve())
-            if resolved not in seen_paths:
-                agent_files.append(user_file)
-                seen_paths.add(resolved)
-                loaded_agent_files.add(resolved)
-                logger.debug(f"Loaded user-level agent file: {user_file}")
+    if include_user_context:
+        for filename in AGENT_FILES:
+            user_file = config_dir / filename
+            if user_file.exists():
+                resolved = str(user_file.resolve())
+                if resolved not in seen_paths:
+                    agent_files.append(user_file)
+                    seen_paths.add(resolved)
+                    loaded_agent_files.add(resolved)
+                    logger.debug(f"Loaded user-level agent file: {user_file}")
 
     # 2. Walk from home down to workspace, loading any AGENT_FILES found
     #    Uses find_agent_files_in_tree() -- shared with the agents_md_inject hook
@@ -237,31 +239,32 @@ def prompt_workspace(
     # - Absolute paths: used as-is
     # - ~ expansion supported
     # - Relative paths: resolved relative to the config directory (e.g. ~/.config/gptme)
-    try:
-        user_files = (
-            get_config().user.prompt.files
-            if get_config().user and get_config().user.prompt
-            else []
-        )
-    except (ImportError, OSError, ValueError, AttributeError):
-        user_files = []
-    if user_files:
-        for entry in user_files:
-            p = Path(entry).expanduser()
-            if not p.is_absolute():
-                p = config_dir / entry
-            try:
-                p = p.resolve()
-            except OSError:
-                # If resolve fails (e.g., path doesn't exist yet), keep as-is
-                pass
-            if p.exists():
-                rp = str(p)
-                if rp not in seen_paths:
-                    context_files.append(p)
-                    seen_paths.add(rp)
-            else:
-                logger.debug(f"User-configured file not found: {p}")
+    if include_user_context:
+        try:
+            user_files = (
+                get_config().user.prompt.files
+                if get_config().user and get_config().user.prompt
+                else []
+            )
+        except (ImportError, OSError, ValueError, AttributeError):
+            user_files = []
+        if user_files:
+            for entry in user_files:
+                p = Path(entry).expanduser()
+                if not p.is_absolute():
+                    p = config_dir / entry
+                try:
+                    p = p.resolve()
+                except OSError:
+                    # If resolve fails (e.g., path doesn't exist yet), keep as-is
+                    pass
+                if p.exists():
+                    rp = str(p)
+                    if rp not in seen_paths:
+                        context_files.append(p)
+                        seen_paths.add(rp)
+                else:
+                    logger.debug(f"User-configured file not found: {p}")
 
     # Get tree output if enabled
     if tree_output := get_tree_output(workspace):

--- a/gptme/prompts/workspace.py
+++ b/gptme/prompts/workspace.py
@@ -183,12 +183,17 @@ def prompt_workspace(
 
     # 2. Walk from home down to workspace, loading any AGENT_FILES found
     #    Uses find_agent_files_in_tree() -- shared with the agents_md_inject hook
-    for agent_file in find_agent_files_in_tree(workspace_resolved, exclude=seen_paths):
-        resolved = str(agent_file.resolve())
-        agent_files.append(agent_file)
-        seen_paths.add(resolved)
-        loaded_agent_files.add(resolved)
-        logger.debug(f"Loaded agent file from tree: {agent_file}")
+    #    Skipped when include_user_context=False: eval workspaces often live under
+    #    ~/.local/share/gptme/, so without this guard ~/AGENTS.md would still leak.
+    if include_user_context:
+        for agent_file in find_agent_files_in_tree(
+            workspace_resolved, exclude=seen_paths
+        ):
+            resolved = str(agent_file.resolve())
+            agent_files.append(agent_file)
+            seen_paths.add(resolved)
+            loaded_agent_files.add(resolved)
+            logger.debug(f"Loaded agent file from tree: {agent_file}")
 
     # Determine which additional file patterns to use (from config or defaults)
     if project is None or project.files is None:

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -17,6 +17,7 @@ from gptme.eval.main import main, resolve_eval_names, results_to_json
 from gptme.eval.run import ProcessError, SyncedDict, act_process
 from gptme.eval.suites import suites, tests_map
 from gptme.eval.types import CaseResult, EvalResult, ModelConfig
+from gptme.message import Message
 
 # importlib.import_module returns the actual module object from sys.modules,
 # not the 'main' Click-command attribute exposed via gptme/eval/__init__.py.
@@ -305,6 +306,64 @@ tests = [
     assert captured_evals[0]["name"] == "my-feature"
     # Key: should NOT fail with "module must define a 'tests' list"
     assert "must define a 'tests' list" not in (result.output or "")
+
+
+def test_eval_cli_user_context_flag_propagation():
+    """CLI should default to isolated evals and allow explicit opt-in."""
+    captured: list[bool] = []
+
+    def fake_run_evals(evals, *args, **kwargs):
+        captured.append(kwargs["include_user_context"])
+        return {}
+
+    runner = CliRunner()
+    with (
+        patch.object(_eval_main_module, "run_evals", side_effect=fake_run_evals),
+        patch.object(_eval_main_module, "print_model_results", return_value=None),
+        patch.object(_eval_main_module, "print_model_results_table", return_value=None),
+        patch.object(_eval_main_module, "write_results", return_value=None),
+    ):
+        result = runner.invoke(main, ["hello", "--model", "anthropic"])
+        assert result.exit_code == 0, result.output
+        assert captured == [False]
+
+        captured.clear()
+        result = runner.invoke(
+            main, ["hello", "--model", "anthropic", "--user-context"]
+        )
+        assert result.exit_code == 0, result.output
+        assert captured == [True]
+
+
+def test_eval_agent_passes_user_context_flag(monkeypatch, tmp_path):
+    """GPTMe eval agent should opt out by default and allow explicit opt-in."""
+    captured: list[bool] = []
+
+    monkeypatch.setattr("gptme.eval.agents.get_logs_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        "gptme.eval.agents.generate_conversation_id",
+        lambda prefix, _log_dir: prefix,
+    )
+    monkeypatch.setattr(
+        "gptme.eval.agents.prepare_execution_environment",
+        lambda workspace, tools: (None, []),
+    )
+
+    def fake_get_prompt(*args, **kwargs):
+        captured.append(kwargs["include_user_context"])
+        return [Message("system", "base prompt")]
+
+    monkeypatch.setattr("gptme.eval.agents.get_prompt", fake_get_prompt)
+    monkeypatch.setattr("gptme.eval.agents.gptme_chat", lambda *args, **kwargs: None)
+
+    GPTMe(model="test-model", tool_format="markdown").act(None, "hello")
+    GPTMe(
+        model="test-model",
+        tool_format="markdown",
+        include_user_context=True,
+    ).act(None, "hello")
+
+    assert captured == [False, True]
 
 
 def _detect_model():

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,4 +1,5 @@
 import os
+from types import SimpleNamespace
 
 import pytest
 
@@ -284,3 +285,43 @@ def test_workspace_git_status_in_prompt(tmp_path):
     content = "\n".join(msg.content for msg in msgs)
     assert "Git Status" in content
     assert "Branch" in content
+
+
+def test_prompt_workspace_can_skip_user_context(tmp_path, monkeypatch):
+    """User-level prompt files and AGENTS.md should be optional."""
+    from gptme.prompts import prompt_workspace
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "README.md").write_text("# Local README")
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    user_agent = config_dir / "AGENTS.md"
+    user_agent.write_text("# User Agent Rules")
+    user_notes = tmp_path / "user-notes.md"
+    user_notes.write_text("absolute path leak")
+
+    cfg = SimpleNamespace(
+        user=SimpleNamespace(
+            prompt=SimpleNamespace(files=[str(user_notes)]),
+        )
+    )
+    monkeypatch.setattr(
+        "gptme.prompts.workspace.config_path",
+        str(config_dir / "config.toml"),
+    )
+    monkeypatch.setattr("gptme.prompts.workspace.get_config", lambda: cfg)
+
+    msgs_with_user = list(prompt_workspace(workspace, include_user_context=True))
+    msgs_without_user = list(prompt_workspace(workspace, include_user_context=False))
+
+    files_with_user = [str(f) for msg in msgs_with_user for f in msg.files]
+    files_without_user = [str(f) for msg in msgs_without_user for f in msg.files]
+
+    assert str((workspace / "README.md").resolve()) in files_with_user
+    assert str((workspace / "README.md").resolve()) in files_without_user
+    assert str(user_agent.resolve()) in files_with_user
+    assert str(user_notes.resolve()) in files_with_user
+    assert str(user_agent.resolve()) not in files_without_user
+    assert str(user_notes.resolve()) not in files_without_user

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -325,3 +325,46 @@ def test_prompt_workspace_can_skip_user_context(tmp_path, monkeypatch):
     assert str(user_notes.resolve()) in files_with_user
     assert str(user_agent.resolve()) not in files_without_user
     assert str(user_notes.resolve()) not in files_without_user
+
+
+def test_prompt_workspace_skip_home_agents_md(tmp_path, monkeypatch):
+    """~/AGENTS.md must not leak when workspace is under the home directory.
+
+    This covers the gap in the original test: eval workspaces default to
+    ~/.local/share/gptme/logs/..., so find_agent_files_in_tree walks through
+    the home dir and picks up ~/AGENTS.md unless the tree-walk is gated by
+    include_user_context.
+    """
+    from gptme.prompts import prompt_workspace
+
+    # Simulate a home dir and an eval workspace inside it
+    fake_home = tmp_path / "home" / "user"
+    fake_home.mkdir(parents=True)
+    eval_workspace = fake_home / ".local" / "share" / "gptme" / "logs" / "eval-task"
+    eval_workspace.mkdir(parents=True)
+
+    # Place an AGENTS.md in the fake home (the file that must not leak)
+    home_agents = fake_home / "AGENTS.md"
+    home_agents.write_text("# Home user agent rules — must not appear in evals")
+
+    # Also place a project-level AGENTS.md in the workspace itself
+    project_agents = eval_workspace / "AGENTS.md"
+    project_agents.write_text("# Project-level agent rules")
+
+    monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+    # Minimal config with no user files
+    cfg = SimpleNamespace(user=SimpleNamespace(prompt=SimpleNamespace(files=[])))
+    monkeypatch.setattr("gptme.prompts.workspace.get_config", lambda: cfg)
+    monkeypatch.setattr(
+        "gptme.prompts.workspace.config_path",
+        str(fake_home / ".config" / "gptme" / "config.toml"),
+    )
+
+    msgs_without_user = list(
+        prompt_workspace(eval_workspace, include_user_context=False)
+    )
+    files_without_user = [str(f) for msg in msgs_without_user for f in msg.files]
+
+    assert str(home_agents.resolve()) not in files_without_user, (
+        "~/AGENTS.md must not appear in eval runs (include_user_context=False)"
+    )


### PR DESCRIPTION
Fixes #2167.

## Summary
- add an `include_user_context` switch to prompt construction so callers can skip `~/.config/gptme` prompt files and user-level agent instructions
- make `gptme-eval` default to isolated runs via `--user-context/--no-user-context`
- cover the prompt-layer skip, eval CLI flag propagation, and GPTMe eval-agent behavior with tests

## Verification
- `PYTHONPATH=/tmp/worktrees/gptme-2167 /home/bob/gptme/.venv/bin/python -m pytest tests/test_prompts.py -q`
- `PYTHONPATH=/tmp/worktrees/gptme-2167 /home/bob/gptme/.venv/bin/python -m pytest tests/test_prompts.py::test_prompt_workspace_can_skip_user_context tests/test_eval.py::test_eval_cli_user_context_flag_propagation tests/test_eval.py::test_eval_agent_passes_user_context_flag -q`
- `PYTHONPATH=/tmp/worktrees/gptme-2167 /home/bob/gptme/.venv/bin/python -m ruff check gptme/prompts/workspace.py gptme/prompts/__init__.py gptme/eval/agents/__init__.py gptme/eval/run.py gptme/eval/main.py tests/test_prompts.py tests/test_eval.py`
- `mypy --ignore-missing-imports --check-untyped-defs gptme/eval/main.py gptme/prompts/__init__.py tests/test_eval.py tests/test_prompts.py gptme/eval/agents/__init__.py gptme/prompts/workspace.py gptme/eval/run.py`

## Notes
- `tests/test_eval.py -q` still has an unrelated existing failure in `test_act_process_maps_subprocess_timeout_to_timeout_result` due `os.setpgrp()` permissions in this environment, so I verified the changed eval coverage directly instead of claiming the whole file is clean.